### PR TITLE
refactor(config): extract internal/config package for configuration management

### DIFF
--- a/internal/auth/config.go
+++ b/internal/auth/config.go
@@ -1,66 +1,42 @@
 package auth
 
 import (
-	"os"
-	"path/filepath"
+	"github.com/open-cli-collective/google-readonly/internal/config"
 )
 
+// Re-export constants for backward compatibility
 const (
 	// ConfigDirName is the name of the configuration directory
-	ConfigDirName = "google-readonly"
+	// Deprecated: Use config.DirName instead
+	ConfigDirName = config.DirName
 	// CredentialsFile is the name of the OAuth credentials file
-	CredentialsFile = "credentials.json"
+	// Deprecated: Use config.CredentialsFile instead
+	CredentialsFile = config.CredentialsFile
 	// TokenFile is the name of the OAuth token file (fallback storage)
-	TokenFile = "token.json"
+	// Deprecated: Use config.TokenFile instead
+	TokenFile = config.TokenFile
 )
 
 // GetConfigDir returns the configuration directory path, creating it if needed.
-// Uses XDG_CONFIG_HOME if set, otherwise ~/.config/google-readonly
+// Deprecated: Use config.GetConfigDir() instead
 func GetConfigDir() (string, error) {
-	configHome := os.Getenv("XDG_CONFIG_HOME")
-	if configHome == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		configHome = filepath.Join(home, ".config")
-	}
-	configDir := filepath.Join(configHome, ConfigDirName)
-
-	if err := os.MkdirAll(configDir, 0700); err != nil {
-		return "", err
-	}
-
-	return configDir, nil
+	return config.GetConfigDir()
 }
 
 // GetCredentialsPath returns the full path to credentials.json
+// Deprecated: Use config.GetCredentialsPath() instead
 func GetCredentialsPath() (string, error) {
-	dir, err := GetConfigDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, CredentialsFile), nil
+	return config.GetCredentialsPath()
 }
 
 // GetTokenPath returns the full path to token.json (fallback storage)
+// Deprecated: Use config.GetTokenPath() instead
 func GetTokenPath() (string, error) {
-	dir, err := GetConfigDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, TokenFile), nil
+	return config.GetTokenPath()
 }
 
 // ShortenPath replaces the home directory prefix with ~ for display purposes.
-// This prevents exposing full paths including usernames in error messages.
+// Deprecated: Use config.ShortenPath() instead
 func ShortenPath(path string) string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return path
-	}
-	if len(path) >= len(home) && path[:len(home)] == home {
-		return "~" + path[len(home):]
-	}
-	return path
+	return config.ShortenPath(path)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,68 @@
+// Package config provides centralized configuration management for the application.
+// It has no external dependencies to avoid circular imports with other internal packages.
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const (
+	// DirName is the name of the configuration directory
+	DirName = "google-readonly"
+	// CredentialsFile is the name of the OAuth credentials file
+	CredentialsFile = "credentials.json"
+	// TokenFile is the name of the OAuth token file (fallback storage)
+	TokenFile = "token.json"
+)
+
+// GetConfigDir returns the configuration directory path, creating it if needed.
+// Uses XDG_CONFIG_HOME if set, otherwise ~/.config/google-readonly
+func GetConfigDir() (string, error) {
+	configHome := os.Getenv("XDG_CONFIG_HOME")
+	if configHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		configHome = filepath.Join(home, ".config")
+	}
+	configDir := filepath.Join(configHome, DirName)
+
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		return "", err
+	}
+
+	return configDir, nil
+}
+
+// GetCredentialsPath returns the full path to credentials.json
+func GetCredentialsPath() (string, error) {
+	dir, err := GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, CredentialsFile), nil
+}
+
+// GetTokenPath returns the full path to token.json (fallback storage)
+func GetTokenPath() (string, error) {
+	dir, err := GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, TokenFile), nil
+}
+
+// ShortenPath replaces the home directory prefix with ~ for display purposes.
+// This prevents exposing full paths including usernames in error messages.
+func ShortenPath(path string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if len(path) >= len(home) && path[:len(home)] == home {
+		return "~" + path[len(home):]
+	}
+	return path
+}

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -10,12 +10,13 @@ import (
 	"path/filepath"
 
 	"golang.org/x/oauth2"
+
+	"github.com/open-cli-collective/google-readonly/internal/config"
 )
 
 const (
-	serviceName = "google-readonly"
+	serviceName = config.DirName
 	tokenKey    = "oauth_token"
-	tokenFile   = "token.json"
 )
 
 // StorageBackend represents where tokens are stored
@@ -32,25 +33,9 @@ var (
 	ErrTokenNotFound = errors.New("no token found in secure storage")
 )
 
-// configDir returns the configuration directory path
-func configDir() (string, error) {
-	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
-		return filepath.Join(xdg, serviceName), nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("failed to get home directory: %w", err)
-	}
-	return filepath.Join(home, ".config", serviceName), nil
-}
-
 // tokenFilePath returns the full path to the token file
 func tokenFilePath() (string, error) {
-	dir, err := configDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, tokenFile), nil
+	return config.GetTokenPath()
 }
 
 // GetToken retrieves the OAuth token from secure storage


### PR DESCRIPTION
## Summary
- Create new `internal/config` package with no external dependencies
- Move configuration utilities from auth package to config package
- Update keychain package to use config instead of duplicated code

## Motivation
The auth package imports keychain, so keychain cannot import auth without circular dependency. By extracting config into its own package with no imports, all packages can share configuration utilities.

## Changes

### New: internal/config package
- `GetConfigDir()`: XDG-compliant config directory management
- `GetCredentialsPath()`, `GetTokenPath()`: path helpers
- `ShortenPath()`: home directory display utility
- `DirName`, `CredentialsFile`, `TokenFile` constants

### Updated packages
- `auth`: delegates to config package, maintains deprecated wrappers
- `keychain`: uses config.GetTokenPath() and config.DirName constant
  - Removed duplicated `configDir()` function
  - Removed `tokenFile` constant

## Dependency Graph
```
config (no deps) <-- auth <-- keychain
                 <-- keychain (direct)
```

## Test Plan
- [x] Config package has comprehensive tests
- [x] Auth package tests verify delegation to config
- [x] Keychain tests updated and pass
- [x] All existing tests pass

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)