### PR TITLE
feat(contacts): add Google Contacts readonly commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,10 @@ gro is a **read-only** command-line interface for Google services written in Go.
 ### Current Features
 - Gmail: Search, read, thread viewing, labels, attachments
 - Google Calendar: List calendars, view events, today/week shortcuts
+- Google Contacts: List contacts, search, view details, list groups
 
 ### Planned Features
 - Google Drive: List files, download content
-- Google Contacts: List contacts, search, view groups
 
 ## Quick Commands
 
@@ -74,13 +74,23 @@ google-readonly/
 │   │   │   ├── output.go            # Shared output helpers
 │   │   │   └── *_test.go
 │   │   │
-│   │   └── calendar/                # gro calendar {list,events,get,today,week}
-│   │       ├── calendar.go          # Parent command with 'cal' alias
+│   │   ├── calendar/                # gro calendar {list,events,get,today,week}
+│   │   │   ├── calendar.go          # Parent command with 'cal' alias
+│   │   │   ├── list.go
+│   │   │   ├── events.go
+│   │   │   ├── get.go
+│   │   │   ├── today.go
+│   │   │   ├── week.go
+│   │   │   ├── dates.go             # Date parsing/formatting helpers
+│   │   │   ├── output.go            # Shared output helpers
+│   │   │   └── *_test.go
+│   │   │
+│   │   └── contacts/                # gro contacts {list,search,get,groups}
+│   │       ├── contacts.go          # Parent command with 'ppl' alias
 │   │       ├── list.go
-│   │       ├── events.go
+│   │       ├── search.go
 │   │       ├── get.go
-│   │       ├── today.go
-│   │       ├── week.go
+│   │       ├── groups.go
 │   │       ├── output.go            # Shared output helpers
 │   │       └── *_test.go
 │   │
@@ -93,6 +103,11 @@ google-readonly/
 │   ├── calendar/                    # Google Calendar API client
 │   │   ├── client.go
 │   │   ├── events.go
+│   │   └── *_test.go
+│   │
+│   ├── contacts/                    # Google People API client (Contacts)
+│   │   ├── client.go
+│   │   ├── contacts.go
 │   │   └── *_test.go
 │   │
 │   ├── keychain/                    # Secure credential storage
@@ -237,6 +252,8 @@ Key dependencies:
 - `github.com/spf13/cobra` - CLI framework
 - `golang.org/x/oauth2` - OAuth2 client
 - `google.golang.org/api/gmail/v1` - Gmail API client
+- `google.golang.org/api/calendar/v3` - Calendar API client
+- `google.golang.org/api/people/v1` - People API client (Contacts)
 - `github.com/stretchr/testify` - Testing assertions (dev)
 
 ## Error Message Conventions

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ A read-only command-line interface for Google services. Search, read, and view G
 
 ## Features
 
-- **Read-only access** - Uses `gmail.readonly`, `calendar.readonly`, and `drive.readonly` OAuth scopes
+- **Read-only access** - Uses `gmail.readonly`, `calendar.readonly`, and `contacts.readonly` OAuth scopes
 - **Gmail support** - Search messages, read content, view threads, list labels, download attachments
 - **Calendar support** - List calendars, view events, today/week shortcuts
+- **Contacts support** - List contacts, search, view details, list groups
 - **JSON output** - Machine-readable output for scripting
 - **Secure storage** - OAuth tokens stored in system keychain (macOS/Linux)
 
@@ -98,7 +99,8 @@ go install github.com/open-cli-collective/google-readonly/cmd/gro@latest
 3. Enable the required APIs:
    - Go to **APIs & Services** > **Library**
    - Search for and enable: **Gmail API**
-   - (Optional for future features) Enable: **Google Calendar API**, **Google Drive API**
+   - Enable: **Google Calendar API**
+   - Enable: **People API** (for Contacts)
 
 ### 2. Create OAuth Credentials
 
@@ -109,8 +111,8 @@ go install github.com/open-cli-collective/google-readonly/cmd/gro@latest
    - Fill in required fields (app name, support email)
    - Add scopes:
      - `https://www.googleapis.com/auth/gmail.readonly`
-     - `https://www.googleapis.com/auth/calendar.readonly` (optional)
-     - `https://www.googleapis.com/auth/drive.readonly` (optional)
+     - `https://www.googleapis.com/auth/calendar.readonly`
+     - `https://www.googleapis.com/auth/contacts.readonly`
    - Add your email as a test user
 4. For Application type, select **Desktop app**
 5. Click **Create**
@@ -405,6 +407,84 @@ Flags:
   -j, --json              Output as JSON
 ```
 
+### Contacts Commands
+
+All Contacts commands are under `gro contacts` (or `gro ppl`):
+
+```bash
+# List all contacts
+gro contacts list
+gro ppl list --max 20
+gro contacts list --json
+
+# Search contacts
+gro contacts search "John"
+gro ppl search "example.com" --max 20
+
+# Get contact details
+gro contacts get people/c123456789
+gro ppl get people/c123456789 --json
+
+# List contact groups
+gro contacts groups
+gro ppl groups --json
+```
+
+### gro contacts list
+
+List all contacts sorted by last name.
+
+```
+Usage: gro contacts list [flags]
+
+Aliases: gro ppl list
+
+Flags:
+  -m, --max int    Maximum number of contacts (default 10)
+  -j, --json       Output as JSON
+```
+
+### gro contacts search
+
+Search contacts by name, email, phone, or organization.
+
+```
+Usage: gro contacts search <query> [flags]
+
+Aliases: gro ppl search
+
+Flags:
+  -m, --max int    Maximum number of results (default 10)
+  -j, --json       Output as JSON
+```
+
+### gro contacts get
+
+Get the full details of a specific contact.
+
+```
+Usage: gro contacts get <resource-name> [flags]
+
+Aliases: gro ppl get
+
+Flags:
+  -j, --json       Output as JSON
+```
+
+### gro contacts groups
+
+List all contact groups (labels).
+
+```
+Usage: gro contacts groups [flags]
+
+Aliases: gro ppl groups
+
+Flags:
+  -m, --max int    Maximum number of groups (default 30)
+  -j, --json       Output as JSON
+```
+
 ## Search Query Reference
 
 gro supports all Gmail search operators:
@@ -523,7 +603,6 @@ Your OAuth consent screen may not be properly configured. Ensure:
 
 ## Future Features
 
-- **Google Calendar** - Read events, list calendars
 - **Google Drive** - List files, download content
 
 ## License

--- a/integration-tests.md
+++ b/integration-tests.md
@@ -14,6 +14,9 @@ Comprehensive integration test suite for gro. Tests are designed to work against
 - Access to Google Calendar with:
   - At least one calendar
   - At least one upcoming event
+- Access to Google Contacts with:
+  - At least some contacts
+  - At least one contact group (optional)
 
 ### Verification
 ```bash
