### PR TITLE
feat: implement init and config commands

### DIFF
--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -1,0 +1,186 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/gmail"
+	"github.com/open-cli-collective/google-readonly/internal/keychain"
+)
+
+// NewCommand returns the config command with subcommands
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage gro configuration",
+		Long:  "View and manage gro configuration and authentication status.",
+	}
+
+	cmd.AddCommand(newShowCommand())
+	cmd.AddCommand(newTestCommand())
+	cmd.AddCommand(newClearCommand())
+
+	return cmd
+}
+
+func newShowCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show",
+		Short: "Display configuration status",
+		Long: `Display the current configuration status including:
+- Credentials file location and status
+- OAuth token storage location and status
+- Token expiration time (if available)`,
+		Args: cobra.NoArgs,
+		RunE: runShow,
+	}
+}
+
+func newTestCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "test",
+		Short: "Test Gmail API connectivity",
+		Long: `Test the Gmail API connection with current credentials.
+This verifies that the OAuth token is valid and the API is accessible.`,
+		Args: cobra.NoArgs,
+		RunE: runTest,
+	}
+}
+
+func newClearCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "clear",
+		Short: "Remove stored OAuth token",
+		Long: `Remove the stored OAuth token, forcing re-authentication on next use.
+
+Note: This only removes the OAuth token (access/refresh tokens).
+The credentials.json file (OAuth client config) is not removed.`,
+		Args: cobra.NoArgs,
+		RunE: runClear,
+	}
+}
+
+func runShow(cmd *cobra.Command, args []string) error {
+	// Check credentials file
+	credPath, err := gmail.GetCredentialsPath()
+	if err != nil {
+		return fmt.Errorf("failed to get credentials path: %w", err)
+	}
+
+	credStatus := "OK"
+	if _, err := os.Stat(credPath); os.IsNotExist(err) {
+		credStatus = "Not found"
+	}
+	fmt.Printf("Credentials: %s (%s)\n", credPath, credStatus)
+
+	// Check token
+	tokenStatus := "Not found"
+	var tokenExpiry string
+
+	if keychain.HasStoredToken() {
+		backend := keychain.GetStorageBackend()
+		tokenStatus = string(backend)
+
+		// Try to get token expiry
+		if token, err := keychain.GetToken(); err == nil && !token.Expiry.IsZero() {
+			if token.Expiry.Before(time.Now()) {
+				tokenExpiry = fmt.Sprintf("Expired at %s", token.Expiry.Format(time.RFC3339))
+			} else {
+				remaining := time.Until(token.Expiry).Round(time.Minute)
+				tokenExpiry = fmt.Sprintf("Expires %s (in %s)", token.Expiry.Format(time.RFC3339), remaining)
+			}
+		}
+	}
+
+	fmt.Printf("Token:       %s\n", tokenStatus)
+	if tokenExpiry != "" {
+		fmt.Printf("Expiry:      %s\n", tokenExpiry)
+	}
+
+	// Check if secure storage is being used
+	if keychain.IsSecureStorage() {
+		fmt.Println("Security:    Secure storage (system keychain)")
+	} else if keychain.HasStoredToken() {
+		fmt.Println("Security:    File storage (0600 permissions)")
+	}
+
+	// Show email if we can get it without triggering auth
+	if keychain.HasStoredToken() && credStatus == "OK" {
+		if client, err := gmail.NewClient(context.Background()); err == nil {
+			if profile, err := client.Service.Users.GetProfile("me").Do(); err == nil {
+				fmt.Printf("Email:       %s\n", profile.EmailAddress)
+			}
+		}
+	}
+
+	// Show help if not fully configured
+	if credStatus == "Not found" || tokenStatus == "Not found" {
+		fmt.Println()
+		fmt.Println("Run 'gro init' to complete setup.")
+	}
+
+	return nil
+}
+
+func runTest(cmd *cobra.Command, args []string) error {
+	fmt.Println("Testing Gmail API connection...")
+	fmt.Println()
+
+	// Check token exists
+	if !keychain.HasStoredToken() {
+		fmt.Println("  OAuth token: Not found")
+		fmt.Println()
+		fmt.Println("Run 'gro init' to authenticate.")
+		return fmt.Errorf("no OAuth token found")
+	}
+	fmt.Println("  OAuth token: Found")
+
+	// Try to create client (tests token validity)
+	client, err := gmail.NewClient(context.Background())
+	if err != nil {
+		fmt.Println("  Token valid: FAILED")
+		fmt.Println()
+		fmt.Println("Token may be expired or revoked.")
+		fmt.Println("Run 'gro config clear' then 'gro init' to re-authenticate.")
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+	fmt.Println("  Token valid: OK")
+
+	// Test API access
+	profile, err := client.Service.Users.GetProfile("me").Do()
+	if err != nil {
+		fmt.Println("  Gmail API:   FAILED")
+		return fmt.Errorf("failed to access Gmail API: %w", err)
+	}
+	fmt.Println("  Gmail API:   OK")
+	fmt.Printf("  Messages:    %d total\n", profile.MessagesTotal)
+
+	fmt.Println()
+	fmt.Printf("Authenticated as: %s\n", profile.EmailAddress)
+
+	return nil
+}
+
+func runClear(cmd *cobra.Command, args []string) error {
+	if !keychain.HasStoredToken() {
+		fmt.Println("No OAuth token found to clear.")
+		return nil
+	}
+
+	backend := keychain.GetStorageBackend()
+
+	if err := keychain.DeleteToken(); err != nil {
+		return fmt.Errorf("failed to clear token: %w", err)
+	}
+
+	fmt.Printf("Cleared OAuth token from %s.\n", backend)
+	fmt.Println()
+	fmt.Println("Note: credentials.json is not removed (contains OAuth client config, not user data).")
+	fmt.Println("Run 'gro init' to re-authenticate.")
+
+	return nil
+}

--- a/internal/cmd/config/config_test.go
+++ b/internal/cmd/config/config_test.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigCommand(t *testing.T) {
+	cmd := NewCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "config", cmd.Use)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Short)
+	})
+
+	t.Run("has subcommands", func(t *testing.T) {
+		subcommands := cmd.Commands()
+		assert.GreaterOrEqual(t, len(subcommands), 3)
+
+		var names []string
+		for _, sub := range subcommands {
+			names = append(names, sub.Name())
+		}
+		assert.Contains(t, names, "show")
+		assert.Contains(t, names, "test")
+		assert.Contains(t, names, "clear")
+	})
+}
+
+func TestConfigShowCommand(t *testing.T) {
+	cmd := newShowCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "show", cmd.Use)
+	})
+
+	t.Run("requires no arguments", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"extra"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Short)
+	})
+
+	t.Run("has long description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Long)
+	})
+}
+
+func TestConfigTestCommand(t *testing.T) {
+	cmd := newTestCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "test", cmd.Use)
+	})
+
+	t.Run("requires no arguments", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"extra"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Short)
+	})
+
+	t.Run("has long description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Long)
+	})
+}
+
+func TestConfigClearCommand(t *testing.T) {
+	cmd := newClearCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "clear", cmd.Use)
+	})
+
+	t.Run("requires no arguments", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"extra"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Short)
+	})
+
+	t.Run("has long description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Long)
+		assert.Contains(t, cmd.Long, "token")
+	})
+}

