### PR TITLE
feat: implement mail commands

### DIFF
--- a/internal/cmd/mail/attachments.go
+++ b/internal/cmd/mail/attachments.go
@@ -1,0 +1,26 @@
+package mail
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newAttachmentsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "attachments",
+		Short: "Manage message attachments",
+		Long: `List and download attachments from Gmail messages.
+
+This command group provides read-only access to message attachments.
+Use 'list' to view attachment metadata and 'download' to save files locally.
+
+Examples:
+  gro mail attachments list 18abc123def456
+  gro mail attachments download 18abc123def456 --all
+  gro mail attachments download 18abc123def456 --filename report.pdf`,
+	}
+
+	cmd.AddCommand(newListAttachmentsCommand())
+	cmd.AddCommand(newDownloadAttachmentsCommand())
+
+	return cmd
+}

--- a/internal/cmd/mail/attachments_download.go
+++ b/internal/cmd/mail/attachments_download.go
@@ -1,0 +1,139 @@
+package mail
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/gmail"
+	ziputil "github.com/open-cli-collective/google-readonly/internal/zip"
+)
+
+var (
+	downloadFilename string
+	downloadDir      string
+	downloadExtract  bool
+	downloadAll      bool
+)
+
+func newDownloadAttachmentsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "download <message-id>",
+		Short: "Download attachments from a message",
+		Long: `Download attachments from a Gmail message to local disk.
+
+By default, requires --filename to specify which attachment to download,
+or --all to download all attachments.
+
+Zip files can be automatically extracted with --extract flag.
+
+Examples:
+  gro mail attachments download 18abc123def456 --filename report.pdf
+  gro mail attachments download 18abc123def456 --all
+  gro mail attachments download 18abc123def456 --all --output ~/Downloads
+  gro mail attachments download 18abc123def456 --filename archive.zip --extract`,
+		Args: cobra.ExactArgs(1),
+		RunE: runDownloadAttachments,
+	}
+
+	cmd.Flags().StringVarP(&downloadFilename, "filename", "f", "",
+		"Download only attachment with this filename")
+	cmd.Flags().StringVarP(&downloadDir, "output", "o", ".",
+		"Directory to save attachments")
+	cmd.Flags().BoolVarP(&downloadExtract, "extract", "e", false,
+		"Extract zip files after download")
+	cmd.Flags().BoolVarP(&downloadAll, "all", "a", false,
+		"Download all attachments (required if no --filename specified)")
+
+	return cmd
+}
+
+func runDownloadAttachments(cmd *cobra.Command, args []string) error {
+	if downloadFilename == "" && !downloadAll {
+		return fmt.Errorf("must specify --filename or --all")
+	}
+
+	client, err := newGmailClient()
+	if err != nil {
+		return err
+	}
+
+	messageID := args[0]
+	attachments, err := client.GetAttachments(messageID)
+	if err != nil {
+		return err
+	}
+
+	if len(attachments) == 0 {
+		fmt.Println("No attachments found for message.")
+		return nil
+	}
+
+	// Filter by filename if specified
+	var toDownload []*gmail.Attachment
+	for _, att := range attachments {
+		if downloadFilename == "" || att.Filename == downloadFilename {
+			toDownload = append(toDownload, att)
+		}
+	}
+
+	if len(toDownload) == 0 {
+		return fmt.Errorf("attachment not found: %s", downloadFilename)
+	}
+
+	// Create output directory if needed
+	if err := os.MkdirAll(downloadDir, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	// Download each attachment
+	for _, att := range toDownload {
+		data, err := downloadAttachment(client, messageID, att)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error downloading %s: %v\n", att.Filename, err)
+			continue
+		}
+
+		outputPath := filepath.Join(downloadDir, att.Filename)
+		if err := saveAttachment(outputPath, data); err != nil {
+			fmt.Fprintf(os.Stderr, "Error saving %s: %v\n", att.Filename, err)
+			continue
+		}
+
+		fmt.Printf("Downloaded: %s (%s)\n", outputPath, formatSize(int64(len(data))))
+
+		// Extract if zip and --extract flag
+		if downloadExtract && isZipFile(att.Filename, att.MimeType) {
+			extractDir := filepath.Join(downloadDir,
+				strings.TrimSuffix(att.Filename, filepath.Ext(att.Filename)))
+			if err := ziputil.Extract(outputPath, extractDir, ziputil.DefaultOptions()); err != nil {
+				fmt.Fprintf(os.Stderr, "Error extracting %s: %v\n", att.Filename, err)
+			} else {
+				fmt.Printf("Extracted to: %s\n", extractDir)
+			}
+		}
+	}
+
+	return nil
+}
+
+func downloadAttachment(client *gmail.Client, messageID string, att *gmail.Attachment) ([]byte, error) {
+	if att.AttachmentID != "" {
+		return client.DownloadAttachment(messageID, att.AttachmentID)
+	}
+	return client.DownloadInlineAttachment(messageID, att.PartID)
+}
+
+func saveAttachment(path string, data []byte) error {
+	return os.WriteFile(path, data, 0644)
+}
+
+func isZipFile(filename, mimeType string) bool {
+	ext := strings.ToLower(filepath.Ext(filename))
+	return ext == ".zip" ||
+		mimeType == "application/zip" ||
+		mimeType == "application/x-zip-compressed"
+}

