### PR TITLE
feat(drive): add get command

### DIFF
--- a/internal/cmd/drive/drive.go
+++ b/internal/cmd/drive/drive.go
@@ -28,6 +28,7 @@ Examples:
 
 	cmd.AddCommand(newListCommand())
 	cmd.AddCommand(newSearchCommand())
+	cmd.AddCommand(newGetCommand())
 
 	return cmd
 }

--- a/internal/cmd/drive/get.go
+++ b/internal/cmd/drive/get.go
@@ -1,0 +1,92 @@
+package drive
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/drive"
+)
+
+var getJSONOutput bool
+
+func newGetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <file-id>",
+		Short: "Get file details",
+		Long: `Get detailed metadata for a specific file in Google Drive.
+
+Examples:
+  gro drive get <file-id>        # Show file details
+  gro drive get <file-id> --json # Output as JSON`,
+		Args: cobra.ExactArgs(1),
+		RunE: runGet,
+	}
+
+	cmd.Flags().BoolVarP(&getJSONOutput, "json", "j", false, "Output results as JSON")
+
+	return cmd
+}
+
+func runGet(cmd *cobra.Command, args []string) error {
+	client, err := newDriveClient()
+	if err != nil {
+		return err
+	}
+
+	fileID := args[0]
+	file, err := client.GetFile(fileID)
+	if err != nil {
+		return fmt.Errorf("failed to get file %s: %w", fileID, err)
+	}
+
+	if getJSONOutput {
+		return printJSON(file)
+	}
+
+	printFileDetails(file)
+	return nil
+}
+
+// printFileDetails prints detailed file metadata in a formatted layout
+func printFileDetails(f *drive.File) {
+	fmt.Println("File Details")
+	fmt.Println("────────────────────────────────────────")
+
+	fmt.Printf("ID:         %s\n", f.ID)
+	fmt.Printf("Name:       %s\n", f.Name)
+	fmt.Printf("Type:       %s\n", drive.GetTypeName(f.MimeType))
+
+	if f.Size > 0 {
+		fmt.Printf("Size:       %s\n", formatSize(f.Size))
+	} else {
+		fmt.Printf("Size:       -\n")
+	}
+
+	if !f.CreatedTime.IsZero() {
+		fmt.Printf("Created:    %s\n", f.CreatedTime.Format("2006-01-02 15:04:05"))
+	}
+
+	if !f.ModifiedTime.IsZero() {
+		fmt.Printf("Modified:   %s\n", f.ModifiedTime.Format("2006-01-02 15:04:05"))
+	}
+
+	if len(f.Owners) > 0 {
+		fmt.Printf("Owner:      %s\n", strings.Join(f.Owners, ", "))
+	}
+
+	if f.Shared {
+		fmt.Printf("Shared:     Yes\n")
+	} else {
+		fmt.Printf("Shared:     No\n")
+	}
+
+	if f.WebViewLink != "" {
+		fmt.Printf("Web Link:   %s\n", f.WebViewLink)
+	}
+
+	if len(f.Parents) > 0 {
+		fmt.Printf("Parent:     %s\n", strings.Join(f.Parents, ", "))
+	}
+}