--- a/internal/cmd/initcmd/init.go
+++ b/internal/cmd/initcmd/init.go
@@ -1,0 +1,196 @@
+package initcmd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/gmail"
+	"github.com/open-cli-collective/google-readonly/internal/keychain"
+)
+
+var noVerify bool
+
+// NewCommand returns the init command
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Set up Google API authentication",
+		Long: `Guided setup for Google API OAuth authentication.
+
+This command walks you through the OAuth flow with clear instructions.
+After setup, you can use commands like 'gro mail search', 'gro mail read', etc.
+
+Prerequisites:
+  1. Create a Google Cloud project at https://console.cloud.google.com
+  2. Enable the Gmail API (and Calendar/Drive APIs for future features)
+  3. Create OAuth 2.0 credentials (Desktop app type)
+  4. Download the credentials JSON file
+  5. Save it to ~/.config/google-readonly/credentials.json`,
+		Args: cobra.NoArgs,
+		RunE: runInit,
+	}
+
+	cmd.Flags().BoolVar(&noVerify, "no-verify", false, "Skip connectivity verification after setup")
+
+	return cmd
+}
+
+func runInit(cmd *cobra.Command, args []string) error {
+	// Step 1: Check for credentials.json
+	credPath, err := gmail.GetCredentialsPath()
+	if err != nil {
+		return fmt.Errorf("failed to get credentials path: %w", err)
+	}
+
+	if _, err := os.Stat(credPath); os.IsNotExist(err) {
+		fmt.Println("Credentials file not found.")
+		fmt.Println()
+		printCredentialsInstructions(credPath)
+		return fmt.Errorf("credentials file not found at %s", credPath)
+	}
+	fmt.Printf("Credentials: %s\n", credPath)
+
+	// Step 2: Load OAuth config
+	config, err := gmail.GetOAuthConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load OAuth config: %w", err)
+	}
+
+	// Step 3: Check if already authenticated
+	if keychain.HasStoredToken() {
+		fmt.Println("Token:       Already authenticated")
+		fmt.Println()
+
+		if !noVerify {
+			return verifyConnectivity()
+		}
+
+		fmt.Println("Setup complete! Try: gro mail search \"is:unread\"")
+		return nil
+	}
+
+	// Step 4: Guide through OAuth flow
+	fmt.Println("Token:       Not found - starting OAuth flow")
+	fmt.Println()
+
+	authURL := gmail.GetAuthURL(config)
+	fmt.Println("Open this URL in your browser:")
+	fmt.Println()
+	fmt.Println(authURL)
+	fmt.Println()
+	fmt.Println("After clicking 'Allow', your browser will redirect to a localhost URL.")
+	fmt.Println("This will show an error - that's expected!")
+	fmt.Println()
+	fmt.Println("Copy the ENTIRE URL from your browser's address bar and paste it here,")
+	fmt.Println("or just paste the 'code' parameter value:")
+	fmt.Println()
+	fmt.Print("> ")
+
+	// Read the full line (code may contain special characters)
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("failed to read input: %w", err)
+	}
+
+	code := extractAuthCode(input)
+	if code == "" {
+		return fmt.Errorf("no authorization code found in input")
+	}
+
+	// Step 5: Exchange code for token
+	fmt.Println()
+	fmt.Println("Exchanging authorization code...")
+
+	ctx := context.Background()
+	token, err := gmail.ExchangeAuthCode(ctx, config, code)
+	if err != nil {
+		return fmt.Errorf("failed to exchange authorization code: %w", err)
+	}
+
+	// Step 6: Save token
+	if err := keychain.SetToken(token); err != nil {
+		return fmt.Errorf("failed to save token: %w", err)
+	}
+	fmt.Printf("Token saved to: %s\n", keychain.GetStorageBackend())
+
+	// Step 7: Verify connectivity (unless --no-verify)
+	if !noVerify {
+		fmt.Println()
+		return verifyConnectivity()
+	}
+
+	fmt.Println()
+	fmt.Println("Setup complete! Try: gro mail search \"is:unread\"")
+	return nil
+}
+
+// extractAuthCode extracts the authorization code from user input.
+// It accepts either a full localhost redirect URL or just the code value.
+func extractAuthCode(input string) string {
+	input = strings.TrimSpace(input)
+
+	// If it looks like a URL, try to extract the code parameter
+	if strings.HasPrefix(input, "http://localhost") || strings.HasPrefix(input, "https://localhost") {
+		if u, err := url.Parse(input); err == nil {
+			// Return the code if present, empty string if not
+			// (e.g., URL has ?error=access_denied instead of ?code=...)
+			return u.Query().Get("code")
+		}
+		// URL parsing failed, return empty
+		return ""
+	}
+
+	// Otherwise treat as raw code
+	return input
+}
+
+// verifyConnectivity tests the Gmail API connection
+func verifyConnectivity() error {
+	fmt.Println("Verifying Gmail API connection...")
+
+	client, err := gmail.NewClient(context.Background())
+	if err != nil {
+		fmt.Println("  OAuth token: FAILED")
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+	fmt.Println("  OAuth token: OK")
+
+	// Get profile to verify connectivity and get email address
+	profile, err := client.Service.Users.GetProfile("me").Do()
+	if err != nil {
+		fmt.Println("  Gmail API:   FAILED")
+		return fmt.Errorf("failed to access Gmail API: %w", err)
+	}
+	fmt.Println("  Gmail API:   OK")
+	fmt.Printf("  Messages:    %d total\n", profile.MessagesTotal)
+	fmt.Println()
+	fmt.Printf("Authenticated as: %s\n", profile.EmailAddress)
+	fmt.Println()
+	fmt.Println("Setup complete! Try: gro mail search \"is:unread\"")
+	return nil
+}
+
+func printCredentialsInstructions(credPath string) {
+	fmt.Println("To set up Google API credentials:")
+	fmt.Println()
+	fmt.Println("1. Go to https://console.cloud.google.com")
+	fmt.Println("2. Create a new project (or select an existing one)")
+	fmt.Println("3. Enable the Gmail API:")
+	fmt.Println("   - Go to 'APIs & Services' > 'Library'")
+	fmt.Println("   - Search for 'Gmail API' and enable it")
+	fmt.Println("4. Create OAuth credentials:")
+	fmt.Println("   - Go to 'APIs & Services' > 'Credentials'")
+	fmt.Println("   - Click 'Create Credentials' > 'OAuth client ID'")
+	fmt.Println("   - Select 'Desktop app' as application type")
+	fmt.Println("   - Download the JSON file")
+	fmt.Printf("5. Save the downloaded file to:\n   %s\n", credPath)
+	fmt.Println()
+	fmt.Println("Then run 'gro init' again.")
+}

--- a/internal/cmd/initcmd/init_test.go
+++ b/internal/cmd/initcmd/init_test.go
@@ -1,0 +1,114 @@
+package initcmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitCommand(t *testing.T) {
+	cmd := NewCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "init", cmd.Use)
+	})
+
+	t.Run("requires no arguments", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"extra"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has no-verify flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("no-verify")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "false", flag.DefValue)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Short)
+	})
+
+	t.Run("has long description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Long)
+		assert.Contains(t, cmd.Long, "OAuth")
+	})
+}
+
+func TestExtractAuthCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "raw code",
+			input:    "4/0AQSTgQxyz123",
+			expected: "4/0AQSTgQxyz123",
+		},
+		{
+			name:     "localhost URL with code",
+			input:    "http://localhost/?code=4/0AQSTgQxyz123&scope=email",
+			expected: "4/0AQSTgQxyz123",
+		},
+		{
+			name:     "localhost URL with port",
+			input:    "http://localhost:8080/?code=ABC123&scope=email",
+			expected: "ABC123",
+		},
+		{
+			name:     "https localhost URL",
+			input:    "https://localhost/?code=SecureCode456",
+			expected: "SecureCode456",
+		},
+		{
+			name:     "URL without code param",
+			input:    "http://localhost/?error=access_denied",
+			expected: "",
+		},
+		{
+			name:     "whitespace trimmed",
+			input:    "  4/0AQSTgQxyz123  \n",
+			expected: "4/0AQSTgQxyz123",
+		},
+		{
+			name:     "whitespace trimmed from URL",
+			input:    "  http://localhost/?code=TrimMe  \n",
+			expected: "TrimMe",
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "whitespace only",
+			input:    "   \n\t  ",
+			expected: "",
+		},
+		{
+			name:     "non-localhost URL treated as raw code",
+			input:    "http://example.com/?code=NotExtracted",
+			expected: "http://example.com/?code=NotExtracted",
+		},
+		{
+			name:     "code with special characters",
+			input:    "http://localhost/?code=4/P-abc_123.xyz~456",
+			expected: "4/P-abc_123.xyz~456",
+		},
+		{
+			name:     "URL encoded code",
+			input:    "http://localhost/?code=4%2F0AQSTgQ",
+			expected: "4/0AQSTgQ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractAuthCode(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/google-readonly/internal/cmd/config"
+	"github.com/open-cli-collective/google-readonly/internal/cmd/initcmd"
 	"github.com/open-cli-collective/google-readonly/internal/version"
 )
 
@@ -35,4 +37,8 @@ func Execute() {
 func init() {
 	// Set custom version template to include commit and build date
 	rootCmd.SetVersionTemplate("gro " + version.Info() + "\n")
+
+	// Register commands
+	rootCmd.AddCommand(initcmd.NewCommand())
+	rootCmd.AddCommand(config.NewCommand())
 }


### PR DESCRIPTION
## Summary
- Add `gro init` command for guided OAuth authentication setup
- Add `gro config show` command to display configuration status
- Add `gro config test` command to test Gmail API connectivity
- Add `gro config clear` command to remove stored OAuth token

## Features
- `gro init`: Guided OAuth flow with clear instructions
  - Checks for credentials.json and provides setup help
  - Accepts full redirect URL or just authorization code
  - Optional `--no-verify` flag to skip connectivity test
- `gro config show`: Displays credentials, token status, expiration, security info
- `gro config test`: Verifies OAuth token and API access
- `gro config clear`: Removes token, prompts for re-authentication

## Test plan
- [x] Run `make test` - all tests pass (7 test functions for commands)
- [x] Run `make lint` - no issues
- [x] `gro --help` shows init and config commands
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)