--- a/internal/cmd/mail/attachments_list.go
+++ b/internal/cmd/mail/attachments_list.go
@@ -1,0 +1,77 @@
+package mail
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var listAttachmentsJSON bool
+
+func newListAttachmentsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list <message-id>",
+		Short: "List attachments in a message",
+		Long: `List all attachments in a Gmail message with their metadata.
+
+Shows filename, MIME type, size, and whether the attachment is inline.
+
+Examples:
+  gro mail attachments list 18abc123def456
+  gro mail attachments list 18abc123def456 --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: runListAttachments,
+	}
+
+	cmd.Flags().BoolVarP(&listAttachmentsJSON, "json", "j", false, "Output as JSON")
+
+	return cmd
+}
+
+func runListAttachments(cmd *cobra.Command, args []string) error {
+	client, err := newGmailClient()
+	if err != nil {
+		return err
+	}
+
+	attachments, err := client.GetAttachments(args[0])
+	if err != nil {
+		return err
+	}
+
+	if len(attachments) == 0 {
+		fmt.Println("No attachments found for message.")
+		return nil
+	}
+
+	if listAttachmentsJSON {
+		return printJSON(attachments)
+	}
+
+	fmt.Printf("Found %d attachment(s):\n\n", len(attachments))
+	for i, att := range attachments {
+		fmt.Printf("%d. %s\n", i+1, att.Filename)
+		fmt.Printf("   Type: %s\n", att.MimeType)
+		fmt.Printf("   Size: %s\n", formatSize(att.Size))
+		if att.IsInline {
+			fmt.Printf("   Inline: yes\n")
+		}
+		fmt.Println()
+	}
+
+	return nil
+}
+
+// formatSize converts bytes to human-readable format
+func formatSize(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}

--- a/internal/cmd/mail/attachments_test.go
+++ b/internal/cmd/mail/attachments_test.go
@@ -1,0 +1,134 @@
+package mail
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsZipFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		mimeType string
+		expected bool
+	}{
+		{"zip extension lowercase", "archive.zip", "", true},
+		{"zip extension uppercase", "ARCHIVE.ZIP", "", true},
+		{"zip extension mixed case", "Archive.Zip", "", true},
+		{"application/zip mime type", "archive", "application/zip", true},
+		{"application/x-zip-compressed mime type", "archive", "application/x-zip-compressed", true},
+		{"pdf file", "document.pdf", "application/pdf", false},
+		{"txt file", "readme.txt", "text/plain", false},
+		{"no extension with wrong mime", "archive", "application/octet-stream", false},
+		{"zip extension with different mime", "archive.zip", "application/octet-stream", true},
+		{"empty filename with zip mime", "", "application/zip", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isZipFile(tt.filename, tt.mimeType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormatSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		bytes    int64
+		expected string
+	}{
+		{"zero bytes", 0, "0 B"},
+		{"small bytes", 500, "500 B"},
+		{"exactly 1KB", 1024, "1.0 KB"},
+		{"1.5 KB", 1536, "1.5 KB"},
+		{"exactly 1MB", 1024 * 1024, "1.0 MB"},
+		{"2.5 MB", 2621440, "2.5 MB"},
+		{"exactly 1GB", 1024 * 1024 * 1024, "1.0 GB"},
+		{"large file", 5368709120, "5.0 GB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatSize(tt.bytes)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestAttachmentsCommand(t *testing.T) {
+	cmd := newAttachmentsCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "attachments", cmd.Use)
+	})
+
+	t.Run("has subcommands", func(t *testing.T) {
+		subcommands := cmd.Commands()
+		assert.GreaterOrEqual(t, len(subcommands), 2)
+
+		var names []string
+		for _, cmd := range subcommands {
+			names = append(names, cmd.Name())
+		}
+		assert.Contains(t, names, "list")
+		assert.Contains(t, names, "download")
+	})
+}
+
+func TestListAttachmentsCommand(t *testing.T) {
+	cmd := newListAttachmentsCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "list <message-id>", cmd.Use)
+	})
+
+	t.Run("requires exactly one argument", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.Error(t, err)
+
+		err = cmd.Args(cmd, []string{"msg123"})
+		assert.NoError(t, err)
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "j", flag.Shorthand)
+	})
+}
+
+func TestDownloadAttachmentsCommand(t *testing.T) {
+	cmd := newDownloadAttachmentsCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "download <message-id>", cmd.Use)
+	})
+
+	t.Run("requires exactly one argument", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.Error(t, err)
+
+		err = cmd.Args(cmd, []string{"msg123"})
+		assert.NoError(t, err)
+	})
+
+	t.Run("has required flags", func(t *testing.T) {
+		flags := []struct {
+			name      string
+			shorthand string
+		}{
+			{"filename", "f"},
+			{"output", "o"},
+			{"extract", "e"},
+			{"all", "a"},
+		}
+
+		for _, f := range flags {
+			flag := cmd.Flags().Lookup(f.name)
+			assert.NotNil(t, flag, "flag %s should exist", f.name)
+			assert.Equal(t, f.shorthand, flag.Shorthand, "flag %s should have shorthand %s", f.name, f.shorthand)
+		}
+	})
+}

--- a/internal/cmd/mail/labels.go
+++ b/internal/cmd/mail/labels.go
@@ -1,0 +1,130 @@
+package mail
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	gmailapi "google.golang.org/api/gmail/v1"
+)
+
+var labelsJSONOutput bool
+
+// Label represents a Gmail label for output
+type Label struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	Type           string `json:"type"`
+	MessagesTotal  int64  `json:"messagesTotal,omitempty"`
+	MessagesUnread int64  `json:"messagesUnread,omitempty"`
+}
+
+func newLabelsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "labels",
+		Short: "List all labels",
+		Long: `List all Gmail labels including user labels and system categories.
+
+Shows label name, type (system/user/category), and message counts.
+
+Examples:
+  gro mail labels
+  gro mail labels --json`,
+		Args: cobra.NoArgs,
+		RunE: runLabels,
+	}
+
+	cmd.Flags().BoolVarP(&labelsJSONOutput, "json", "j", false, "Output results as JSON")
+
+	return cmd
+}
+
+func runLabels(cmd *cobra.Command, args []string) error {
+	client, err := newGmailClient()
+	if err != nil {
+		return err
+	}
+
+	if err := client.FetchLabels(); err != nil {
+		return err
+	}
+
+	gmailLabels := client.GetLabels()
+	if len(gmailLabels) == 0 {
+		fmt.Println("No labels found.")
+		return nil
+	}
+
+	// Convert to our Label type and categorize
+	labels := make([]Label, 0, len(gmailLabels))
+	for _, gl := range gmailLabels {
+		label := Label{
+			ID:             gl.Id,
+			Name:           gl.Name,
+			Type:           getLabelType(gl),
+			MessagesTotal:  gl.MessagesTotal,
+			MessagesUnread: gl.MessagesUnread,
+		}
+		labels = append(labels, label)
+	}
+
+	// Sort by type then name
+	sort.Slice(labels, func(i, j int) bool {
+		if labels[i].Type != labels[j].Type {
+			return labelTypePriority(labels[i].Type) < labelTypePriority(labels[j].Type)
+		}
+		return strings.ToLower(labels[i].Name) < strings.ToLower(labels[j].Name)
+	})
+
+	if labelsJSONOutput {
+		return printJSON(labels)
+	}
+
+	// Text output
+	fmt.Printf("%-30s %-10s %8s %8s\n", "NAME", "TYPE", "TOTAL", "UNREAD")
+	fmt.Println(strings.Repeat("-", 60))
+	for _, label := range labels {
+		fmt.Printf("%-30s %-10s %8d %8d\n",
+			truncate(label.Name, 30),
+			label.Type,
+			label.MessagesTotal,
+			label.MessagesUnread)
+	}
+
+	return nil
+}
+
+func getLabelType(gl *gmailapi.Label) string {
+	// Check for categories
+	if strings.HasPrefix(gl.Id, "CATEGORY_") {
+		return "category"
+	}
+
+	// System labels have Type = "system"
+	if gl.Type == "system" {
+		return "system"
+	}
+
+	return "user"
+}
+
+func labelTypePriority(t string) int {
+	switch t {
+	case "user":
+		return 0
+	case "category":
+		return 1
+	case "system":
+		return 2
+	default:
+		return 3
+	}
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/internal/cmd/mail/labels_test.go
+++ b/internal/cmd/mail/labels_test.go
@@ -1,0 +1,114 @@
+package mail
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	gmailapi "google.golang.org/api/gmail/v1"
+)
+
+func TestLabelsCommand(t *testing.T) {
+	cmd := newLabelsCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "labels", cmd.Use)
+	})
+
+	t.Run("requires no arguments", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"extra"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "j", flag.Shorthand)
+		assert.Equal(t, "false", flag.DefValue)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Short)
+		assert.Contains(t, cmd.Short, "label")
+	})
+}
+
+func TestGetLabelType(t *testing.T) {
+	t.Run("returns category for CATEGORY_ prefix", func(t *testing.T) {
+		label := &gmailapi.Label{Id: "CATEGORY_UPDATES", Type: "system"}
+		assert.Equal(t, "category", getLabelType(label))
+	})
+
+	t.Run("returns category for all category types", func(t *testing.T) {
+		categories := []string{"CATEGORY_SOCIAL", "CATEGORY_PROMOTIONS", "CATEGORY_FORUMS", "CATEGORY_PERSONAL"}
+		for _, id := range categories {
+			label := &gmailapi.Label{Id: id, Type: "system"}
+			assert.Equal(t, "category", getLabelType(label), "expected category for %s", id)
+		}
+	})
+
+	t.Run("returns system for system type", func(t *testing.T) {
+		label := &gmailapi.Label{Id: "INBOX", Type: "system"}
+		assert.Equal(t, "system", getLabelType(label))
+	})
+
+	t.Run("returns user for user type", func(t *testing.T) {
+		label := &gmailapi.Label{Id: "Label_123", Type: "user"}
+		assert.Equal(t, "user", getLabelType(label))
+	})
+
+	t.Run("returns user for empty type", func(t *testing.T) {
+		label := &gmailapi.Label{Id: "Label_456", Type: ""}
+		assert.Equal(t, "user", getLabelType(label))
+	})
+}
+
+func TestLabelTypePriority(t *testing.T) {
+	t.Run("user has highest priority (lowest value)", func(t *testing.T) {
+		assert.Equal(t, 0, labelTypePriority("user"))
+	})
+
+	t.Run("category is second priority", func(t *testing.T) {
+		assert.Equal(t, 1, labelTypePriority("category"))
+	})
+
+	t.Run("system is third priority", func(t *testing.T) {
+		assert.Equal(t, 2, labelTypePriority("system"))
+	})
+
+	t.Run("unknown types have lowest priority", func(t *testing.T) {
+		assert.Equal(t, 3, labelTypePriority("unknown"))
+		assert.Equal(t, 3, labelTypePriority(""))
+	})
+
+	t.Run("priorities maintain correct sort order", func(t *testing.T) {
+		assert.Less(t, labelTypePriority("user"), labelTypePriority("category"))
+		assert.Less(t, labelTypePriority("category"), labelTypePriority("system"))
+		assert.Less(t, labelTypePriority("system"), labelTypePriority("unknown"))
+	})
+}
+
+func TestTruncate(t *testing.T) {
+	t.Run("returns string unchanged if within limit", func(t *testing.T) {
+		assert.Equal(t, "short", truncate("short", 10))
+		assert.Equal(t, "exactly10!", truncate("exactly10!", 10))
+	})
+
+	t.Run("truncates with ellipsis when over limit", func(t *testing.T) {
+		result := truncate("this is a very long string", 10)
+		assert.Equal(t, "this is...", result)
+		assert.Len(t, result, 10)
+	})
+
+	t.Run("handles empty string", func(t *testing.T) {
+		assert.Equal(t, "", truncate("", 10))
+	})
+
+	t.Run("handles limit smaller than ellipsis length", func(t *testing.T) {
+		// When maxLen is 3, we'd get "..." which is the ellipsis itself
+		result := truncate("hello", 3)
+		assert.Equal(t, "...", result)
+	})
+}

--- a/internal/cmd/mail/mail.go
+++ b/internal/cmd/mail/mail.go
@@ -1,0 +1,36 @@
+package mail
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewCommand returns the mail parent command with subcommands
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mail",
+		Short: "Gmail commands",
+		Long: `Read-only access to Gmail messages, threads, and attachments.
+
+This command group provides Gmail functionality:
+- search: Search for messages using Gmail query syntax
+- read: Read a single message
+- thread: Read a full conversation thread
+- labels: List all labels
+- attachments: List and download attachments
+
+Examples:
+  gro mail search "is:unread"
+  gro mail read <message-id>
+  gro mail thread <thread-id>
+  gro mail labels
+  gro mail attachments list <message-id>`,
+	}
+
+	cmd.AddCommand(newSearchCommand())
+	cmd.AddCommand(newReadCommand())
+	cmd.AddCommand(newThreadCommand())
+	cmd.AddCommand(newLabelsCommand())
+	cmd.AddCommand(newAttachmentsCommand())
+
+	return cmd
+}

--- a/internal/cmd/mail/mail_test.go
+++ b/internal/cmd/mail/mail_test.go
@@ -1,0 +1,34 @@
+package mail
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMailCommand(t *testing.T) {
+	cmd := NewCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "mail", cmd.Use)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Short)
+	})
+
+	t.Run("has subcommands", func(t *testing.T) {
+		subcommands := cmd.Commands()
+		assert.GreaterOrEqual(t, len(subcommands), 5)
+
+		var names []string
+		for _, sub := range subcommands {
+			names = append(names, sub.Name())
+		}
+		assert.Contains(t, names, "search")
+		assert.Contains(t, names, "read")
+		assert.Contains(t, names, "thread")
+		assert.Contains(t, names, "labels")
+		assert.Contains(t, names, "attachments")
+	})
+}

--- a/internal/cmd/mail/output.go
+++ b/internal/cmd/mail/output.go
@@ -1,0 +1,58 @@
+package mail
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/open-cli-collective/google-readonly/internal/gmail"
+)
+
+// newGmailClient creates and returns a new Gmail client
+func newGmailClient() (*gmail.Client, error) {
+	return gmail.NewClient(context.Background())
+}
+
+// printJSON encodes data as indented JSON to stdout
+func printJSON(data any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(data)
+}
+
+// MessagePrintOptions controls which fields to include in message output
+type MessagePrintOptions struct {
+	IncludeThreadID bool
+	IncludeTo       bool
+	IncludeSnippet  bool
+	IncludeBody     bool
+}
+
+// printMessageHeader prints the common header fields of a message
+func printMessageHeader(msg *gmail.Message, opts MessagePrintOptions) {
+	fmt.Printf("ID: %s\n", msg.ID)
+	if opts.IncludeThreadID {
+		fmt.Printf("ThreadID: %s\n", msg.ThreadID)
+	}
+	fmt.Printf("From: %s\n", msg.From)
+	if opts.IncludeTo {
+		fmt.Printf("To: %s\n", msg.To)
+	}
+	fmt.Printf("Subject: %s\n", msg.Subject)
+	fmt.Printf("Date: %s\n", msg.Date)
+	if len(msg.Labels) > 0 {
+		fmt.Printf("Labels: %s\n", strings.Join(msg.Labels, ", "))
+	}
+	if len(msg.Categories) > 0 {
+		fmt.Printf("Categories: %s\n", strings.Join(msg.Categories, ", "))
+	}
+	if opts.IncludeSnippet {
+		fmt.Printf("Snippet: %s\n", msg.Snippet)
+	}
+	if opts.IncludeBody {
+		fmt.Print("\n--- Body ---\n\n")
+		fmt.Println(msg.Body)
+	}
+}

--- a/internal/cmd/mail/output_test.go
+++ b/internal/cmd/mail/output_test.go
@@ -1,0 +1,28 @@
+package mail
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMessagePrintOptions(t *testing.T) {
+	t.Run("default options are all false", func(t *testing.T) {
+		opts := MessagePrintOptions{}
+		assert.False(t, opts.IncludeThreadID)
+		assert.False(t, opts.IncludeTo)
+		assert.False(t, opts.IncludeSnippet)
+		assert.False(t, opts.IncludeBody)
+	})
+
+	t.Run("options can be set individually", func(t *testing.T) {
+		opts := MessagePrintOptions{
+			IncludeThreadID: true,
+			IncludeBody:     true,
+		}
+		assert.True(t, opts.IncludeThreadID)
+		assert.False(t, opts.IncludeTo)
+		assert.False(t, opts.IncludeSnippet)
+		assert.True(t, opts.IncludeBody)
+	})
+}

--- a/internal/cmd/mail/read.go
+++ b/internal/cmd/mail/read.go
@@ -1,0 +1,50 @@
+package mail
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var readJSONOutput bool
+
+func newReadCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "read <message-id>",
+		Short: "Read a single message",
+		Long: `Read the full content of a Gmail message by its ID.
+
+The message ID can be obtained from the search command output.
+
+Examples:
+  gro mail read 18abc123def456
+  gro mail read 18abc123def456 --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: runRead,
+	}
+
+	cmd.Flags().BoolVarP(&readJSONOutput, "json", "j", false, "Output result as JSON")
+
+	return cmd
+}
+
+func runRead(cmd *cobra.Command, args []string) error {
+	client, err := newGmailClient()
+	if err != nil {
+		return err
+	}
+
+	msg, err := client.GetMessage(args[0], true)
+	if err != nil {
+		return err
+	}
+
+	if readJSONOutput {
+		return printJSON(msg)
+	}
+
+	printMessageHeader(msg, MessagePrintOptions{
+		IncludeTo:   true,
+		IncludeBody: true,
+	})
+
+	return nil
+}

