### PR TITLE
refactor: inject client factories into command handlers

### DIFF
--- a/internal/cmd/calendar/output.go
+++ b/internal/cmd/calendar/output.go
@@ -9,9 +9,15 @@ import (
 	"github.com/open-cli-collective/google-readonly/internal/calendar"
 )
 
-// newCalendarClient creates a new calendar client
-func newCalendarClient() (*calendar.Client, error) {
+// ClientFactory is the function used to create Calendar clients.
+// Override in tests to inject mocks.
+var ClientFactory = func() (calendar.CalendarClientInterface, error) {
 	return calendar.NewClient(context.Background())
+}
+
+// newCalendarClient creates a new calendar client
+func newCalendarClient() (calendar.CalendarClientInterface, error) {
+	return ClientFactory()
 }
 
 // printJSON outputs data as indented JSON

--- a/internal/cmd/contacts/output.go
+++ b/internal/cmd/contacts/output.go
@@ -9,9 +9,15 @@ import (
 	"github.com/open-cli-collective/google-readonly/internal/contacts"
 )
 
-// newContactsClient creates a new contacts client
-func newContactsClient() (*contacts.Client, error) {
+// ClientFactory is the function used to create Contacts clients.
+// Override in tests to inject mocks.
+var ClientFactory = func() (contacts.ContactsClientInterface, error) {
 	return contacts.NewClient(context.Background())
+}
+
+// newContactsClient creates a new contacts client
+func newContactsClient() (contacts.ContactsClientInterface, error) {
+	return ClientFactory()
 }
 
 // printJSON outputs data as indented JSON

--- a/internal/cmd/mail/attachments_download.go
+++ b/internal/cmd/mail/attachments_download.go
@@ -135,7 +135,7 @@ func runDownloadAttachments(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func downloadAttachment(client *gmail.Client, messageID string, att *gmail.Attachment) ([]byte, error) {
+func downloadAttachment(client gmail.GmailClientInterface, messageID string, att *gmail.Attachment) ([]byte, error) {
 	if att.AttachmentID != "" {
 		return client.DownloadAttachment(messageID, att.AttachmentID)
 	}

--- a/internal/cmd/mail/output.go
+++ b/internal/cmd/mail/output.go
@@ -10,9 +10,15 @@ import (
 	"github.com/open-cli-collective/google-readonly/internal/gmail"
 )
 
-// newGmailClient creates and returns a new Gmail client
-func newGmailClient() (*gmail.Client, error) {
+// ClientFactory is the function used to create Gmail clients.
+// Override in tests to inject mocks.
+var ClientFactory = func() (gmail.GmailClientInterface, error) {
 	return gmail.NewClient(context.Background())
+}
+
+// newGmailClient creates and returns a new Gmail client
+func newGmailClient() (gmail.GmailClientInterface, error) {
+	return ClientFactory()
 }
 
 // printJSON encodes data as indented JSON to stdout


### PR DESCRIPTION
## Summary

Adds `ClientFactory` variables to mail, calendar, and contacts command packages to enable dependency injection for testing. The factory functions return the corresponding interface types (from PR #58), allowing tests to inject mock implementations.

## Changes

- **mail package**: `ClientFactory` returns `gmail.GmailClientInterface`
- **calendar package**: `ClientFactory` returns `calendar.CalendarClientInterface`  
- **contacts package**: `ClientFactory` returns `contacts.ContactsClientInterface`
- Updated `downloadAttachment` helper to accept interface type

## Testing Example

```go
func TestSearchCommand(t *testing.T) {
    // Save and restore
    originalFactory := mail.ClientFactory
    defer func() { mail.ClientFactory = originalFactory }()

    // Inject mock
    mockClient := &MockGmailClient{...}
    mail.ClientFactory = func() (gmail.GmailClientInterface, error) {
        return mockClient, nil
    }

    // Test command behavior
    cmd := newSearchCommand()
    // ...
}
```

## Test plan

- [x] All tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [x] Build passes (`go build ./...`)

Closes #36