### PR TITLE
feat(drive): add search command

### DIFF
--- a/internal/cmd/drive/drive.go
+++ b/internal/cmd/drive/drive.go
@@ -27,6 +27,7 @@ Examples:
 	}
 
 	cmd.AddCommand(newListCommand())
+	cmd.AddCommand(newSearchCommand())
 
 	return cmd
 }

--- a/internal/cmd/drive/search.go
+++ b/internal/cmd/drive/search.go
@@ -1,0 +1,146 @@
+package drive
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	searchMaxResults int64
+	searchNameOnly   bool
+	searchFileType   string
+	searchOwner      string
+	searchModAfter   string
+	searchModBefore  string
+	searchInFolder   string
+	searchJSONOutput bool
+)
+
+func newSearchCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "search [query]",
+		Short: "Search for files",
+		Long: `Search for files in Google Drive by content, name, type, owner, or date.
+
+Examples:
+  gro drive search "quarterly report"           # Full-text search
+  gro drive search --name "budget"              # Search by filename only
+  gro drive search --type spreadsheet           # Filter by type
+  gro drive search --owner me                   # Files you own
+  gro drive search --owner john@example.com     # Files owned by someone
+  gro drive search --modified-after 2024-01-01  # Modified after date
+  gro drive search --in-folder <folder-id>      # Search within folder
+  gro drive search "report" --type document --max 20 --json
+
+File types: document, spreadsheet, presentation, folder, pdf, image, video, audio`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runSearch,
+	}
+
+	cmd.Flags().Int64VarP(&searchMaxResults, "max", "m", 25, "Maximum number of results to return")
+	cmd.Flags().BoolVarP(&searchNameOnly, "name", "n", false, "Search filename only (not content)")
+	cmd.Flags().StringVarP(&searchFileType, "type", "t", "", "Filter by file type")
+	cmd.Flags().StringVar(&searchOwner, "owner", "", "Filter by owner (\"me\" or email address)")
+	cmd.Flags().StringVar(&searchModAfter, "modified-after", "", "Modified after date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&searchModBefore, "modified-before", "", "Modified before date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&searchInFolder, "in-folder", "", "Search within specific folder")
+	cmd.Flags().BoolVarP(&searchJSONOutput, "json", "j", false, "Output results as JSON")
+
+	return cmd
+}
+
+func runSearch(cmd *cobra.Command, args []string) error {
+	client, err := newDriveClient()
+	if err != nil {
+		return err
+	}
+
+	query := ""
+	if len(args) > 0 {
+		query = args[0]
+	}
+
+	searchQuery, err := buildSearchQuery(query, searchNameOnly, searchFileType, searchOwner, searchModAfter, searchModBefore, searchInFolder)
+	if err != nil {
+		return err
+	}
+
+	files, err := client.ListFiles(searchQuery, searchMaxResults)
+	if err != nil {
+		return err
+	}
+
+	if len(files) == 0 {
+		if query != "" {
+			fmt.Printf("No files found matching \"%s\".\n", query)
+		} else {
+			fmt.Println("No files found.")
+		}
+		return nil
+	}
+
+	if searchJSONOutput {
+		return printJSON(files)
+	}
+
+	if query != "" {
+		fmt.Printf("Found %d file(s) matching \"%s\":\n\n", len(files), query)
+	} else {
+		fmt.Printf("Found %d file(s):\n\n", len(files))
+	}
+	printFileTable(files)
+	return nil
+}
+
+// buildSearchQuery constructs a Drive API query string for searching files
+func buildSearchQuery(query string, nameOnly bool, fileType, owner, modAfter, modBefore, inFolder string) (string, error) {
+	parts := []string{"trashed = false"}
+
+	// Text search
+	if query != "" {
+		escaped := escapeQueryString(query)
+		if nameOnly {
+			parts = append(parts, fmt.Sprintf("name contains '%s'", escaped))
+		} else {
+			parts = append(parts, fmt.Sprintf("fullText contains '%s'", escaped))
+		}
+	}
+
+	// Type filter
+	if fileType != "" {
+		filter, err := getMimeTypeFilter(fileType)
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, filter)
+	}
+
+	// Owner filter
+	if owner != "" {
+		parts = append(parts, fmt.Sprintf("'%s' in owners", owner))
+	}
+
+	// Date filters
+	if modAfter != "" {
+		// Drive API requires RFC3339 format
+		parts = append(parts, fmt.Sprintf("modifiedTime > '%sT00:00:00'", modAfter))
+	}
+	if modBefore != "" {
+		parts = append(parts, fmt.Sprintf("modifiedTime < '%sT23:59:59'", modBefore))
+	}
+
+	// Folder scope
+	if inFolder != "" {
+		parts = append(parts, fmt.Sprintf("'%s' in parents", inFolder))
+	}
+
+	return strings.Join(parts, " and "), nil
+}
+
+// escapeQueryString escapes special characters in search queries
+func escapeQueryString(s string) string {
+	// Escape single quotes by doubling them
+	return strings.ReplaceAll(s, "'", "\\'")
+}