--- a/internal/cmd/mail/read_test.go
+++ b/internal/cmd/mail/read_test.go
@@ -1,0 +1,42 @@
+package mail
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadCommand(t *testing.T) {
+	cmd := newReadCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "read <message-id>", cmd.Use)
+	})
+
+	t.Run("requires exactly one argument", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.Error(t, err)
+
+		err = cmd.Args(cmd, []string{"msg123"})
+		assert.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"msg1", "msg2"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "j", flag.Shorthand)
+		assert.Equal(t, "false", flag.DefValue)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Short)
+		assert.Contains(t, cmd.Short, "message")
+	})
+
+	t.Run("long description mentions message ID source", func(t *testing.T) {
+		assert.Contains(t, cmd.Long, "search")
+	})
+}

--- a/internal/cmd/mail/search.go
+++ b/internal/cmd/mail/search.go
@@ -1,0 +1,70 @@
+package mail
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	searchMaxResults int64
+	searchJSONOutput bool
+)
+
+func newSearchCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Search for messages",
+		Long: `Search for Gmail messages using Gmail's search syntax.
+
+Examples:
+  gro mail search "from:alice@example.com"
+  gro mail search "subject:meeting" --max 20
+  gro mail search "is:unread" --json
+  gro mail search "after:2024/01/01 before:2024/02/01"
+
+For more query operators, see: https://support.google.com/mail/answer/7190`,
+		Args: cobra.ExactArgs(1),
+		RunE: runSearch,
+	}
+
+	cmd.Flags().Int64VarP(&searchMaxResults, "max", "m", 10, "Maximum number of results to return")
+	cmd.Flags().BoolVarP(&searchJSONOutput, "json", "j", false, "Output results as JSON")
+
+	return cmd
+}
+
+func runSearch(cmd *cobra.Command, args []string) error {
+	client, err := newGmailClient()
+	if err != nil {
+		return err
+	}
+
+	messages, skipped, err := client.SearchMessages(args[0], searchMaxResults)
+	if err != nil {
+		return err
+	}
+
+	if len(messages) == 0 {
+		fmt.Println("No messages found.")
+		return nil
+	}
+
+	if searchJSONOutput {
+		return printJSON(messages)
+	}
+
+	for _, msg := range messages {
+		printMessageHeader(msg, MessagePrintOptions{
+			IncludeThreadID: true,
+			IncludeSnippet:  true,
+		})
+		fmt.Println("---")
+	}
+
+	if skipped > 0 {
+		fmt.Printf("Note: %d message(s) could not be retrieved.\n", skipped)
+	}
+
+	return nil
+}

