### PR TITLE
security(mail): sanitize email output to prevent terminal injection

### DIFF
--- a/internal/cmd/mail/attachments_download.go
+++ b/internal/cmd/mail/attachments_download.go
@@ -97,21 +97,24 @@ func runDownloadAttachments(cmd *cobra.Command, args []string) error {
 
 	// Download each attachment
 	for _, att := range toDownload {
+		// Sanitize filename for display to prevent terminal injection
+		safeFilename := SanitizeFilename(att.Filename)
+
 		// Security: Validate output path to prevent path traversal attacks
 		outputPath, err := safeOutputPath(absDownloadDir, att.Filename)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Skipping %s: %v\n", att.Filename, err)
+			fmt.Fprintf(os.Stderr, "Skipping %s: %v\n", safeFilename, err)
 			continue
 		}
 
 		data, err := downloadAttachment(client, messageID, att)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error downloading %s: %v\n", att.Filename, err)
+			fmt.Fprintf(os.Stderr, "Error downloading %s: %v\n", safeFilename, err)
 			continue
 		}
 
 		if err := saveAttachment(outputPath, data); err != nil {
-			fmt.Fprintf(os.Stderr, "Error saving %s: %v\n", att.Filename, err)
+			fmt.Fprintf(os.Stderr, "Error saving %s: %v\n", safeFilename, err)
 			continue
 		}
 
