### PR TITLE
test: add root command tests for complete coverage

### DIFF
--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -1,0 +1,39 @@
+package root
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRootCommand(t *testing.T) {
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "gro", rootCmd.Use)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, rootCmd.Short)
+	})
+
+	t.Run("has long description", func(t *testing.T) {
+		assert.NotEmpty(t, rootCmd.Long)
+		assert.Contains(t, rootCmd.Long, "read-only")
+	})
+
+	t.Run("has version set", func(t *testing.T) {
+		assert.NotEmpty(t, rootCmd.Version)
+	})
+
+	t.Run("has subcommands", func(t *testing.T) {
+		subcommands := rootCmd.Commands()
+		assert.GreaterOrEqual(t, len(subcommands), 3)
+
+		var names []string
+		for _, sub := range subcommands {
+			names = append(names, sub.Name())
+		}
+		assert.Contains(t, names, "init")
+		assert.Contains(t, names, "config")
+		assert.Contains(t, names, "mail")
+	})
+}


### PR DESCRIPTION
## Summary
Add root command tests to match gmail-ro's test coverage.

## Test Verification
| Metric | gmail-ro | gro (after) |
|--------|----------|-------------|
| Test functions | 69 | 69 |

### Test Coverage Comparison
All gmail-ro tests have been ported to gro. The only difference:
- gmail-ro had `TestVersionCommand` (separate version subcommand)
- gro has `TestMailCommand` (new parent command for mail subcommands)

Both have the same overall test function count (69).

## Test plan
- [x] All tests pass (`make test`)
- [x] Linter passes (`make lint`)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)