--- a/internal/cmd/mail/search_test.go
+++ b/internal/cmd/mail/search_test.go
@@ -1,0 +1,46 @@
+package mail
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSearchCommand(t *testing.T) {
+	cmd := newSearchCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "search <query>", cmd.Use)
+	})
+
+	t.Run("requires exactly one argument", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.Error(t, err)
+
+		err = cmd.Args(cmd, []string{"query"})
+		assert.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"query1", "query2"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has max flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("max")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "m", flag.Shorthand)
+		assert.Equal(t, "10", flag.DefValue)
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "j", flag.Shorthand)
+		assert.Equal(t, "false", flag.DefValue)
+	})
+
+	t.Run("has examples in long description", func(t *testing.T) {
+		assert.Contains(t, cmd.Long, "from:")
+		assert.Contains(t, cmd.Long, "subject:")
+		assert.Contains(t, cmd.Long, "is:unread")
+	})
+}

--- a/internal/cmd/mail/thread.go
+++ b/internal/cmd/mail/thread.go
@@ -1,0 +1,65 @@
+package mail
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var threadJSONOutput bool
+
+func newThreadCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "thread <id>",
+		Short: "Read a full conversation thread",
+		Long: `Read all messages in a Gmail conversation thread.
+
+Accepts either a thread ID or a message ID. If a message ID is provided,
+the thread containing that message will be retrieved automatically.
+Use the search command to find message IDs (the ThreadID field can also
+be used directly).
+
+Examples:
+  gro mail thread 18abc123def456
+  gro mail thread 18abc123def456 --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: runThread,
+	}
+
+	cmd.Flags().BoolVarP(&threadJSONOutput, "json", "j", false, "Output result as JSON")
+
+	return cmd
+}
+
+func runThread(cmd *cobra.Command, args []string) error {
+	client, err := newGmailClient()
+	if err != nil {
+		return err
+	}
+
+	messages, err := client.GetThread(args[0])
+	if err != nil {
+		return err
+	}
+
+	if len(messages) == 0 {
+		fmt.Println("No messages found in thread.")
+		return nil
+	}
+
+	if threadJSONOutput {
+		return printJSON(messages)
+	}
+
+	fmt.Printf("Thread contains %d message(s)\n\n", len(messages))
+	for i, msg := range messages {
+		fmt.Printf("=== Message %d of %d ===\n", i+1, len(messages))
+		printMessageHeader(msg, MessagePrintOptions{
+			IncludeTo:   true,
+			IncludeBody: true,
+		})
+		fmt.Println()
+	}
+
+	return nil
+}

--- a/internal/cmd/mail/thread_test.go
+++ b/internal/cmd/mail/thread_test.go
@@ -1,0 +1,43 @@
+package mail
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestThreadCommand(t *testing.T) {
+	cmd := newThreadCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "thread <id>", cmd.Use)
+	})
+
+	t.Run("requires exactly one argument", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.Error(t, err)
+
+		err = cmd.Args(cmd, []string{"thread123"})
+		assert.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"thread1", "thread2"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "j", flag.Shorthand)
+		assert.Equal(t, "false", flag.DefValue)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Short)
+		assert.Contains(t, cmd.Short, "thread")
+	})
+
+	t.Run("long description explains thread ID", func(t *testing.T) {
+		assert.Contains(t, cmd.Long, "thread ID")
+		assert.Contains(t, cmd.Long, "message ID")
+	})
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/open-cli-collective/google-readonly/internal/cmd/config"
 	"github.com/open-cli-collective/google-readonly/internal/cmd/initcmd"
+	"github.com/open-cli-collective/google-readonly/internal/cmd/mail"
 	"github.com/open-cli-collective/google-readonly/internal/version"
 )
 
@@ -41,4 +42,5 @@ func init() {
 	// Register commands
 	rootCmd.AddCommand(initcmd.NewCommand())
 	rootCmd.AddCommand(config.NewCommand())
+	rootCmd.AddCommand(mail.NewCommand())
 }


### PR DESCRIPTION
## Summary
- Port all Gmail commands from gmail-ro under `gro mail` namespace
- Implements search, read, thread, labels, and attachments subcommands
- Full test coverage ported from gmail-ro

## Commands Added
| Command | Description |
|---------|-------------|
| `gro mail search <query>` | Search messages with Gmail query syntax |
| `gro mail read <id>` | Read a single message |
| `gro mail thread <id>` | Read full conversation thread |
| `gro mail labels` | List all labels |
| `gro mail attachments list <id>` | List message attachments |
| `gro mail attachments download <id>` | Download attachments |

## Files Added
- `internal/cmd/mail/mail.go` - Parent command
- `internal/cmd/mail/search.go`, `read.go`, `thread.go`, `labels.go` - Main commands
- `internal/cmd/mail/attachments.go`, `attachments_list.go`, `attachments_download.go` - Attachment commands
- `internal/cmd/mail/output.go` - Shared output helpers
- All corresponding `*_test.go` files

## Test plan
- [x] All tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Binary builds (`make build`)
- [x] `gro mail --help` shows all subcommands
- [x] `gro mail search --help` shows flags
- [x] `gro mail attachments --help` shows subcommands

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)