--- a/internal/cmd/drive/get_test.go
+++ b/internal/cmd/drive/get_test.go
@@ -1,0 +1,155 @@
+package drive
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-cli-collective/google-readonly/internal/drive"
+)
+
+func TestGetCommand(t *testing.T) {
+	cmd := newGetCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "get <file-id>", cmd.Use)
+	})
+
+	t.Run("requires exactly one argument", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.Error(t, err)
+
+		err = cmd.Args(cmd, []string{"file-id"})
+		assert.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"file-id", "extra"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "j", flag.Shorthand)
+		assert.Equal(t, "false", flag.DefValue)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.Contains(t, cmd.Short, "Get")
+	})
+}
+
+func TestPrintFileDetails(t *testing.T) {
+	// Capture stdout for testing
+	captureOutput := func(fn func()) string {
+		old := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		fn()
+
+		w.Close()
+		os.Stdout = old
+
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		return buf.String()
+	}
+
+	t.Run("prints all fields for complete file", func(t *testing.T) {
+		f := &drive.File{
+			ID:           "abc123",
+			Name:         "Test Document",
+			MimeType:     drive.MimeTypeDocument,
+			Size:         0, // Google Docs have no size
+			CreatedTime:  time.Date(2024, 1, 10, 9, 30, 0, 0, time.UTC),
+			ModifiedTime: time.Date(2024, 1, 15, 14, 22, 0, 0, time.UTC),
+			Owners:       []string{"owner@example.com"},
+			Shared:       true,
+			WebViewLink:  "https://docs.google.com/document/d/abc123/edit",
+			Parents:      []string{"parent123"},
+		}
+
+		output := captureOutput(func() {
+			printFileDetails(f)
+		})
+
+		assert.Contains(t, output, "File Details")
+		assert.Contains(t, output, "ID:         abc123")
+		assert.Contains(t, output, "Name:       Test Document")
+		assert.Contains(t, output, "Type:       Document")
+		assert.Contains(t, output, "Size:       -")
+		assert.Contains(t, output, "Created:    2024-01-10 09:30:00")
+		assert.Contains(t, output, "Modified:   2024-01-15 14:22:00")
+		assert.Contains(t, output, "Owner:      owner@example.com")
+		assert.Contains(t, output, "Shared:     Yes")
+		assert.Contains(t, output, "Web Link:   https://docs.google.com/document/d/abc123/edit")
+		assert.Contains(t, output, "Parent:     parent123")
+	})
+
+	t.Run("prints size for regular files", func(t *testing.T) {
+		f := &drive.File{
+			ID:       "xyz789",
+			Name:     "photo.jpg",
+			MimeType: "image/jpeg",
+			Size:     1572864, // 1.5 MB
+		}
+
+		output := captureOutput(func() {
+			printFileDetails(f)
+		})
+
+		assert.Contains(t, output, "Size:       1.5 MB")
+	})
+
+	t.Run("handles unshared file", func(t *testing.T) {
+		f := &drive.File{
+			ID:     "private123",
+			Name:   "private.txt",
+			Shared: false,
+		}
+
+		output := captureOutput(func() {
+			printFileDetails(f)
+		})
+
+		assert.Contains(t, output, "Shared:     No")
+	})
+
+	t.Run("handles multiple owners", func(t *testing.T) {
+		f := &drive.File{
+			ID:     "shared123",
+			Name:   "shared.txt",
+			Owners: []string{"owner1@example.com", "owner2@example.com"},
+		}
+
+		output := captureOutput(func() {
+			printFileDetails(f)
+		})
+
+		assert.Contains(t, output, "Owner:      owner1@example.com, owner2@example.com")
+	})
+
+	t.Run("omits missing fields gracefully", func(t *testing.T) {
+		f := &drive.File{
+			ID:   "minimal123",
+			Name: "minimal.txt",
+		}
+
+		output := captureOutput(func() {
+			printFileDetails(f)
+		})
+
+		assert.Contains(t, output, "ID:         minimal123")
+		assert.Contains(t, output, "Name:       minimal.txt")
+		// Should not contain empty values or crash
+		assert.NotContains(t, output, "Created:")
+		assert.NotContains(t, output, "Modified:")
+		assert.NotContains(t, output, "Owner:")
+		assert.NotContains(t, output, "Web Link:")
+		assert.NotContains(t, output, "Parent:")
+	})
+}


### PR DESCRIPTION
## Summary
- Add `gro drive get <file-id>` command to show detailed file metadata
- Display: ID, name, type, size, created/modified dates, owner, shared status, web link, parent
- Support `--json` flag for JSON output
- Handle Google Docs (no size) gracefully by showing "-"

## Test Plan
- [x] `gro drive get --help` shows usage
- [x] Tests for command flags and argument validation
- [x] Tests for `printFileDetails()` with various file scenarios
- [x] `make verify` passes

Closes #64