### PR TITLE
docs: add init and config command reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,41 @@ gro mail attachments download <message-id> --filename archive.zip --extract
 
 ## Command Reference
 
+### gro init
+
+Guided setup for Google API OAuth authentication.
+
+```
+Usage: gro init [flags]
+
+Flags:
+      --no-verify   Skip connectivity verification after setup
+```
+
+### gro config show
+
+Display current configuration status including credentials and token.
+
+```
+Usage: gro config show
+```
+
+### gro config test
+
+Test Gmail API connectivity with current credentials.
+
+```
+Usage: gro config test
+```
+
+### gro config clear
+
+Remove stored OAuth token (forces re-authentication).
+
+```
+Usage: gro config clear
+```
+
 ### gro mail search
 
 Search for Gmail messages using Gmail's search syntax.


### PR DESCRIPTION
## Summary
Complete the Command Reference section with all non-mail commands.

## Commands Added to Reference
- `gro init` (with `--no-verify` flag)
- `gro config show`
- `gro config test`
- `gro config clear`

## API Surface Verification

| Command | Flags | Documented? |
|---------|-------|-------------|
| `gro init` | `--no-verify` | ✅ |
| `gro config show` | none | ✅ |
| `gro config test` | none | ✅ |
| `gro config clear` | none | ✅ |
| `gro --version` | n/a | ✅ |
| `gro mail search <query>` | `-m/--max`, `-j/--json` | ✅ |
| `gro mail read <id>` | `-j/--json` | ✅ |
| `gro mail thread <id>` | `-j/--json` | ✅ |
| `gro mail labels` | `-j/--json` | ✅ |
| `gro mail attachments list <id>` | `-j/--json` | ✅ |
| `gro mail attachments download <id>` | `-f`, `-o`, `-a`, `-e` | ✅ |

All commands and flags are now documented in the README.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)