@@ -259,12 +262,60 @@ ATTACHMENT_MSG_ID=$(gro mail search "has:attachment" --max 1 --json | jq -r '.[0
 
 ---
 
+## Contacts Operations
+
+### List Contacts
+
+| Test Case | Command | Expected Result |
+|-----------|---------|-----------------|
+| List all contacts | `gro contacts list` | Shows contacts with ID, Name, Email, Phone |
+| List with max | `gro ppl list --max 5` | Returns up to 5 contacts |
+| List JSON | `gro contacts list --json` | Valid JSON array with contact objects |
+| JSON has required fields | `gro ppl list --json \| jq -e '.[0] \| has("resourceName", "displayName")'` | Returns true |
+
+### Search Contacts
+
+| Test Case | Command | Expected Result |
+|-----------|---------|-----------------|
+| Search by name | `gro contacts search "John"` | Contacts matching "John" |
+| Search by email | `gro ppl search "@gmail.com" --max 5` | Contacts with Gmail addresses |
+| Search JSON | `gro contacts search "test" --json` | Valid JSON array with contacts |
+| No results | `gro ppl search "xyznonexistent12345uniquequery67890"` | "No contacts found matching..." |
+
+### Get Contact Details
+
+| Test Case | Command | Expected Result |
+|-----------|---------|-----------------|
+| Get contact by ID | `CONTACT_ID=$(gro ppl list --max 1 --json \| jq -r '.[0].resourceName'); gro contacts get "$CONTACT_ID"` | Shows full contact details |
+| Get contact JSON | `CONTACT_ID=$(gro ppl list --max 1 --json \| jq -r '.[0].resourceName'); gro ppl get "$CONTACT_ID" --json` | Valid JSON with all contact fields |
+
+### List Contact Groups
+
+| Test Case | Command | Expected Result |
+|-----------|---------|-----------------|
+| List all groups | `gro contacts groups` | Shows groups with ID, Name, Member count |
+| Groups JSON | `gro ppl groups --json` | Valid JSON array with group objects |
+| JSON has required fields | `gro contacts groups --json \| jq -e '.[0] \| has("resourceName", "name", "memberCount")'` | Returns true |
+
+### Alias Support
+
+| Test Case | Command | Expected Result |
+|-----------|---------|-----------------|
+| Ppl alias for list | `gro ppl list` | Same as `gro contacts list` |
+| Ppl alias for search | `gro ppl search "test"` | Same as `gro contacts search` |
+| Ppl alias for get | `gro ppl get <id>` | Same as `gro contacts get` |
+| Ppl alias for groups | `gro ppl groups` | Same as `gro contacts groups` |
+
+---
+
 ## Error Handling
 
 | Test Case | Command | Expected Result |
 |-----------|---------|-----------------|
 | Missing required arg (search) | `gro mail search` | Error: accepts 1 arg(s), received 0 |
 | Missing required arg (calendar get) | `gro calendar get` | Error: accepts 1 arg(s), received 0 |
+| Missing required arg (contacts search) | `gro contacts search` | Error: accepts 1 arg(s), received 0 |
+| Missing required arg (contacts get) | `gro contacts get` | Error: accepts 1 arg(s), received 0 |
 | Missing required arg (read) | `gro mail read` | Error: accepts 1 arg(s), received 0 |
 | Missing required arg (thread) | `gro mail thread` | Error: accepts 1 arg(s), received 0 |
 | Missing required arg (attachments list) | `gro mail attachments list` | Error: accepts 1 arg(s), received 0 |
@@ -373,6 +424,21 @@ gro mail thread "$THREAD_ID" --json | jq -r '.[].body'
 - [ ] `smaller:` filter
 - [ ] `filename:` with pdf, xlsx, zip
 - [ ] Combined `filename:` + `larger:` search
+
+### Calendar
+- [ ] `gro calendar list` shows calendars
+- [ ] `gro cal events` lists events
+- [ ] `gro cal today` shows today's events
+- [ ] `gro cal week` shows this week's events
+- [ ] `gro cal get <id>` gets event details
+- [ ] Calendar alias works (`gro cal` = `gro calendar`)
+
+### Contacts
+- [ ] `gro contacts list` shows contacts
+- [ ] `gro ppl search "query"` searches contacts
+- [ ] `gro contacts get <id>` gets contact details
+- [ ] `gro ppl groups` lists contact groups
+- [ ] Contacts alias works (`gro ppl` = `gro contacts`)
 
 ### Output Formats
 - [ ] Text output for all commands

--- a/internal/cmd/contacts/contacts.go
+++ b/internal/cmd/contacts/contacts.go
@@ -1,0 +1,30 @@
+package contacts
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewCommand creates the contacts parent command
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "contacts",
+		Aliases: []string{"ppl"},
+		Short:   "Google Contacts commands",
+		Long: `Commands for reading Google Contacts.
+
+All commands are read-only - no modifications are possible.
+
+The short alias 'ppl' can be used instead of 'contacts':
+  gro ppl list
+  gro ppl search "John"
+  gro ppl get <resource-name>
+  gro ppl groups`,
+	}
+
+	cmd.AddCommand(newListCommand())
+	cmd.AddCommand(newSearchCommand())
+	cmd.AddCommand(newGetCommand())
+	cmd.AddCommand(newGroupsCommand())
+
+	return cmd
+}

--- a/internal/cmd/contacts/contacts_test.go
+++ b/internal/cmd/contacts/contacts_test.go
@@ -1,0 +1,180 @@
+package contacts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContactsCommand(t *testing.T) {
+	cmd := NewCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "contacts", cmd.Use)
+	})
+
+	t.Run("has ppl alias", func(t *testing.T) {
+		assert.Contains(t, cmd.Aliases, "ppl")
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Short)
+	})
+
+	t.Run("has long description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Long)
+		assert.Contains(t, cmd.Long, "read-only")
+	})
+
+	t.Run("has subcommands", func(t *testing.T) {
+		subcommands := cmd.Commands()
+		assert.GreaterOrEqual(t, len(subcommands), 4)
+
+		var names []string
+		for _, sub := range subcommands {
+			names = append(names, sub.Name())
+		}
+		assert.Contains(t, names, "list")
+		assert.Contains(t, names, "search")
+		assert.Contains(t, names, "get")
+		assert.Contains(t, names, "groups")
+	})
+}
+
+func TestListCommand(t *testing.T) {
+	cmd := newListCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "list", cmd.Use)
+	})
+
+	t.Run("requires no arguments", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects arguments", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{"extra"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Short)
+	})
+
+	t.Run("has max flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("max")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "m", flag.Shorthand)
+		assert.Equal(t, "10", flag.DefValue)
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "j", flag.Shorthand)
+		assert.Equal(t, "false", flag.DefValue)
+	})
+}
+
+func TestSearchCommand(t *testing.T) {
+	cmd := newSearchCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "search <query>", cmd.Use)
+	})
+
+	t.Run("requires exactly one argument", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{"query"})
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects no arguments", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects multiple arguments", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{"query1", "query2"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Short)
+	})
+
+	t.Run("has max flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("max")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "m", flag.Shorthand)
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "j", flag.Shorthand)
+	})
+}
+
+func TestGetCommand(t *testing.T) {
+	cmd := newGetCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "get <resource-name>", cmd.Use)
+	})
+
+	t.Run("requires exactly one argument", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{"people/c123"})
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects no arguments", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.Error(t, err)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Short)
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "j", flag.Shorthand)
+	})
+}
+
+func TestGroupsCommand(t *testing.T) {
+	cmd := newGroupsCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "groups", cmd.Use)
+	})
+
+	t.Run("requires no arguments", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects arguments", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{"extra"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Short)
+	})
+
+	t.Run("has max flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("max")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "m", flag.Shorthand)
+		assert.Equal(t, "30", flag.DefValue)
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "j", flag.Shorthand)
+	})
+}

