### PR TITLE
feat(drive): add list command

### DIFF
--- a/internal/cmd/drive/drive.go
+++ b/internal/cmd/drive/drive.go
@@ -26,7 +26,7 @@ Examples:
   gro drive download <file-id> --format pdf`,
 	}
 
-	// Subcommands will be added as they are implemented
+	cmd.AddCommand(newListCommand())
 
 	return cmd
 }

--- a/internal/cmd/drive/list.go
+++ b/internal/cmd/drive/list.go
@@ -1,0 +1,167 @@
+package drive
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/drive"
+)
+
+var (
+	listMaxResults int64
+	listFileType   string
+	listJSONOutput bool
+)
+
+func newListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list [folder-id]",
+		Short: "List files in Drive",
+		Long: `List files in Google Drive root or a specific folder.
+
+Examples:
+  gro drive list                    # List files in root
+  gro drive list <folder-id>        # List files in specific folder
+  gro drive list --type document    # Filter by file type
+  gro drive list --max 50           # Limit results
+  gro drive list --json             # Output as JSON
+
+File types: document, spreadsheet, presentation, folder, pdf, image, video, audio`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runList,
+	}
+
+	cmd.Flags().Int64VarP(&listMaxResults, "max", "m", 25, "Maximum number of results to return")
+	cmd.Flags().StringVarP(&listFileType, "type", "t", "", "Filter by file type")
+	cmd.Flags().BoolVarP(&listJSONOutput, "json", "j", false, "Output results as JSON")
+
+	return cmd
+}
+
+func runList(cmd *cobra.Command, args []string) error {
+	client, err := newDriveClient()
+	if err != nil {
+		return err
+	}
+
+	folderID := ""
+	if len(args) > 0 {
+		folderID = args[0]
+	}
+
+	query, err := buildListQuery(folderID, listFileType)
+	if err != nil {
+		return err
+	}
+
+	files, err := client.ListFiles(query, listMaxResults)
+	if err != nil {
+		return err
+	}
+
+	if len(files) == 0 {
+		fmt.Println("No files found.")
+		return nil
+	}
+
+	if listJSONOutput {
+		return printJSON(files)
+	}
+
+	printFileTable(files)
+	return nil
+}
+
+// buildListQuery constructs a Drive API query string for listing files
+func buildListQuery(folderID, fileType string) (string, error) {
+	parts := []string{"trashed = false"}
+
+	if folderID != "" {
+		parts = append(parts, fmt.Sprintf("'%s' in parents", folderID))
+	} else {
+		parts = append(parts, "'root' in parents")
+	}
+
+	if fileType != "" {
+		filter, err := getMimeTypeFilter(fileType)
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, filter)
+	}
+
+	return strings.Join(parts, " and "), nil
+}
+
+// getMimeTypeFilter returns the Drive API query filter for a file type
+func getMimeTypeFilter(fileType string) (string, error) {
+	switch strings.ToLower(fileType) {
+	case "document", "doc":
+		return fmt.Sprintf("mimeType = '%s'", drive.MimeTypeDocument), nil
+	case "spreadsheet", "sheet":
+		return fmt.Sprintf("mimeType = '%s'", drive.MimeTypeSpreadsheet), nil
+	case "presentation", "slides":
+		return fmt.Sprintf("mimeType = '%s'", drive.MimeTypePresentation), nil
+	case "folder":
+		return fmt.Sprintf("mimeType = '%s'", drive.MimeTypeFolder), nil
+	case "pdf":
+		return "mimeType = 'application/pdf'", nil
+	case "image":
+		return "mimeType contains 'image/'", nil
+	case "video":
+		return "mimeType contains 'video/'", nil
+	case "audio":
+		return "mimeType contains 'audio/'", nil
+	default:
+		return "", fmt.Errorf("unknown file type: %s (valid types: document, spreadsheet, presentation, folder, pdf, image, video, audio)", fileType)
+	}
+}
+
+// printFileTable prints files in a formatted table
+func printFileTable(files []*drive.File) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ID\tNAME\tTYPE\tSIZE\tMODIFIED")
+
+	for _, f := range files {
+		size := "-"
+		if f.Size > 0 {
+			size = formatSize(f.Size)
+		}
+
+		modified := "-"
+		if !f.ModifiedTime.IsZero() {
+			modified = f.ModifiedTime.Format("2006-01-02")
+		}
+
+		typeName := drive.GetTypeName(f.MimeType)
+
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			f.ID, f.Name, typeName, size, modified)
+	}
+
+	_ = w.Flush()
+}
+
+// formatSize formats a byte size into a human-readable string
+func formatSize(bytes int64) string {
+	const (
+		KB = 1024
+		MB = KB * 1024
+		GB = MB * 1024
+	)
+
+	switch {
+	case bytes >= GB:
+		return fmt.Sprintf("%.1f GB", float64(bytes)/float64(GB))
+	case bytes >= MB:
+		return fmt.Sprintf("%.1f MB", float64(bytes)/float64(MB))
+	case bytes >= KB:
+		return fmt.Sprintf("%.1f KB", float64(bytes)/float64(KB))
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}

--- a/internal/cmd/drive/list_test.go
+++ b/internal/cmd/drive/list_test.go
@@ -1,0 +1,196 @@
+package drive
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListCommand(t *testing.T) {
+	cmd := newListCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "list [folder-id]", cmd.Use)
+	})
+
+	t.Run("accepts zero or one argument", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"folder-id"})
+		assert.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"folder-id", "extra"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has max flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("max")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "m", flag.Shorthand)
+		assert.Equal(t, "25", flag.DefValue)
+	})
+
+	t.Run("has type flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("type")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "t", flag.Shorthand)
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "j", flag.Shorthand)
+		assert.Equal(t, "false", flag.DefValue)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.Contains(t, cmd.Short, "List")
+	})
+}
+
+func TestBuildListQuery(t *testing.T) {
+	t.Run("builds query for root folder", func(t *testing.T) {
+		query, err := buildListQuery("", "")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "trashed = false")
+		assert.Contains(t, query, "'root' in parents")
+	})
+
+	t.Run("builds query for specific folder", func(t *testing.T) {
+		query, err := buildListQuery("folder123", "")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "'folder123' in parents")
+		assert.NotContains(t, query, "'root' in parents")
+	})
+
+	t.Run("adds type filter for document", func(t *testing.T) {
+		query, err := buildListQuery("", "document")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "mimeType = 'application/vnd.google-apps.document'")
+	})
+
+	t.Run("adds type filter for spreadsheet", func(t *testing.T) {
+		query, err := buildListQuery("", "spreadsheet")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "mimeType = 'application/vnd.google-apps.spreadsheet'")
+	})
+
+	t.Run("adds type filter for presentation", func(t *testing.T) {
+		query, err := buildListQuery("", "presentation")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "mimeType = 'application/vnd.google-apps.presentation'")
+	})
+
+	t.Run("adds type filter for folder", func(t *testing.T) {
+		query, err := buildListQuery("", "folder")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "mimeType = 'application/vnd.google-apps.folder'")
+	})
+
+	t.Run("adds type filter for pdf", func(t *testing.T) {
+		query, err := buildListQuery("", "pdf")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "mimeType = 'application/pdf'")
+	})
+
+	t.Run("adds type filter for image", func(t *testing.T) {
+		query, err := buildListQuery("", "image")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "mimeType contains 'image/'")
+	})
+
+	t.Run("adds type filter for video", func(t *testing.T) {
+		query, err := buildListQuery("", "video")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "mimeType contains 'video/'")
+	})
+
+	t.Run("adds type filter for audio", func(t *testing.T) {
+		query, err := buildListQuery("", "audio")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "mimeType contains 'audio/'")
+	})
+
+	t.Run("returns error for unknown type", func(t *testing.T) {
+		_, err := buildListQuery("", "unknown")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown file type")
+	})
+
+	t.Run("accepts type aliases", func(t *testing.T) {
+		query, err := buildListQuery("", "doc")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "application/vnd.google-apps.document")
+
+		query, err = buildListQuery("", "sheet")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "application/vnd.google-apps.spreadsheet")
+
+		query, err = buildListQuery("", "slides")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "application/vnd.google-apps.presentation")
+	})
+
+	t.Run("is case insensitive for type", func(t *testing.T) {
+		query, err := buildListQuery("", "DOCUMENT")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "application/vnd.google-apps.document")
+	})
+}
+
+func TestGetMimeTypeFilter(t *testing.T) {
+	tests := []struct {
+		fileType string
+		expected string
+		hasError bool
+	}{
+		{"document", "mimeType = 'application/vnd.google-apps.document'", false},
+		{"doc", "mimeType = 'application/vnd.google-apps.document'", false},
+		{"spreadsheet", "mimeType = 'application/vnd.google-apps.spreadsheet'", false},
+		{"sheet", "mimeType = 'application/vnd.google-apps.spreadsheet'", false},
+		{"presentation", "mimeType = 'application/vnd.google-apps.presentation'", false},
+		{"slides", "mimeType = 'application/vnd.google-apps.presentation'", false},
+		{"folder", "mimeType = 'application/vnd.google-apps.folder'", false},
+		{"pdf", "mimeType = 'application/pdf'", false},
+		{"image", "mimeType contains 'image/'", false},
+		{"video", "mimeType contains 'video/'", false},
+		{"audio", "mimeType contains 'audio/'", false},
+		{"invalid", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fileType, func(t *testing.T) {
+			result, err := getMimeTypeFilter(tt.fileType)
+			if tt.hasError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestFormatSize(t *testing.T) {
+	tests := []struct {
+		bytes    int64
+		expected string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{1572864, "1.5 MB"},
+		{1073741824, "1.0 GB"},
+		{1610612736, "1.5 GB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := formatSize(tt.bytes)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/cmd/drive/output.go
+++ b/internal/cmd/drive/output.go
@@ -15,15 +15,11 @@ var ClientFactory = func() (drive.DriveClientInterface, error) {
 }
 
 // newDriveClient creates and returns a new Drive client
-//
-//nolint:unused // Will be used by subcommands
 func newDriveClient() (drive.DriveClientInterface, error) {
 	return ClientFactory()
 }
 
 // printJSON encodes data as indented JSON to stdout
-//
-//nolint:unused // Will be used by subcommands
 func printJSON(data any) error {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")


### PR DESCRIPTION
## Summary
- Add `gro drive list` command to list files in Google Drive root or specific folder
- Support `--type` flag for filtering by file type (document, spreadsheet, presentation, folder, pdf, image, video, audio)
- Support `--max` flag for limiting results (default 25)
- Support `--json` flag for JSON output
- Table output includes ID, name, type, size, and modified date

## Test Plan
- [x] `gro drive list --help` shows usage
- [x] Tests for query building and type filtering
- [x] Tests for size formatting
- [x] `make verify` passes

Closes #62