--- a/internal/cmd/drive/search_test.go
+++ b/internal/cmd/drive/search_test.go
@@ -1,0 +1,175 @@
+package drive
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSearchCommand(t *testing.T) {
+	cmd := newSearchCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "search [query]", cmd.Use)
+	})
+
+	t.Run("accepts zero or one argument", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"query"})
+		assert.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"query1", "query2"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has max flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("max")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "m", flag.Shorthand)
+		assert.Equal(t, "25", flag.DefValue)
+	})
+
+	t.Run("has name flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("name")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "n", flag.Shorthand)
+	})
+
+	t.Run("has type flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("type")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "t", flag.Shorthand)
+	})
+
+	t.Run("has owner flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("owner")
+		assert.NotNil(t, flag)
+	})
+
+	t.Run("has modified-after flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("modified-after")
+		assert.NotNil(t, flag)
+	})
+
+	t.Run("has modified-before flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("modified-before")
+		assert.NotNil(t, flag)
+	})
+
+	t.Run("has in-folder flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("in-folder")
+		assert.NotNil(t, flag)
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "j", flag.Shorthand)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.Contains(t, cmd.Short, "Search")
+	})
+}
+
+func TestBuildSearchQuery(t *testing.T) {
+	t.Run("builds full-text search query", func(t *testing.T) {
+		query, err := buildSearchQuery("quarterly report", false, "", "", "", "", "")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "trashed = false")
+		assert.Contains(t, query, "fullText contains 'quarterly report'")
+	})
+
+	t.Run("builds name-only search query", func(t *testing.T) {
+		query, err := buildSearchQuery("budget", true, "", "", "", "", "")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "name contains 'budget'")
+		assert.NotContains(t, query, "fullText")
+	})
+
+	t.Run("adds type filter", func(t *testing.T) {
+		query, err := buildSearchQuery("test", false, "document", "", "", "", "")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "mimeType = 'application/vnd.google-apps.document'")
+	})
+
+	t.Run("returns error for invalid type", func(t *testing.T) {
+		_, err := buildSearchQuery("test", false, "invalid", "", "", "", "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown file type")
+	})
+
+	t.Run("adds owner filter with 'me'", func(t *testing.T) {
+		query, err := buildSearchQuery("", false, "", "me", "", "", "")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "'me' in owners")
+	})
+
+	t.Run("adds owner filter with email", func(t *testing.T) {
+		query, err := buildSearchQuery("", false, "", "john@example.com", "", "", "")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "'john@example.com' in owners")
+	})
+
+	t.Run("adds modified-after filter", func(t *testing.T) {
+		query, err := buildSearchQuery("", false, "", "", "2024-01-01", "", "")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "modifiedTime > '2024-01-01T00:00:00'")
+	})
+
+	t.Run("adds modified-before filter", func(t *testing.T) {
+		query, err := buildSearchQuery("", false, "", "", "", "2024-12-31", "")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "modifiedTime < '2024-12-31T23:59:59'")
+	})
+
+	t.Run("adds folder scope", func(t *testing.T) {
+		query, err := buildSearchQuery("", false, "", "", "", "", "folder123")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "'folder123' in parents")
+	})
+
+	t.Run("combines multiple filters", func(t *testing.T) {
+		query, err := buildSearchQuery("report", false, "document", "me", "2024-01-01", "", "folder123")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "trashed = false")
+		assert.Contains(t, query, "fullText contains 'report'")
+		assert.Contains(t, query, "mimeType = 'application/vnd.google-apps.document'")
+		assert.Contains(t, query, "'me' in owners")
+		assert.Contains(t, query, "modifiedTime > '2024-01-01T00:00:00'")
+		assert.Contains(t, query, "'folder123' in parents")
+	})
+
+	t.Run("builds query with no search term", func(t *testing.T) {
+		query, err := buildSearchQuery("", false, "document", "", "", "", "")
+		assert.NoError(t, err)
+		assert.Contains(t, query, "trashed = false")
+		assert.Contains(t, query, "mimeType")
+		assert.NotContains(t, query, "fullText")
+		assert.NotContains(t, query, "name contains")
+	})
+}
+
+func TestEscapeQueryString(t *testing.T) {
+	t.Run("escapes single quotes", func(t *testing.T) {
+		result := escapeQueryString("it's a test")
+		assert.Equal(t, "it\\'s a test", result)
+	})
+
+	t.Run("handles string without quotes", func(t *testing.T) {
+		result := escapeQueryString("simple query")
+		assert.Equal(t, "simple query", result)
+	})
+
+	t.Run("handles multiple quotes", func(t *testing.T) {
+		result := escapeQueryString("don't won't can't")
+		assert.Equal(t, "don\\'t won\\'t can\\'t", result)
+	})
+
+	t.Run("handles empty string", func(t *testing.T) {
+		result := escapeQueryString("")
+		assert.Equal(t, "", result)
+	})
+}


### PR DESCRIPTION
## Summary
- Add `gro drive search` command for searching files in Google Drive
- Support full-text content search and filename-only search (`--name`)
- Filter by type, owner, modified date range, and folder scope
- Support `--max` and `--json` flags
- Reuse `getMimeTypeFilter()` and `printFileTable()` from list command

## Test Plan
- [x] `gro drive search --help` shows usage
- [x] Tests for query building with all filter combinations
- [x] Tests for query string escaping
- [x] `make verify` passes

Closes #63