--- a/internal/cmd/contacts/get.go
+++ b/internal/cmd/contacts/get.go
@@ -1,0 +1,56 @@
+package contacts
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/contacts"
+)
+
+var (
+	getJSONOutput bool
+)
+
+func newGetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <resource-name>",
+		Short: "Get contact details",
+		Long: `Get the full details of a specific contact.
+
+The resource name is in the format "people/c123456789" and can be
+obtained from the list or search commands.
+
+Examples:
+  gro contacts get people/c123456789
+  gro ppl get people/c123456789 --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: runGet,
+	}
+
+	cmd.Flags().BoolVarP(&getJSONOutput, "json", "j", false, "Output as JSON")
+
+	return cmd
+}
+
+func runGet(cmd *cobra.Command, args []string) error {
+	resourceName := args[0]
+
+	client, err := newContactsClient()
+	if err != nil {
+		return err
+	}
+
+	person, err := client.GetContact(resourceName)
+	if err != nil {
+		return err
+	}
+
+	contact := contacts.ParseContact(person)
+
+	if getJSONOutput {
+		return printJSON(contact)
+	}
+
+	printContact(contact, true)
+
+	return nil
+}

--- a/internal/cmd/contacts/groups.go
+++ b/internal/cmd/contacts/groups.go
@@ -1,0 +1,70 @@
+package contacts
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/contacts"
+)
+
+var (
+	groupsMaxResults int64
+	groupsJSONOutput bool
+)
+
+func newGroupsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "groups",
+		Short: "List contact groups",
+		Long: `List all contact groups (labels) from your Google Contacts.
+
+Contact groups include both user-created labels and system groups.
+
+Examples:
+  gro contacts groups
+  gro contacts groups --max 50
+  gro ppl groups --json`,
+		Args: cobra.NoArgs,
+		RunE: runGroups,
+	}
+
+	cmd.Flags().Int64VarP(&groupsMaxResults, "max", "m", 30, "Maximum number of groups to return")
+	cmd.Flags().BoolVarP(&groupsJSONOutput, "json", "j", false, "Output as JSON")
+
+	return cmd
+}
+
+func runGroups(cmd *cobra.Command, args []string) error {
+	client, err := newContactsClient()
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.ListContactGroups("", groupsMaxResults)
+	if err != nil {
+		return err
+	}
+
+	if len(resp.ContactGroups) == 0 {
+		fmt.Println("No contact groups found.")
+		return nil
+	}
+
+	// Convert to our format
+	parsedGroups := make([]*contacts.ContactGroup, len(resp.ContactGroups))
+	for i, g := range resp.ContactGroups {
+		parsedGroups[i] = contacts.ParseContactGroup(g)
+	}
+
+	if groupsJSONOutput {
+		return printJSON(parsedGroups)
+	}
+
+	fmt.Printf("Found %d contact group(s):\n\n", len(resp.ContactGroups))
+	for _, group := range parsedGroups {
+		printContactGroup(group)
+	}
+
+	return nil
+}

--- a/internal/cmd/contacts/list.go
+++ b/internal/cmd/contacts/list.go
@@ -1,0 +1,70 @@
+package contacts
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/contacts"
+)
+
+var (
+	listMaxResults int64
+	listJSONOutput bool
+)
+
+func newListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all contacts",
+		Long: `List all contacts from your Google Contacts.
+
+Contacts are sorted by last name.
+
+Examples:
+  gro contacts list
+  gro contacts list --max 50
+  gro ppl list --json`,
+		Args: cobra.NoArgs,
+		RunE: runList,
+	}
+
+	cmd.Flags().Int64VarP(&listMaxResults, "max", "m", 10, "Maximum number of contacts to return")
+	cmd.Flags().BoolVarP(&listJSONOutput, "json", "j", false, "Output as JSON")
+
+	return cmd
+}
+
+func runList(cmd *cobra.Command, args []string) error {
+	client, err := newContactsClient()
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.ListContacts("", listMaxResults)
+	if err != nil {
+		return err
+	}
+
+	if len(resp.Connections) == 0 {
+		fmt.Println("No contacts found.")
+		return nil
+	}
+
+	// Convert to our format
+	parsedContacts := make([]*contacts.Contact, len(resp.Connections))
+	for i, p := range resp.Connections {
+		parsedContacts[i] = contacts.ParseContact(p)
+	}
+
+	if listJSONOutput {
+		return printJSON(parsedContacts)
+	}
+
+	fmt.Printf("Found %d contact(s):\n\n", len(resp.Connections))
+	for _, contact := range parsedContacts {
+		printContactSummary(contact)
+	}
+
+	return nil
+}

--- a/internal/cmd/contacts/output.go
+++ b/internal/cmd/contacts/output.go
@@ -1,0 +1,156 @@
+package contacts
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/open-cli-collective/google-readonly/internal/contacts"
+)
+
+// newContactsClient creates a new contacts client
+func newContactsClient() (*contacts.Client, error) {
+	return contacts.NewClient(context.Background())
+}
+
+// printJSON outputs data as indented JSON
+func printJSON(data any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(data)
+}
+
+// printContact prints a single contact in text format
+func printContact(contact *contacts.Contact, showDetails bool) {
+	fmt.Printf("ID: %s\n", contact.ResourceName)
+	fmt.Printf("Name: %s\n", contact.GetDisplayName())
+
+	if email := contact.GetPrimaryEmail(); email != "" {
+		fmt.Printf("Email: %s\n", email)
+	}
+
+	if phone := contact.GetPrimaryPhone(); phone != "" {
+		fmt.Printf("Phone: %s\n", phone)
+	}
+
+	if org := contact.GetOrganization(); org != "" {
+		fmt.Printf("Organization: %s\n", org)
+	}
+
+	if showDetails {
+		// Show all emails
+		if len(contact.Emails) > 1 {
+			fmt.Println("All Emails:")
+			for _, e := range contact.Emails {
+				primary := ""
+				if e.Primary {
+					primary = " (primary)"
+				}
+				typeStr := ""
+				if e.Type != "" {
+					typeStr = fmt.Sprintf(" [%s]", e.Type)
+				}
+				fmt.Printf("  - %s%s%s\n", e.Value, typeStr, primary)
+			}
+		}
+
+		// Show all phones
+		if len(contact.Phones) > 1 {
+			fmt.Println("All Phones:")
+			for _, p := range contact.Phones {
+				typeStr := ""
+				if p.Type != "" {
+					typeStr = fmt.Sprintf(" [%s]", p.Type)
+				}
+				fmt.Printf("  - %s%s\n", p.Value, typeStr)
+			}
+		}
+
+		// Show all organizations
+		if len(contact.Organizations) > 0 {
+			fmt.Println("Organizations:")
+			for _, o := range contact.Organizations {
+				if o.Name != "" {
+					fmt.Printf("  - %s", o.Name)
+					if o.Title != "" {
+						fmt.Printf(" (%s)", o.Title)
+					}
+					if o.Department != "" {
+						fmt.Printf(" - %s", o.Department)
+					}
+					fmt.Println()
+				} else if o.Title != "" {
+					fmt.Printf("  - %s\n", o.Title)
+				}
+			}
+		}
+
+		// Show addresses
+		if len(contact.Addresses) > 0 {
+			fmt.Println("Addresses:")
+			for _, a := range contact.Addresses {
+				typeStr := ""
+				if a.Type != "" {
+					typeStr = fmt.Sprintf("[%s] ", a.Type)
+				}
+				fmt.Printf("  - %s%s\n", typeStr, a.FormattedValue)
+			}
+		}
+
+		// Show URLs
+		if len(contact.URLs) > 0 {
+			fmt.Println("URLs:")
+			for _, u := range contact.URLs {
+				typeStr := ""
+				if u.Type != "" {
+					typeStr = fmt.Sprintf("[%s] ", u.Type)
+				}
+				fmt.Printf("  - %s%s\n", typeStr, u.Value)
+			}
+		}
+
+		// Show birthday
+		if contact.Birthday != "" {
+			fmt.Printf("Birthday: %s\n", contact.Birthday)
+		}
+
+		// Show biography
+		if contact.Biography != "" {
+			fmt.Println()
+			fmt.Println("--- Biography ---")
+			fmt.Println(contact.Biography)
+		}
+	}
+}
+
+// printContactSummary prints a brief contact summary for list views
+func printContactSummary(contact *contacts.Contact) {
+	fmt.Printf("ID: %s\n", contact.ResourceName)
+	fmt.Printf("Name: %s\n", contact.GetDisplayName())
+
+	if email := contact.GetPrimaryEmail(); email != "" {
+		fmt.Printf("Email: %s\n", email)
+	}
+
+	if phone := contact.GetPrimaryPhone(); phone != "" {
+		fmt.Printf("Phone: %s\n", phone)
+	}
+
+	if org := contact.GetOrganization(); org != "" {
+		fmt.Printf("Organization: %s\n", org)
+	}
+
+	fmt.Println("---")
+}
+
+// printContactGroup prints a contact group
+func printContactGroup(group *contacts.ContactGroup) {
+	fmt.Printf("ID: %s\n", group.ResourceName)
+	fmt.Printf("Name: %s\n", group.Name)
+	if group.GroupType != "" {
+		fmt.Printf("Type: %s\n", group.GroupType)
+	}
+	fmt.Printf("Members: %d\n", group.MemberCount)
+	fmt.Println("---")
+}

--- a/internal/cmd/contacts/output_test.go
+++ b/internal/cmd/contacts/output_test.go
@@ -1,0 +1,384 @@
+package contacts
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-cli-collective/google-readonly/internal/contacts"
+)
+
+func TestPrintJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		data any
+	}{
+		{
+			name: "single contact",
+			data: &contacts.Contact{
+				ResourceName: "people/c123",
+				DisplayName:  "John Doe",
+			},
+		},
+		{
+			name: "contact list",
+			data: []*contacts.Contact{
+				{ResourceName: "people/c1", DisplayName: "Alice"},
+				{ResourceName: "people/c2", DisplayName: "Bob"},
+			},
+		},
+		{
+			name: "contact group",
+			data: &contacts.ContactGroup{
+				ResourceName: "contactGroups/abc",
+				Name:         "Work",
+				MemberCount:  5,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture stdout
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			err := printJSON(tt.data)
+			require.NoError(t, err)
+
+			w.Close()
+			os.Stdout = oldStdout
+
+			var buf bytes.Buffer
+			io.Copy(&buf, r)
+
+			output := buf.String()
+			assert.NotEmpty(t, output)
+
+			// Verify it's valid JSON
+			var parsed any
+			err = json.Unmarshal([]byte(output), &parsed)
+			assert.NoError(t, err, "output should be valid JSON")
+		})
+	}
+}
+
+func TestPrintContact(t *testing.T) {
+	tests := []struct {
+		name            string
+		contact         *contacts.Contact
+		showDetails     bool
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name: "basic contact",
+			contact: &contacts.Contact{
+				ResourceName: "people/c123",
+				DisplayName:  "John Doe",
+			},
+			showDetails: false,
+			wantContains: []string{
+				"ID: people/c123",
+				"Name: John Doe",
+			},
+		},
+		{
+			name: "contact with email",
+			contact: &contacts.Contact{
+				ResourceName: "people/c456",
+				DisplayName:  "Jane Smith",
+				Emails: []contacts.Email{
+					{Value: "jane@example.com", Primary: true},
+				},
+			},
+			showDetails: false,
+			wantContains: []string{
+				"Email: jane@example.com",
+			},
+		},
+		{
+			name: "contact with phone",
+			contact: &contacts.Contact{
+				ResourceName: "people/c789",
+				DisplayName:  "Bob Wilson",
+				Phones: []contacts.Phone{
+					{Value: "+1-555-123-4567", Type: "mobile"},
+				},
+			},
+			showDetails: false,
+			wantContains: []string{
+				"Phone: +1-555-123-4567",
+			},
+		},
+		{
+			name: "contact with organization",
+			contact: &contacts.Contact{
+				ResourceName: "people/c101",
+				DisplayName:  "Alice Brown",
+				Organizations: []contacts.Organization{
+					{Name: "Acme Corp", Title: "Engineer"},
+				},
+			},
+			showDetails: false,
+			wantContains: []string{
+				"Organization: Acme Corp",
+			},
+		},
+		{
+			name: "contact with details - multiple emails",
+			contact: &contacts.Contact{
+				ResourceName: "people/c102",
+				DisplayName:  "Charlie Davis",
+				Emails: []contacts.Email{
+					{Value: "charlie@work.com", Type: "work", Primary: true},
+					{Value: "charlie@home.com", Type: "home"},
+				},
+			},
+			showDetails: true,
+			wantContains: []string{
+				"All Emails:",
+				"charlie@work.com",
+				"[work]",
+				"(primary)",
+				"charlie@home.com",
+			},
+		},
+		{
+			name: "contact with details - addresses",
+			contact: &contacts.Contact{
+				ResourceName: "people/c103",
+				DisplayName:  "Diana Evans",
+				Addresses: []contacts.Address{
+					{FormattedValue: "123 Main St, SF, CA", Type: "home"},
+				},
+			},
+			showDetails: true,
+			wantContains: []string{
+				"Addresses:",
+				"[home]",
+				"123 Main St",
+			},
+		},
+		{
+			name: "contact with details - URLs",
+			contact: &contacts.Contact{
+				ResourceName: "people/c104",
+				DisplayName:  "Eve Franklin",
+				URLs: []contacts.URL{
+					{Value: "https://linkedin.com/in/eve", Type: "profile"},
+				},
+			},
+			showDetails: true,
+			wantContains: []string{
+				"URLs:",
+				"https://linkedin.com/in/eve",
+			},
+		},
+		{
+			name: "contact with details - birthday",
+			contact: &contacts.Contact{
+				ResourceName: "people/c105",
+				DisplayName:  "Frank Garcia",
+				Birthday:     "1990-06-15",
+			},
+			showDetails: true,
+			wantContains: []string{
+				"Birthday: 1990-06-15",
+			},
+		},
+		{
+			name: "contact with details - biography",
+			contact: &contacts.Contact{
+				ResourceName: "people/c106",
+				DisplayName:  "Grace Harris",
+				Biography:    "Software engineer and open source contributor.",
+			},
+			showDetails: true,
+			wantContains: []string{
+				"--- Biography ---",
+				"Software engineer",
+			},
+		},
+		{
+			name: "contact without details - hides biography",
+			contact: &contacts.Contact{
+				ResourceName: "people/c107",
+				DisplayName:  "Henry Irving",
+				Biography:    "Should be hidden",
+			},
+			showDetails: false,
+			wantNotContains: []string{
+				"--- Biography ---",
+				"Should be hidden",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture stdout
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			printContact(tt.contact, tt.showDetails)
+
+			w.Close()
+			os.Stdout = oldStdout
+
+			var buf bytes.Buffer
+			io.Copy(&buf, r)
+
+			output := buf.String()
+
+			for _, want := range tt.wantContains {
+				assert.Contains(t, output, want)
+			}
+			for _, notWant := range tt.wantNotContains {
+				assert.NotContains(t, output, notWant)
+			}
+		})
+	}
+}
+
+func TestPrintContactSummary(t *testing.T) {
+	tests := []struct {
+		name         string
+		contact      *contacts.Contact
+		wantContains []string
+	}{
+		{
+			name: "basic summary",
+			contact: &contacts.Contact{
+				ResourceName: "people/c123",
+				DisplayName:  "John Doe",
+				Emails:       []contacts.Email{{Value: "john@example.com"}},
+				Phones:       []contacts.Phone{{Value: "+1-555-1234"}},
+			},
+			wantContains: []string{
+				"ID: people/c123",
+				"Name: John Doe",
+				"Email: john@example.com",
+				"Phone: +1-555-1234",
+				"---",
+			},
+		},
+		{
+			name: "summary with organization",
+			contact: &contacts.Contact{
+				ResourceName: "people/c456",
+				DisplayName:  "Jane Smith",
+				Organizations: []contacts.Organization{
+					{Name: "Tech Corp"},
+				},
+			},
+			wantContains: []string{
+				"Organization: Tech Corp",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture stdout
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			printContactSummary(tt.contact)
+
+			w.Close()
+			os.Stdout = oldStdout
+
+			var buf bytes.Buffer
+			io.Copy(&buf, r)
+
+			output := buf.String()
+
+			for _, want := range tt.wantContains {
+				assert.Contains(t, output, want)
+			}
+		})
+	}
+}
+
+func TestPrintContactGroup(t *testing.T) {
+	tests := []struct {
+		name         string
+		group        *contacts.ContactGroup
+		wantContains []string
+	}{
+		{
+			name: "user contact group",
+			group: &contacts.ContactGroup{
+				ResourceName: "contactGroups/abc123",
+				Name:         "Work",
+				GroupType:    "USER_CONTACT_GROUP",
+				MemberCount:  42,
+			},
+			wantContains: []string{
+				"ID: contactGroups/abc123",
+				"Name: Work",
+				"Type: USER_CONTACT_GROUP",
+				"Members: 42",
+				"---",
+			},
+		},
+		{
+			name: "system group",
+			group: &contacts.ContactGroup{
+				ResourceName: "contactGroups/all",
+				Name:         "All Contacts",
+				GroupType:    "SYSTEM_CONTACT_GROUP",
+				MemberCount:  100,
+			},
+			wantContains: []string{
+				"Name: All Contacts",
+				"Type: SYSTEM_CONTACT_GROUP",
+				"Members: 100",
+			},
+		},
+		{
+			name: "group without type",
+			group: &contacts.ContactGroup{
+				ResourceName: "contactGroups/xyz",
+				Name:         "Friends",
+				MemberCount:  5,
+			},
+			wantContains: []string{
+				"Name: Friends",
+				"Members: 5",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture stdout
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			printContactGroup(tt.group)
+
+			w.Close()
+			os.Stdout = oldStdout
+
+			var buf bytes.Buffer
+			io.Copy(&buf, r)
+
+			output := buf.String()
+
+			for _, want := range tt.wantContains {
+				assert.Contains(t, output, want)
+			}
+		})
+	}
+}

--- a/internal/cmd/contacts/search.go
+++ b/internal/cmd/contacts/search.go
@@ -1,0 +1,78 @@
+package contacts
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/contacts"
+)
+
+var (
+	searchMaxResults int64
+	searchJSONOutput bool
+)
+
+func newSearchCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Search contacts",
+		Long: `Search contacts by name, email, phone number, or organization.
+
+The query is matched against multiple fields:
+- Display name
+- Given name and family name
+- Email addresses
+- Phone numbers
+- Organization name
+
+Examples:
+  gro contacts search "John"
+  gro contacts search "example.com"
+  gro contacts search "+1-555" --max 20
+  gro ppl search "Acme" --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: runSearch,
+	}
+
+	cmd.Flags().Int64VarP(&searchMaxResults, "max", "m", 10, "Maximum number of results")
+	cmd.Flags().BoolVarP(&searchJSONOutput, "json", "j", false, "Output as JSON")
+
+	return cmd
+}
+
+func runSearch(cmd *cobra.Command, args []string) error {
+	query := args[0]
+
+	client, err := newContactsClient()
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.SearchContacts(query, searchMaxResults)
+	if err != nil {
+		return err
+	}
+
+	if len(resp.Results) == 0 {
+		fmt.Printf("No contacts found matching \"%s\".\n", query)
+		return nil
+	}
+
+	// Convert to our format
+	parsedContacts := make([]*contacts.Contact, len(resp.Results))
+	for i, r := range resp.Results {
+		parsedContacts[i] = contacts.ParseContact(r.Person)
+	}
+
+	if searchJSONOutput {
+		return printJSON(parsedContacts)
+	}
+
+	fmt.Printf("Found %d contact(s) matching \"%s\":\n\n", len(resp.Results), query)
+	for _, contact := range parsedContacts {
+		printContactSummary(contact)
+	}
+
+	return nil
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/open-cli-collective/google-readonly/internal/cmd/calendar"
 	"github.com/open-cli-collective/google-readonly/internal/cmd/config"
+	"github.com/open-cli-collective/google-readonly/internal/cmd/contacts"
 	"github.com/open-cli-collective/google-readonly/internal/cmd/initcmd"
 	"github.com/open-cli-collective/google-readonly/internal/cmd/mail"
 	"github.com/open-cli-collective/google-readonly/internal/version"
@@ -45,4 +46,5 @@ func init() {
 	rootCmd.AddCommand(config.NewCommand())
 	rootCmd.AddCommand(mail.NewCommand())
 	rootCmd.AddCommand(calendar.NewCommand())
+	rootCmd.AddCommand(contacts.NewCommand())
 }

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -26,7 +26,7 @@ func TestRootCommand(t *testing.T) {
 
 	t.Run("has subcommands", func(t *testing.T) {
 		subcommands := rootCmd.Commands()
-		assert.GreaterOrEqual(t, len(subcommands), 4)
+		assert.GreaterOrEqual(t, len(subcommands), 5)
 
 		var names []string
 		for _, sub := range subcommands {
@@ -36,5 +36,6 @@ func TestRootCommand(t *testing.T) {
 		assert.Contains(t, names, "config")
 		assert.Contains(t, names, "mail")
 		assert.Contains(t, names, "calendar")
+		assert.Contains(t, names, "contacts")
 	})
 }

--- a/internal/contacts/client.go
+++ b/internal/contacts/client.go
@@ -1,0 +1,143 @@
+package contacts
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
+	"google.golang.org/api/people/v1"
+
+	"github.com/open-cli-collective/google-readonly/internal/keychain"
+)
+
+const (
+	configDirName   = "google-readonly"
+	credentialsFile = "credentials.json"
+)
+
+// Client wraps the Google People API service for contacts
+type Client struct {
+	Service *people.Service
+}
+
+// NewClient creates a new Contacts client with OAuth2 authentication
+func NewClient(ctx context.Context) (*Client, error) {
+	configDir, err := getConfigDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get config directory: %w", err)
+	}
+
+	credPath := filepath.Join(configDir, credentialsFile)
+	b, err := os.ReadFile(credPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read credentials file at %s: %w\n\nPlease download your OAuth credentials from Google Cloud Console and save them to %s", credPath, err, credPath)
+	}
+
+	// Request read-only scope for contacts
+	config, err := google.ConfigFromJSON(b, people.ContactsReadonlyScope)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse credentials: %w", err)
+	}
+
+	// Get token from keychain
+	tok, err := keychain.GetToken()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get token: %w\n\nRun 'gro init' to authenticate", err)
+	}
+
+	// Create persistent token source that saves refreshed tokens
+	tokenSource := keychain.NewPersistentTokenSource(config, tok)
+
+	srv, err := people.NewService(ctx, option.WithTokenSource(tokenSource))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create People service: %w", err)
+	}
+
+	return &Client{
+		Service: srv,
+	}, nil
+}
+
+func getConfigDir() (string, error) {
+	configHome := os.Getenv("XDG_CONFIG_HOME")
+	if configHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		configHome = filepath.Join(home, ".config")
+	}
+	configDir := filepath.Join(configHome, configDirName)
+
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		return "", err
+	}
+
+	return configDir, nil
+}
+
+// ListContacts retrieves contacts from the user's account
+func (c *Client) ListContacts(pageToken string, pageSize int64) (*people.ListConnectionsResponse, error) {
+	call := c.Service.People.Connections.List("people/me").
+		PersonFields("names,emailAddresses,phoneNumbers,organizations,addresses,biographies,photos").
+		PageSize(pageSize).
+		SortOrder("LAST_NAME_ASCENDING")
+
+	if pageToken != "" {
+		call = call.PageToken(pageToken)
+	}
+
+	resp, err := call.Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list contacts: %w", err)
+	}
+
+	return resp, nil
+}
+
+// SearchContacts searches for contacts matching a query
+func (c *Client) SearchContacts(query string, pageSize int64) (*people.SearchResponse, error) {
+	resp, err := c.Service.People.SearchContacts().
+		Query(query).
+		ReadMask("names,emailAddresses,phoneNumbers,organizations,addresses,biographies,photos").
+		PageSize(int64(pageSize)).
+		Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to search contacts: %w", err)
+	}
+
+	return resp, nil
+}
+
+// GetContact retrieves a specific contact by resource name
+func (c *Client) GetContact(resourceName string) (*people.Person, error) {
+	resp, err := c.Service.People.Get(resourceName).
+		PersonFields("names,emailAddresses,phoneNumbers,organizations,addresses,biographies,urls,birthdays,events,relations,photos,metadata").
+		Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get contact: %w", err)
+	}
+
+	return resp, nil
+}
+
+// ListContactGroups retrieves all contact groups
+func (c *Client) ListContactGroups(pageToken string, pageSize int64) (*people.ListContactGroupsResponse, error) {
+	call := c.Service.ContactGroups.List().
+		PageSize(pageSize).
+		GroupFields("name,groupType,memberCount")
+
+	if pageToken != "" {
+		call = call.PageToken(pageToken)
+	}
+
+	resp, err := call.Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list contact groups: %w", err)
+	}
+
+	return resp, nil
+}