@@ -122,7 +125,7 @@ func runDownloadAttachments(cmd *cobra.Command, args []string) error {
 			extractDir := filepath.Join(downloadDir,
 				strings.TrimSuffix(att.Filename, filepath.Ext(att.Filename)))
 			if err := ziputil.Extract(outputPath, extractDir, ziputil.DefaultOptions()); err != nil {
-				fmt.Fprintf(os.Stderr, "Error extracting %s: %v\n", att.Filename, err)
+				fmt.Fprintf(os.Stderr, "Error extracting %s: %v\n", safeFilename, err)
 			} else {
 				fmt.Printf("Extracted to: %s\n", extractDir)
 			}

--- a/internal/cmd/mail/attachments_list.go
+++ b/internal/cmd/mail/attachments_list.go
@@ -50,7 +50,8 @@ func runListAttachments(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Found %d attachment(s):\n\n", len(attachments))
 	for i, att := range attachments {
-		fmt.Printf("%d. %s\n", i+1, att.Filename)
+		// Sanitize filename to prevent terminal injection from malicious attachment names
+		fmt.Printf("%d. %s\n", i+1, SanitizeFilename(att.Filename))
 		fmt.Printf("   Type: %s\n", att.MimeType)
 		fmt.Printf("   Size: %s\n", formatSize(att.Size))
 		if att.IsInline {

--- a/internal/cmd/mail/output.go
+++ b/internal/cmd/mail/output.go
@@ -36,11 +36,12 @@ func printMessageHeader(msg *gmail.Message, opts MessagePrintOptions) {
 	if opts.IncludeThreadID {
 		fmt.Printf("ThreadID: %s\n", msg.ThreadID)
 	}
-	fmt.Printf("From: %s\n", msg.From)
+	// Sanitize user-provided content to prevent terminal injection attacks
+	fmt.Printf("From: %s\n", SanitizeOutput(msg.From))
 	if opts.IncludeTo {
-		fmt.Printf("To: %s\n", msg.To)
+		fmt.Printf("To: %s\n", SanitizeOutput(msg.To))
 	}
-	fmt.Printf("Subject: %s\n", msg.Subject)
+	fmt.Printf("Subject: %s\n", SanitizeOutput(msg.Subject))
 	fmt.Printf("Date: %s\n", msg.Date)
 	if len(msg.Labels) > 0 {
 		fmt.Printf("Labels: %s\n", strings.Join(msg.Labels, ", "))
@@ -49,10 +50,10 @@ func printMessageHeader(msg *gmail.Message, opts MessagePrintOptions) {
 		fmt.Printf("Categories: %s\n", strings.Join(msg.Categories, ", "))
 	}
 	if opts.IncludeSnippet {
-		fmt.Printf("Snippet: %s\n", msg.Snippet)
+		fmt.Printf("Snippet: %s\n", SanitizeOutput(msg.Snippet))
 	}
 	if opts.IncludeBody {
 		fmt.Print("\n--- Body ---\n\n")
-		fmt.Println(msg.Body)
+		fmt.Println(SanitizeOutput(msg.Body))
 	}
 }

--- a/internal/cmd/mail/sanitize.go
+++ b/internal/cmd/mail/sanitize.go
@@ -1,0 +1,57 @@
+package mail
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ansiEscapeRegex matches ANSI escape sequences including:
+// - CSI sequences (ESC [ ... letter) - cursor movement, colors, etc.
+// - OSC sequences (ESC ] ... BEL/ST) - window title, hyperlinks, etc.
+// - Simple escape sequences (ESC followed by single character)
+var ansiEscapeRegex = regexp.MustCompile(`\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*\x07|\][^\x1b]*\x1b\\|[@-Z\\-_])`)
+
+// controlCharRegex matches other potentially dangerous control characters
+// excluding common whitespace (tab, newline, carriage return)
+var controlCharRegex = regexp.MustCompile(`[\x00-\x08\x0b\x0c\x0e-\x1a\x1c-\x1f\x7f]`)
+
+// SanitizeOutput removes ANSI escape sequences and dangerous control characters
+// from a string to prevent terminal injection attacks. Safe whitespace characters
+// (tab, newline, carriage return) are preserved.
+func SanitizeOutput(s string) string {
+	// Remove ANSI escape sequences
+	s = ansiEscapeRegex.ReplaceAllString(s, "")
+
+	// Remove other control characters (except tab, newline, carriage return)
+	s = controlCharRegex.ReplaceAllString(s, "")
+
+	return s
+}
+
+// SanitizeFilename sanitizes a filename for display, removing potentially
+// dangerous characters while preserving readability.
+func SanitizeFilename(s string) string {
+	// First apply general output sanitization
+	s = SanitizeOutput(s)
+
+	// Additionally handle Unicode direction overrides that could be used
+	// to disguise file extensions (e.g., making "evil.exe" appear as "exe.live")
+	// Unicode bidirectional control characters
+	bidiChars := []string{
+		"\u202A", // LEFT-TO-RIGHT EMBEDDING
+		"\u202B", // RIGHT-TO-LEFT EMBEDDING
+		"\u202C", // POP DIRECTIONAL FORMATTING
+		"\u202D", // LEFT-TO-RIGHT OVERRIDE
+		"\u202E", // RIGHT-TO-LEFT OVERRIDE
+		"\u2066", // LEFT-TO-RIGHT ISOLATE
+		"\u2067", // RIGHT-TO-LEFT ISOLATE
+		"\u2068", // FIRST STRONG ISOLATE
+		"\u2069", // POP DIRECTIONAL ISOLATE
+	}
+
+	for _, char := range bidiChars {
+		s = strings.ReplaceAll(s, char, "")
+	}
+
+	return s
+}

--- a/internal/cmd/mail/sanitize_test.go
+++ b/internal/cmd/mail/sanitize_test.go
@@ -1,0 +1,220 @@
+package mail
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "plain text unchanged",
+			input:    "Hello, World!",
+			expected: "Hello, World!",
+		},
+		{
+			name:     "preserves newlines",
+			input:    "Line 1\nLine 2\nLine 3",
+			expected: "Line 1\nLine 2\nLine 3",
+		},
+		{
+			name:     "preserves tabs",
+			input:    "Col1\tCol2\tCol3",
+			expected: "Col1\tCol2\tCol3",
+		},
+		{
+			name:     "preserves carriage return",
+			input:    "Line1\r\nLine2",
+			expected: "Line1\r\nLine2",
+		},
+		{
+			name:     "removes simple color codes",
+			input:    "\x1b[31mRed Text\x1b[0m",
+			expected: "Red Text",
+		},
+		{
+			name:     "removes bold/reset sequences",
+			input:    "\x1b[1mBold\x1b[0m Normal",
+			expected: "Bold Normal",
+		},
+		{
+			name:     "removes cursor movement",
+			input:    "\x1b[2J\x1b[H\x1b[3AClear and move",
+			expected: "Clear and move",
+		},
+		{
+			name:     "removes OSC title sequence",
+			input:    "\x1b]0;Evil Title\x07Normal text",
+			expected: "Normal text",
+		},
+		{
+			name:     "removes OSC with ST terminator",
+			input:    "\x1b]0;Evil Title\x1b\\Normal text",
+			expected: "Normal text",
+		},
+		{
+			name:     "removes hyperlink OSC",
+			input:    "\x1b]8;;http://evil.com\x07Click me\x1b]8;;\x07",
+			expected: "Click me",
+		},
+		{
+			name:     "removes null bytes",
+			input:    "Hello\x00World",
+			expected: "HelloWorld",
+		},
+		{
+			name:     "removes bell character",
+			input:    "Alert!\x07\x07\x07",
+			expected: "Alert!",
+		},
+		{
+			name:     "removes backspace",
+			input:    "Overwrite\x08\x08\x08\x08\x08test",
+			expected: "Overwritetest",
+		},
+		{
+			name:     "removes form feed",
+			input:    "Page1\x0cPage2",
+			expected: "Page1Page2",
+		},
+		{
+			name:     "removes vertical tab",
+			input:    "Line1\x0bLine2",
+			expected: "Line1Line2",
+		},
+		{
+			name:     "removes DEL character",
+			input:    "Hello\x7fWorld",
+			expected: "HelloWorld",
+		},
+		{
+			name:     "handles multiple escape sequences",
+			input:    "\x1b[31m\x1b[1mBold Red\x1b[0m and \x1b[32mGreen\x1b[0m",
+			expected: "Bold Red and Green",
+		},
+		{
+			name:     "handles complex CSI sequence",
+			input:    "\x1b[38;2;255;0;0mTrue color red\x1b[0m",
+			expected: "True color red",
+		},
+		{
+			name:     "preserves escape without valid sequence",
+			input:    "Normal \x1b text",
+			expected: "Normal \x1b text", // Lone escape without valid sequence is preserved (harmless)
+		},
+		{
+			name:     "preserves unicode text",
+			input:    "Hello 世界 🌍",
+			expected: "Hello 世界 🌍",
+		},
+		{
+			name:     "preserves email formatting",
+			input:    "From: user@example.com\nSubject: Test\n\nBody here",
+			expected: "From: user@example.com\nSubject: Test\n\nBody here",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeOutput(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSanitizeFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "normal filename unchanged",
+			input:    "document.pdf",
+			expected: "document.pdf",
+		},
+		{
+			name:     "filename with spaces",
+			input:    "my document.pdf",
+			expected: "my document.pdf",
+		},
+		{
+			name:     "removes ANSI from filename",
+			input:    "\x1b[31mevil.exe\x1b[0m",
+			expected: "evil.exe",
+		},
+		{
+			name:     "removes RTL override (extension spoofing)",
+			input:    "invoice\u202Efdp.exe",
+			expected: "invoicefdp.exe",
+		},
+		{
+			name:     "removes LTR override",
+			input:    "file\u202Dname.txt",
+			expected: "filename.txt",
+		},
+		{
+			name:     "removes multiple bidi characters",
+			input:    "\u202Atest\u202B\u202Cfile\u202D.txt\u202E",
+			expected: "testfile.txt",
+		},
+		{
+			name:     "removes isolate characters",
+			input:    "\u2066\u2067\u2068test\u2069.pdf",
+			expected: "test.pdf",
+		},
+		{
+			name:     "preserves unicode in filename",
+			input:    "文档.pdf",
+			expected: "文档.pdf",
+		},
+		{
+			name:     "removes null byte from filename",
+			input:    "file\x00name.txt",
+			expected: "filename.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeFilename(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSanitizeOutput_RealWorldExamples(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "terminal title attack",
+			input:    "\x1b]0;rm -rf /\x07Please review this document",
+			expected: "Please review this document",
+		},
+		{
+			name:     "cursor position manipulation",
+			input:    "\x1b[1;1H\x1b[2JClearing your screen...",
+			expected: "Clearing your screen...",
+		},
+		{
+			name:     "hyperlink with misleading text",
+			input:    "\x1b]8;;http://phishing.com\x07https://google.com\x1b]8;;\x07",
+			expected: "https://google.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeOutput(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `SanitizeOutput()` function to strip ANSI escape sequences and control characters from email content
- Add `SanitizeFilename()` function with additional bidirectional character filtering for filenames
- Apply sanitization to From, To, Subject, Snippet, Body fields before display
- Apply filename sanitization in attachment list and download commands

## Security Impact
Prevents terminal injection attacks where malicious emails could:
- Set window title to misleading content
- Execute commands in vulnerable terminals via OSC sequences
- Spoof hyperlinks (display one URL, link to another)
- Clear screen or manipulate cursor position
- Spoof file extensions using RTL override characters

## Test Plan
- [x] Tests for plain text preservation
- [x] Tests for safe whitespace preservation (tabs, newlines, CR)
- [x] Tests for ANSI color code removal
- [x] Tests for cursor movement sequence removal
- [x] Tests for OSC title/hyperlink sequence removal
- [x] Tests for control character removal (null, bell, backspace, etc.)
- [x] Tests for Unicode bidirectional override removal in filenames
- [x] Real-world attack vector tests
- [x] All existing tests pass

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)