### PR TITLE
docs: add full README and CLAUDE.md documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,304 @@
+# CLAUDE.md
+
+This file provides guidance for AI agents working with the gro codebase.
+
+## Project Overview
+
+gro is a **read-only** command-line interface for Google services written in Go. It uses OAuth2 for authentication and only requests read-only scopes - no write, send, or delete operations are possible.
+
+**Binary name:** `gro`
+**Module:** `github.com/open-cli-collective/google-readonly`
+
+### Current Features
+- Gmail: Search, read, thread viewing, labels, attachments
+
+### Planned Features
+- Google Calendar: List calendars, view events
+- Google Drive: List files, download content
+
+## Quick Commands
+
+```bash
+# Build
+make build
+
+# Run tests
+make test
+
+# Run tests with coverage
+make test-cover
+
+# Lint
+make lint
+
+# Format code
+make fmt
+
+# All checks (format, lint, test)
+make verify
+
+# Install locally
+make install
+
+# Clean build artifacts
+make clean
+```
+
+## Architecture
+
+```
+google-readonly/
+├── main.go                          # Entry point
+├── cmd/gro/                         # Main package
+│   └── main.go
+├── internal/
+│   ├── cmd/
+│   │   ├── root/                    # Root command, version
+│   │   │   └── root.go
+│   │   ├── initcmd/                 # OAuth setup (gro init)
+│   │   │   ├── init.go
+│   │   │   └── init_test.go
+│   │   ├── config/                  # gro config {show,test,clear}
+│   │   │   ├── config.go
+│   │   │   └── config_test.go
+│   │   └── mail/                    # gro mail {search,read,thread,labels,attachments}
+│   │       ├── mail.go              # Parent command
+│   │       ├── search.go
+│   │       ├── read.go
+│   │       ├── thread.go
+│   │       ├── labels.go
+│   │       ├── attachments.go
+│   │       ├── attachments_list.go
+│   │       ├── attachments_download.go
+│   │       ├── output.go            # Shared output helpers
+│   │       └── *_test.go
+│   │
+│   ├── gmail/                       # Gmail API client
+│   │   ├── client.go
+│   │   ├── messages.go
+│   │   ├── attachments.go
+│   │   └── *_test.go
+│   │
+│   ├── keychain/                    # Secure credential storage
+│   │   ├── keychain.go
+│   │   ├── keychain_darwin.go       # macOS Keychain support
+│   │   ├── keychain_linux.go        # Linux secret-tool support
+│   │   ├── keychain_windows.go      # Windows file fallback
+│   │   ├── token_source.go          # Persistent token source wrapper
+│   │   └── keychain_test.go
+│   │
+│   ├── zip/                         # Secure zip extraction
+│   │   ├── extract.go
+│   │   └── extract_test.go
+│   │
+│   └── version/                     # Build-time version injection
+│       └── version.go
+│
+├── .github/workflows/
+│   ├── ci.yml                       # Lint and test on PR/push
+│   ├── auto-release.yml             # Create tags on main push
+│   └── release.yml                  # Build and release binaries
+│
+├── packaging/
+│   ├── chocolatey/                  # Windows Chocolatey package
+│   └── winget/                      # Windows Winget manifests
+│
+├── Makefile                         # Build, test, lint targets
+├── .goreleaser.yml                  # Cross-platform builds
+└── .golangci.yml                    # Linter config (v2 format)
+```
+
+## Key Patterns
+
+### Read-Only by Design
+
+This CLI intentionally only supports read operations:
+- Uses `gmail.GmailReadonlyScope` exclusively
+- Only calls `.List()` and `.Get()` Gmail API methods
+- No `.Send()`, `.Delete()`, `.Modify()`, or `.Trash()` operations
+
+### OAuth2 Configuration
+
+Credentials are stored in `~/.config/google-readonly/`:
+- `credentials.json` - OAuth client credentials (from Google Cloud Console)
+
+OAuth tokens are stored securely based on platform:
+- **macOS**: System Keychain (via `security` CLI)
+- **Linux**: libsecret (via `secret-tool`) if available, otherwise config file
+- **Fallback**: `~/.config/google-readonly/token.json` with 0600 permissions
+
+### Command Patterns
+
+All commands use the factory pattern with `NewCommand()`:
+
+```go
+func NewCommand() *cobra.Command {
+    cmd := &cobra.Command{
+        Use:   "search <query>",
+        Short: "Search for messages",
+        Args:  cobra.ExactArgs(1),
+        RunE:  runSearch,
+    }
+    cmd.Flags().Int64VarP(&searchMaxResults, "max", "m", 10, "Maximum results")
+    return cmd
+}
+
+func runSearch(cmd *cobra.Command, args []string) error {
+    client, err := newGmailClient()
+    if err != nil {
+        return err
+    }
+    // ... use client
+}
+```
+
+### Output Formats
+
+Commands support two output modes:
+- **Text** (default): Human-readable formatted output
+- **JSON** (`--json`): Machine-readable JSON for scripting
+
+```go
+if jsonOutput {
+    return printJSON(messages)
+}
+// ... text output
+```
+
+## Testing
+
+Tests use `testify` for assertions and table-driven test patterns:
+
+```go
+func TestParseMessage(t *testing.T) {
+    tests := []struct {
+        name     string
+        input    *gmail.Message
+        expected *Message
+    }{
+        {"basic message", ...},
+        {"multipart message", ...},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            result := parseMessage(tt.input, true)
+            assert.Equal(t, tt.expected.Subject, result.Subject)
+        })
+    }
+}
+```
+
+Run tests: `make test`
+
+Coverage report: `make test-cover && open coverage.html`
+
+## Adding a New Command
+
+1. Create new file in appropriate `internal/cmd/` directory
+2. Define the command with `NewCommand()` factory function
+3. Register in parent command's `NewCommand()` with `AddCommand()`
+4. Add flags if needed
+5. Write tests in `*_test.go`
+
+Example:
+
+```go
+func NewCommand() *cobra.Command {
+    cmd := &cobra.Command{
+        Use:   "labels",
+        Short: "List Gmail labels",
+        RunE:  runLabels,
+    }
+    cmd.Flags().BoolVarP(&labelsJSON, "json", "j", false, "Output as JSON")
+    return cmd
+}
+```
+
+## Dependencies
+
+Key dependencies:
+- `github.com/spf13/cobra` - CLI framework
+- `golang.org/x/oauth2` - OAuth2 client
+- `google.golang.org/api/gmail/v1` - Gmail API client
+- `github.com/stretchr/testify` - Testing assertions (dev)
+
+## Error Message Conventions
+
+Follow [Go Code Review Comments](https://github.com/go/wiki/wiki/CodeReviewComments#error-strings):
+
+- Start with lowercase
+- Don't end with punctuation
+- Be descriptive but concise
+
+```go
+// Good
+return fmt.Errorf("failed to get message: %w", err)
+return fmt.Errorf("attachment not found: %s", filename)
+
+// Bad
+return fmt.Errorf("Failed to get message: %w", err)  // capitalized
+return fmt.Errorf("attachment not found.")           // ends with punctuation
+```
+
+## Commit Conventions
+
+Use conventional commits:
+
+```
+type(scope): description
+
+feat(mail): add attachment download command
+fix(keychain): handle missing secret-tool
+docs(readme): add installation instructions
+```
+
+| Prefix | Purpose | Triggers Release? |
+|--------|---------|-------------------|
+| `feat:` | New features | Yes |
+| `fix:` | Bug fixes | Yes |
+| `docs:` | Documentation only | No |
+| `test:` | Adding/updating tests | No |
+| `refactor:` | Code changes that don't fix bugs or add features | No |
+| `chore:` | Maintenance tasks | No |
+| `ci:` | CI/CD changes | No |
+
+## CI & Release Workflow
+
+Releases are automated with a dual-gate system:
+
+**Gate 1 - Path filter:** Only triggers when Go code changes (`**.go`, `go.mod`, `go.sum`)
+**Gate 2 - Commit prefix:** Only `feat:` and `fix:` commits create releases
+
+This means:
+- `feat: add command` + Go files changed → release
+- `fix: handle edge case` + Go files changed → release
+- `docs:`, `ci:`, `test:`, `refactor:` → no release
+- Changes only to docs, packaging, workflows → no release
+
+## Common Issues
+
+### "Unable to read credentials file"
+
+Ensure OAuth credentials are set up:
+```bash
+mkdir -p ~/.config/google-readonly
+# Download credentials.json from Google Cloud Console
+mv ~/Downloads/client_secret_*.json ~/.config/google-readonly/credentials.json
+```
+
+### "Token has been expired or revoked"
+
+Clear the token and re-authenticate:
+```bash
+gro config clear
+gro init
+```
+
+## Security
+
+- **Read-only scope**: Cannot modify, send, or delete data
+- **Secure token storage**: OAuth tokens stored in system keychain when available
+- **File fallback**: When secure storage is unavailable, tokens stored with 0600 permissions
+- **Token refresh persistence**: Refreshed tokens are automatically saved
+- **No credential exposure**: Credentials never logged or transmitted

--- a/README.md
+++ b/README.md
@@ -1,2 +1,395 @@
-# google-readonly
-Read-only operations for Google Products and services.
+# gro
+
+A read-only command-line interface for Google services. Search, read, and view Gmail messages, threads, and attachments without any ability to modify, send, or delete data.
+
+## Features
+
+- **Read-only access** - Uses `gmail.readonly`, `calendar.readonly`, and `drive.readonly` OAuth scopes
+- **Gmail support** - Search messages, read content, view threads, list labels, download attachments
+- **JSON output** - Machine-readable output for scripting
+- **Secure storage** - OAuth tokens stored in system keychain (macOS/Linux)
+
+## Installation
+
+### macOS
+
+**Homebrew (recommended)**
+
+```bash
+brew install open-cli-collective/tap/gro
+```
+
+> Note: This installs from our third-party tap.
+
+---
+
+### Windows
+
+**Chocolatey**
+
+```powershell
+choco install google-readonly
+```
+
+**Winget**
+
+```powershell
+winget install OpenCLICollective.gro
+```
+
+---
+
+### Linux
+
+**APT (Debian/Ubuntu)**
+
+```bash
+# Add the GPG key
+curl -fsSL https://open-cli-collective.github.io/linux-packages/keys/gpg.asc | sudo gpg --dearmor -o /usr/share/keyrings/open-cli-collective.gpg
+
+# Add the repository
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/open-cli-collective.gpg] https://open-cli-collective.github.io/linux-packages/apt stable main" | sudo tee /etc/apt/sources.list.d/open-cli-collective.list
+
+# Install
+sudo apt update
+sudo apt install gro
+```
+
+> Note: This is our third-party APT repository, not official Debian/Ubuntu repos.
+
+**DNF/YUM (Fedora/RHEL/CentOS)**
+
+```bash
+# Add the repository
+sudo tee /etc/yum.repos.d/open-cli-collective.repo << 'EOF'
+[open-cli-collective]
+name=Open CLI Collective
+baseurl=https://open-cli-collective.github.io/linux-packages/rpm
+enabled=1
+gpgcheck=1
+gpgkey=https://open-cli-collective.github.io/linux-packages/keys/gpg.asc
+EOF
+
+# Install
+sudo dnf install gro
+```
+
+> Note: This is our third-party RPM repository, not official Fedora/RHEL repos.
+
+**Binary download**
+
+Download `.deb`, `.rpm`, or `.tar.gz` from the [Releases page](https://github.com/open-cli-collective/google-readonly/releases).
+
+---
+
+### From Source
+
+```bash
+go install github.com/open-cli-collective/google-readonly/cmd/gro@latest
+```
+
+## Setup
+
+### 1. Create Google Cloud Project
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Create a new project or select an existing one
+3. Enable the required APIs:
+   - Go to **APIs & Services** > **Library**
+   - Search for and enable: **Gmail API**
+   - (Optional for future features) Enable: **Google Calendar API**, **Google Drive API**
+
+### 2. Create OAuth Credentials
+
+1. Go to **APIs & Services** > **Credentials**
+2. Click **Create Credentials** > **OAuth client ID**
+3. If prompted, configure the OAuth consent screen:
+   - Choose **External** user type
+   - Fill in required fields (app name, support email)
+   - Add scopes:
+     - `https://www.googleapis.com/auth/gmail.readonly`
+     - `https://www.googleapis.com/auth/calendar.readonly` (optional)
+     - `https://www.googleapis.com/auth/drive.readonly` (optional)
+   - Add your email as a test user
+4. For Application type, select **Desktop app**
+5. Click **Create**
+6. Download the JSON file
+
+### 3. Configure gro
+
+1. Create the config directory:
+   ```bash
+   mkdir -p ~/.config/google-readonly
+   ```
+
+2. Move the downloaded credentials file:
+   ```bash
+   mv ~/Downloads/client_secret_*.json ~/.config/google-readonly/credentials.json
+   ```
+
+### 4. Authenticate
+
+Run the init command to complete OAuth setup:
+
+```bash
+gro init
+```
+
+1. A URL will be displayed - open it in your browser
+2. Sign in with your Google account
+3. Grant read-only access
+4. Your browser will redirect to a localhost URL (the error page is expected)
+5. Copy the entire URL or just the authorization code
+6. Paste it back into the terminal
+
+Your token will be saved securely (system keychain on macOS/Linux, or `~/.config/google-readonly/token.json` as fallback).
+
+## Commands
+
+### Configuration Commands
+
+```bash
+# Guided OAuth setup
+gro init
+
+# Check configuration status
+gro config show
+
+# Test API connectivity
+gro config test
+
+# Clear stored OAuth token
+gro config clear
+
+# Show version
+gro --version
+```
+
+### Gmail Commands
+
+All Gmail commands are under `gro mail`:
+
+```bash
+# Search messages
+gro mail search "is:unread"
+gro mail search "from:someone@example.com" --max 20
+gro mail search "subject:meeting" --json
+
+# Read a message
+gro mail read <message-id>
+gro mail read <message-id> --json
+
+# View conversation thread
+gro mail thread <thread-id>
+gro mail thread <message-id> --json
+
+# List labels
+gro mail labels
+gro mail labels --json
+
+# List attachments
+gro mail attachments list <message-id>
+gro mail attachments list <message-id> --json
+
+# Download attachments
+gro mail attachments download <message-id> --all
+gro mail attachments download <message-id> --filename report.pdf
+gro mail attachments download <message-id> --all --output ~/Downloads
+gro mail attachments download <message-id> --filename archive.zip --extract
+```
+
+## Command Reference
+
+### gro mail search
+
+Search for Gmail messages using Gmail's search syntax.
+
+```
+Usage: gro mail search <query> [flags]
+
+Flags:
+  -m, --max int    Maximum number of results (default 10)
+  -j, --json       Output as JSON
+```
+
+### gro mail read
+
+Read the full content of a Gmail message by its ID.
+
+```
+Usage: gro mail read <message-id> [flags]
+
+Flags:
+  -j, --json       Output as JSON
+```
+
+### gro mail thread
+
+Read all messages in a Gmail conversation thread.
+
+```
+Usage: gro mail thread <id> [flags]
+
+Flags:
+  -j, --json       Output as JSON
+```
+
+### gro mail labels
+
+List all Gmail labels including user labels and system categories.
+
+```
+Usage: gro mail labels [flags]
+
+Flags:
+  -j, --json       Output as JSON
+```
+
+### gro mail attachments list
+
+List all attachments in a Gmail message.
+
+```
+Usage: gro mail attachments list <message-id> [flags]
+
+Flags:
+  -j, --json       Output as JSON
+```
+
+### gro mail attachments download
+
+Download attachments from a Gmail message.
+
+```
+Usage: gro mail attachments download <message-id> [flags]
+
+Flags:
+  -f, --filename string   Download only this attachment
+  -o, --output string     Output directory (default ".")
+  -a, --all               Download all attachments
+  -e, --extract           Extract zip files after download
+```
+
+## Search Query Reference
+
+gro supports all Gmail search operators:
+
+| Operator | Example | Description |
+|----------|---------|-------------|
+| `from:` | `from:alice@example.com` | Messages from sender |
+| `to:` | `to:bob@example.com` | Messages to recipient |
+| `subject:` | `subject:meeting` | Subject contains word |
+| `is:` | `is:unread`, `is:starred` | Message state |
+| `has:` | `has:attachment` | Has attachment |
+| `after:` | `after:2024/01/01` | After date |
+| `before:` | `before:2024/02/01` | Before date |
+| `label:` | `label:work` | Has label |
+| `category:` | `category:updates` | In category |
+| `in:` | `in:inbox`, `in:sent` | In folder |
+| `larger:` | `larger:5M` | Larger than size |
+| `smaller:` | `smaller:1M` | Smaller than size |
+
+See [Gmail search operators](https://support.google.com/mail/answer/7190) for the complete list.
+
+## Shell Completion
+
+gro supports tab completion for bash, zsh, fish, and PowerShell.
+
+### Bash
+
+```bash
+# Load in current session
+source <(gro completion bash)
+
+# Install permanently (Linux)
+gro completion bash | sudo tee /etc/bash_completion.d/gro > /dev/null
+
+# Install permanently (macOS with Homebrew)
+gro completion bash > $(brew --prefix)/etc/bash_completion.d/gro
+```
+
+### Zsh
+
+```bash
+# Load in current session
+source <(gro completion zsh)
+
+# Install permanently
+mkdir -p ~/.zsh/completions
+gro completion zsh > ~/.zsh/completions/_gro
+
+# Add to ~/.zshrc if not already present:
+# fpath=(~/.zsh/completions $fpath)
+# autoload -Uz compinit && compinit
+```
+
+### Fish
+
+```bash
+# Load in current session
+gro completion fish | source
+
+# Install permanently
+gro completion fish > ~/.config/fish/completions/gro.fish
+```
+
+### PowerShell
+
+```powershell
+# Load in current session
+gro completion powershell | Out-String | Invoke-Expression
+
+# Install permanently (add to $PROFILE)
+gro completion powershell >> $PROFILE
+```
+
+## Configuration
+
+Configuration files are stored in `~/.config/google-readonly/`:
+
+| File | Description |
+|------|-------------|
+| `credentials.json` | OAuth client credentials (from Google Cloud Console) |
+| `token.json` | OAuth access/refresh token (fallback if keychain unavailable) |
+
+## Security
+
+- This tool only requests **read-only** access to Google services
+- No write, send, or delete operations are possible
+- OAuth tokens are stored in system keychain (macOS Keychain / Linux secret-tool) when available
+- File-based storage uses `0600` permissions
+- Credentials never leave your machine
+- Zip extraction includes security safeguards (size limits, path traversal prevention)
+
+## Troubleshooting
+
+### "Unable to read credentials file"
+
+Ensure `credentials.json` exists:
+```bash
+ls -la ~/.config/google-readonly/credentials.json
+```
+
+### "Token has been expired or revoked"
+
+Clear the token and re-authenticate:
+```bash
+gro config clear
+gro init
+```
+
+### "Access blocked: This app's request is invalid"
+
+Your OAuth consent screen may not be properly configured. Ensure:
+1. The Gmail API is enabled
+2. Your email is added as a test user (for apps in testing mode)
+3. The required scopes are added
+
+## Future Features
+
+- **Google Calendar** - Read events, list calendars
+- **Google Drive** - List files, download content
+
+## License
+
+MIT License - see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- Complete README.md with full documentation
- New CLAUDE.md with project architecture and development patterns

## README Contents
- Installation instructions (Homebrew, Chocolatey, Winget, APT, DNF, source)
- OAuth setup guide
- Command reference for all `gro` commands
- Gmail search query reference
- Shell completion instructions
- Security information
- Troubleshooting section

## CLAUDE.md Contents
- Project overview and architecture
- Directory structure
- Key patterns (read-only design, OAuth, command patterns)
- Testing patterns
- Adding new commands guide
- Commit conventions
- CI/CD workflow documentation

## Test plan
- [x] README renders correctly
- [x] All command examples match implemented commands
- [x] No typos in package names

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)