--- a/internal/contacts/client_test.go
+++ b/internal/contacts/client_test.go
@@ -1,0 +1,26 @@
+package contacts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetConfigDir(t *testing.T) {
+	t.Run("returns valid path", func(t *testing.T) {
+		dir, err := getConfigDir()
+		assert.NoError(t, err)
+		assert.NotEmpty(t, dir)
+		assert.Contains(t, dir, "google-readonly")
+	})
+}
+
+func TestConstants(t *testing.T) {
+	t.Run("config dir name is correct", func(t *testing.T) {
+		assert.Equal(t, "google-readonly", configDirName)
+	})
+
+	t.Run("credentials file name is correct", func(t *testing.T) {
+		assert.Equal(t, "credentials.json", credentialsFile)
+	})
+}

--- a/internal/contacts/contacts.go
+++ b/internal/contacts/contacts.go
@@ -1,0 +1,275 @@
+package contacts
+
+import (
+	"google.golang.org/api/people/v1"
+)
+
+// Contact represents a simplified contact for output
+type Contact struct {
+	ResourceName  string         `json:"resourceName"`
+	DisplayName   string         `json:"displayName,omitempty"`
+	Names         []Name         `json:"names,omitempty"`
+	Emails        []Email        `json:"emails,omitempty"`
+	Phones        []Phone        `json:"phones,omitempty"`
+	Organizations []Organization `json:"organizations,omitempty"`
+	Addresses     []Address      `json:"addresses,omitempty"`
+	URLs          []URL          `json:"urls,omitempty"`
+	Biography     string         `json:"biography,omitempty"`
+	Birthday      string         `json:"birthday,omitempty"`
+	PhotoURL      string         `json:"photoUrl,omitempty"`
+}
+
+// Name represents a contact name
+type Name struct {
+	DisplayName      string `json:"displayName,omitempty"`
+	GivenName        string `json:"givenName,omitempty"`
+	FamilyName       string `json:"familyName,omitempty"`
+	MiddleName       string `json:"middleName,omitempty"`
+	HonorificPrefix  string `json:"honorificPrefix,omitempty"`
+	HonorificSuffix  string `json:"honorificSuffix,omitempty"`
+	PhoneticFullName string `json:"phoneticFullName,omitempty"`
+}
+
+// Email represents an email address
+type Email struct {
+	Value       string `json:"value"`
+	Type        string `json:"type,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+	Primary     bool   `json:"primary,omitempty"`
+}
+
+// Phone represents a phone number
+type Phone struct {
+	Value string `json:"value"`
+	Type  string `json:"type,omitempty"`
+}
+
+// Organization represents a company/organization
+type Organization struct {
+	Name       string `json:"name,omitempty"`
+	Title      string `json:"title,omitempty"`
+	Department string `json:"department,omitempty"`
+	Type       string `json:"type,omitempty"`
+}
+
+// Address represents a physical address
+type Address struct {
+	FormattedValue string `json:"formattedValue,omitempty"`
+	Type           string `json:"type,omitempty"`
+	City           string `json:"city,omitempty"`
+	Region         string `json:"region,omitempty"`
+	PostalCode     string `json:"postalCode,omitempty"`
+	Country        string `json:"country,omitempty"`
+}
+
+// URL represents a website or link
+type URL struct {
+	Value string `json:"value"`
+	Type  string `json:"type,omitempty"`
+}
+
+// ContactGroup represents a contact group/label
+type ContactGroup struct {
+	ResourceName string `json:"resourceName"`
+	Name         string `json:"name"`
+	GroupType    string `json:"groupType,omitempty"`
+	MemberCount  int64  `json:"memberCount"`
+}
+
+// ParseContact converts a People API Person to our Contact type
+func ParseContact(p *people.Person) *Contact {
+	if p == nil {
+		return nil
+	}
+
+	contact := &Contact{
+		ResourceName: p.ResourceName,
+	}
+
+	// Parse names
+	if len(p.Names) > 0 {
+		contact.DisplayName = p.Names[0].DisplayName
+		contact.Names = make([]Name, len(p.Names))
+		for i, n := range p.Names {
+			contact.Names[i] = Name{
+				DisplayName:      n.DisplayName,
+				GivenName:        n.GivenName,
+				FamilyName:       n.FamilyName,
+				MiddleName:       n.MiddleName,
+				HonorificPrefix:  n.HonorificPrefix,
+				HonorificSuffix:  n.HonorificSuffix,
+				PhoneticFullName: n.PhoneticFullName,
+			}
+		}
+	}
+
+	// Parse emails
+	if len(p.EmailAddresses) > 0 {
+		contact.Emails = make([]Email, len(p.EmailAddresses))
+		for i, e := range p.EmailAddresses {
+			contact.Emails[i] = Email{
+				Value:       e.Value,
+				Type:        e.Type,
+				DisplayName: e.DisplayName,
+			}
+			if e.Metadata != nil && e.Metadata.Primary {
+				contact.Emails[i].Primary = true
+			}
+		}
+	}
+
+	// Parse phones
+	if len(p.PhoneNumbers) > 0 {
+		contact.Phones = make([]Phone, len(p.PhoneNumbers))
+		for i, ph := range p.PhoneNumbers {
+			contact.Phones[i] = Phone{
+				Value: ph.Value,
+				Type:  ph.Type,
+			}
+		}
+	}
+
+	// Parse organizations
+	if len(p.Organizations) > 0 {
+		contact.Organizations = make([]Organization, len(p.Organizations))
+		for i, o := range p.Organizations {
+			contact.Organizations[i] = Organization{
+				Name:       o.Name,
+				Title:      o.Title,
+				Department: o.Department,
+				Type:       o.Type,
+			}
+		}
+	}
+
+	// Parse addresses
+	if len(p.Addresses) > 0 {
+		contact.Addresses = make([]Address, len(p.Addresses))
+		for i, a := range p.Addresses {
+			contact.Addresses[i] = Address{
+				FormattedValue: a.FormattedValue,
+				Type:           a.Type,
+				City:           a.City,
+				Region:         a.Region,
+				PostalCode:     a.PostalCode,
+				Country:        a.Country,
+			}
+		}
+	}
+
+	// Parse URLs
+	if len(p.Urls) > 0 {
+		contact.URLs = make([]URL, len(p.Urls))
+		for i, u := range p.Urls {
+			contact.URLs[i] = URL{
+				Value: u.Value,
+				Type:  u.Type,
+			}
+		}
+	}
+
+	// Parse biography
+	if len(p.Biographies) > 0 {
+		contact.Biography = p.Biographies[0].Value
+	}
+
+	// Parse birthday
+	if len(p.Birthdays) > 0 && p.Birthdays[0].Date != nil {
+		d := p.Birthdays[0].Date
+		if d.Year > 0 {
+			contact.Birthday = formatDate(d.Year, d.Month, d.Day)
+		} else if d.Month > 0 {
+			contact.Birthday = formatMonthDay(d.Month, d.Day)
+		}
+	}
+
+	// Parse photo
+	if len(p.Photos) > 0 {
+		contact.PhotoURL = p.Photos[0].Url
+	}
+
+	return contact
+}
+
+// ParseContactGroup converts a People API ContactGroup to our ContactGroup type
+func ParseContactGroup(g *people.ContactGroup) *ContactGroup {
+	if g == nil {
+		return nil
+	}
+
+	return &ContactGroup{
+		ResourceName: g.ResourceName,
+		Name:         g.Name,
+		GroupType:    g.GroupType,
+		MemberCount:  g.MemberCount,
+	}
+}
+
+func formatDate(year int64, month int64, day int64) string {
+	if year > 0 && month > 0 && day > 0 {
+		return formatInt(year, 4) + "-" + formatInt(month, 2) + "-" + formatInt(day, 2)
+	}
+	return ""
+}
+
+func formatMonthDay(month int64, day int64) string {
+	if month > 0 && day > 0 {
+		return formatInt(month, 2) + "-" + formatInt(day, 2)
+	}
+	return ""
+}
+
+func formatInt(n int64, width int) string {
+	s := ""
+	for i := 0; i < width; i++ {
+		s = string(rune('0'+n%10)) + s
+		n /= 10
+	}
+	return s
+}
+
+// GetDisplayName returns the best display name for a contact
+func (c *Contact) GetDisplayName() string {
+	if c.DisplayName != "" {
+		return c.DisplayName
+	}
+	if len(c.Names) > 0 && c.Names[0].DisplayName != "" {
+		return c.Names[0].DisplayName
+	}
+	if len(c.Emails) > 0 {
+		return c.Emails[0].Value
+	}
+	return c.ResourceName
+}
+
+// GetPrimaryEmail returns the primary email or first email
+func (c *Contact) GetPrimaryEmail() string {
+	for _, e := range c.Emails {
+		if e.Primary {
+			return e.Value
+		}
+	}
+	if len(c.Emails) > 0 {
+		return c.Emails[0].Value
+	}
+	return ""
+}
+
+// GetPrimaryPhone returns the first phone number
+func (c *Contact) GetPrimaryPhone() string {
+	if len(c.Phones) > 0 {
+		return c.Phones[0].Value
+	}
+	return ""
+}
+
+// GetOrganization returns the first organization name
+func (c *Contact) GetOrganization() string {
+	if len(c.Organizations) > 0 {
+		if c.Organizations[0].Name != "" {
+			return c.Organizations[0].Name
+		}
+		return c.Organizations[0].Title
+	}
+	return ""
+}

--- a/internal/contacts/contacts_test.go
+++ b/internal/contacts/contacts_test.go
@@ -1,0 +1,361 @@
+package contacts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/people/v1"
+)
+
+func TestParseContact(t *testing.T) {
+	t.Run("parses basic contact", func(t *testing.T) {
+		p := &people.Person{
+			ResourceName: "people/c123",
+			Names: []*people.Name{
+				{
+					DisplayName: "John Doe",
+					GivenName:   "John",
+					FamilyName:  "Doe",
+				},
+			},
+		}
+
+		contact := ParseContact(p)
+
+		assert.Equal(t, "people/c123", contact.ResourceName)
+		assert.Equal(t, "John Doe", contact.DisplayName)
+		assert.Len(t, contact.Names, 1)
+		assert.Equal(t, "John", contact.Names[0].GivenName)
+		assert.Equal(t, "Doe", contact.Names[0].FamilyName)
+	})
+
+	t.Run("parses contact with email", func(t *testing.T) {
+		p := &people.Person{
+			ResourceName: "people/c456",
+			Names: []*people.Name{
+				{DisplayName: "Jane Smith"},
+			},
+			EmailAddresses: []*people.EmailAddress{
+				{
+					Value:    "jane@example.com",
+					Type:     "work",
+					Metadata: &people.FieldMetadata{Primary: true},
+				},
+				{
+					Value: "jane.personal@example.com",
+					Type:  "home",
+				},
+			},
+		}
+
+		contact := ParseContact(p)
+
+		assert.Len(t, contact.Emails, 2)
+		assert.Equal(t, "jane@example.com", contact.Emails[0].Value)
+		assert.Equal(t, "work", contact.Emails[0].Type)
+		assert.True(t, contact.Emails[0].Primary)
+		assert.Equal(t, "jane.personal@example.com", contact.Emails[1].Value)
+		assert.False(t, contact.Emails[1].Primary)
+	})
+
+	t.Run("parses contact with phone numbers", func(t *testing.T) {
+		p := &people.Person{
+			ResourceName: "people/c789",
+			PhoneNumbers: []*people.PhoneNumber{
+				{Value: "+1-555-123-4567", Type: "mobile"},
+				{Value: "+1-555-987-6543", Type: "work"},
+			},
+		}
+
+		contact := ParseContact(p)
+
+		assert.Len(t, contact.Phones, 2)
+		assert.Equal(t, "+1-555-123-4567", contact.Phones[0].Value)
+		assert.Equal(t, "mobile", contact.Phones[0].Type)
+	})
+
+	t.Run("parses contact with organization", func(t *testing.T) {
+		p := &people.Person{
+			ResourceName: "people/c101",
+			Organizations: []*people.Organization{
+				{
+					Name:       "Acme Corp",
+					Title:      "Software Engineer",
+					Department: "Engineering",
+				},
+			},
+		}
+
+		contact := ParseContact(p)
+
+		assert.Len(t, contact.Organizations, 1)
+		assert.Equal(t, "Acme Corp", contact.Organizations[0].Name)
+		assert.Equal(t, "Software Engineer", contact.Organizations[0].Title)
+		assert.Equal(t, "Engineering", contact.Organizations[0].Department)
+	})
+
+	t.Run("parses contact with address", func(t *testing.T) {
+		p := &people.Person{
+			ResourceName: "people/c102",
+			Addresses: []*people.Address{
+				{
+					FormattedValue: "123 Main St, San Francisco, CA 94102",
+					Type:           "home",
+					City:           "San Francisco",
+					Region:         "CA",
+					PostalCode:     "94102",
+					Country:        "USA",
+				},
+			},
+		}
+
+		contact := ParseContact(p)
+
+		assert.Len(t, contact.Addresses, 1)
+		assert.Equal(t, "home", contact.Addresses[0].Type)
+		assert.Equal(t, "San Francisco", contact.Addresses[0].City)
+		assert.Equal(t, "94102", contact.Addresses[0].PostalCode)
+	})
+
+	t.Run("parses contact with URLs", func(t *testing.T) {
+		p := &people.Person{
+			ResourceName: "people/c103",
+			Urls: []*people.Url{
+				{Value: "https://linkedin.com/in/johndoe", Type: "profile"},
+				{Value: "https://github.com/johndoe", Type: "other"},
+			},
+		}
+
+		contact := ParseContact(p)
+
+		assert.Len(t, contact.URLs, 2)
+		assert.Equal(t, "https://linkedin.com/in/johndoe", contact.URLs[0].Value)
+	})
+
+	t.Run("parses contact with biography", func(t *testing.T) {
+		p := &people.Person{
+			ResourceName: "people/c104",
+			Biographies: []*people.Biography{
+				{Value: "A passionate software developer."},
+			},
+		}
+
+		contact := ParseContact(p)
+
+		assert.Equal(t, "A passionate software developer.", contact.Biography)
+	})
+
+	t.Run("parses contact with birthday including year", func(t *testing.T) {
+		p := &people.Person{
+			ResourceName: "people/c105",
+			Birthdays: []*people.Birthday{
+				{Date: &people.Date{Year: 1990, Month: 6, Day: 15}},
+			},
+		}
+
+		contact := ParseContact(p)
+
+		assert.Equal(t, "1990-06-15", contact.Birthday)
+	})
+
+	t.Run("parses contact with birthday month/day only", func(t *testing.T) {
+		p := &people.Person{
+			ResourceName: "people/c106",
+			Birthdays: []*people.Birthday{
+				{Date: &people.Date{Month: 12, Day: 25}},
+			},
+		}
+
+		contact := ParseContact(p)
+
+		assert.Equal(t, "12-25", contact.Birthday)
+	})
+
+	t.Run("parses contact with photo", func(t *testing.T) {
+		p := &people.Person{
+			ResourceName: "people/c107",
+			Photos: []*people.Photo{
+				{Url: "https://example.com/photo.jpg"},
+			},
+		}
+
+		contact := ParseContact(p)
+
+		assert.Equal(t, "https://example.com/photo.jpg", contact.PhotoURL)
+	})
+
+	t.Run("handles nil person", func(t *testing.T) {
+		contact := ParseContact(nil)
+		assert.Nil(t, contact)
+	})
+}
+
+func TestParseContactGroup(t *testing.T) {
+	t.Run("parses contact group", func(t *testing.T) {
+		g := &people.ContactGroup{
+			ResourceName: "contactGroups/abc123",
+			Name:         "Work",
+			GroupType:    "USER_CONTACT_GROUP",
+			MemberCount:  42,
+		}
+
+		group := ParseContactGroup(g)
+
+		assert.Equal(t, "contactGroups/abc123", group.ResourceName)
+		assert.Equal(t, "Work", group.Name)
+		assert.Equal(t, "USER_CONTACT_GROUP", group.GroupType)
+		assert.Equal(t, int64(42), group.MemberCount)
+	})
+
+	t.Run("handles nil group", func(t *testing.T) {
+		group := ParseContactGroup(nil)
+		assert.Nil(t, group)
+	})
+}
+
+func TestContactGetDisplayName(t *testing.T) {
+	t.Run("returns display name when set", func(t *testing.T) {
+		c := &Contact{
+			ResourceName: "people/c1",
+			DisplayName:  "John Doe",
+		}
+		assert.Equal(t, "John Doe", c.GetDisplayName())
+	})
+
+	t.Run("falls back to names array", func(t *testing.T) {
+		c := &Contact{
+			ResourceName: "people/c2",
+			Names: []Name{
+				{DisplayName: "Jane Smith"},
+			},
+		}
+		assert.Equal(t, "Jane Smith", c.GetDisplayName())
+	})
+
+	t.Run("falls back to email", func(t *testing.T) {
+		c := &Contact{
+			ResourceName: "people/c3",
+			Emails: []Email{
+				{Value: "test@example.com"},
+			},
+		}
+		assert.Equal(t, "test@example.com", c.GetDisplayName())
+	})
+
+	t.Run("falls back to resource name", func(t *testing.T) {
+		c := &Contact{
+			ResourceName: "people/c4",
+		}
+		assert.Equal(t, "people/c4", c.GetDisplayName())
+	})
+}
+
+func TestContactGetPrimaryEmail(t *testing.T) {
+	t.Run("returns primary email when marked", func(t *testing.T) {
+		c := &Contact{
+			Emails: []Email{
+				{Value: "work@example.com", Primary: false},
+				{Value: "primary@example.com", Primary: true},
+			},
+		}
+		assert.Equal(t, "primary@example.com", c.GetPrimaryEmail())
+	})
+
+	t.Run("returns first email when no primary", func(t *testing.T) {
+		c := &Contact{
+			Emails: []Email{
+				{Value: "first@example.com"},
+				{Value: "second@example.com"},
+			},
+		}
+		assert.Equal(t, "first@example.com", c.GetPrimaryEmail())
+	})
+
+	t.Run("returns empty string when no emails", func(t *testing.T) {
+		c := &Contact{}
+		assert.Equal(t, "", c.GetPrimaryEmail())
+	})
+}
+
+func TestContactGetPrimaryPhone(t *testing.T) {
+	t.Run("returns first phone", func(t *testing.T) {
+		c := &Contact{
+			Phones: []Phone{
+				{Value: "+1-555-123-4567"},
+				{Value: "+1-555-987-6543"},
+			},
+		}
+		assert.Equal(t, "+1-555-123-4567", c.GetPrimaryPhone())
+	})
+
+	t.Run("returns empty string when no phones", func(t *testing.T) {
+		c := &Contact{}
+		assert.Equal(t, "", c.GetPrimaryPhone())
+	})
+}
+
+func TestContactGetOrganization(t *testing.T) {
+	t.Run("returns organization name", func(t *testing.T) {
+		c := &Contact{
+			Organizations: []Organization{
+				{Name: "Acme Corp", Title: "Engineer"},
+			},
+		}
+		assert.Equal(t, "Acme Corp", c.GetOrganization())
+	})
+
+	t.Run("returns title when no name", func(t *testing.T) {
+		c := &Contact{
+			Organizations: []Organization{
+				{Title: "Freelance Developer"},
+			},
+		}
+		assert.Equal(t, "Freelance Developer", c.GetOrganization())
+	})
+
+	t.Run("returns empty string when no organizations", func(t *testing.T) {
+		c := &Contact{}
+		assert.Equal(t, "", c.GetOrganization())
+	})
+}
+
+func TestFormatDate(t *testing.T) {
+	tests := []struct {
+		name   string
+		year   int64
+		month  int64
+		day    int64
+		expect string
+	}{
+		{"full date", 2024, 12, 25, "2024-12-25"},
+		{"single digit month/day", 2024, 1, 5, "2024-01-05"},
+		{"missing components", 0, 0, 0, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatDate(tt.year, tt.month, tt.day)
+			assert.Equal(t, tt.expect, result)
+		})
+	}
+}
+
+func TestFormatMonthDay(t *testing.T) {
+	tests := []struct {
+		name   string
+		month  int64
+		day    int64
+		expect string
+	}{
+		{"standard date", 12, 25, "12-25"},
+		{"single digit", 1, 5, "01-05"},
+		{"missing components", 0, 0, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatMonthDay(tt.month, tt.day)
+			assert.Equal(t, tt.expect, result)
+		})
+	}
+}

--- a/internal/gmail/client.go
+++ b/internal/gmail/client.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
+	"google.golang.org/api/people/v1"
 
 	"github.com/open-cli-collective/google-readonly/internal/keychain"
 )
@@ -48,6 +49,7 @@ func NewClient(ctx context.Context) (*Client, error) {
 	config, err := google.ConfigFromJSON(b,
 		gmail.GmailReadonlyScope,
 		calendar.CalendarReadonlyScope,
+		people.ContactsReadonlyScope,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse credentials: %w", err)
@@ -224,6 +226,7 @@ func GetOAuthConfig() (*oauth2.Config, error) {
 	return google.ConfigFromJSON(b,
 		gmail.GmailReadonlyScope,
 		calendar.CalendarReadonlyScope,
+		people.ContactsReadonlyScope,
 	)
 }
 


### PR DESCRIPTION
## Summary
- Add `gro contacts` commands with `gro ppl` alias for Google Contacts readonly access
- Implement list, search, get, and groups subcommands
- Update OAuth scopes to include `contacts.readonly`
- All commands support `--json` flag for machine-readable output

## Changes
- **internal/contacts/**: People API client package with client.go and contacts.go
- **internal/cmd/contacts/**: All contacts subcommands (list, search, get, groups)
- **internal/gmail/client.go**: Added contacts scope to OAuth configuration
- **README.md**: Added contacts command documentation
- **CLAUDE.md**: Updated architecture documentation
- **integration-tests.md**: Added contacts test scenarios

## Commands Added
```bash
gro contacts list              # List all contacts
gro contacts search "John"     # Search contacts
gro contacts get people/c123   # Get contact details
gro contacts groups            # List contact groups
```

All commands support `--json` flag and the `ppl` alias (e.g., `gro ppl list`).

## Test plan
- [x] `make build` passes
- [x] `make test` passes (unit tests for contacts package)
- [x] `make lint` passes
- [ ] Integration tests: contacts list, search, get, groups
- [ ] CI workflow passes

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)