### PR TITLE
feat(drive): add download command

### DIFF
--- a/internal/cmd/drive/download.go
+++ b/internal/cmd/drive/download.go
@@ -1,0 +1,138 @@
+package drive
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/drive"
+)
+
+var (
+	downloadOutput string
+	downloadFormat string
+	downloadStdout bool
+)
+
+func newDownloadCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "download <file-id>",
+		Short: "Download a file",
+		Long: `Download a file from Google Drive or export a Google Workspace file.
+
+Regular files (PDFs, images, etc.) are downloaded directly.
+Google Workspace files (Docs, Sheets, Slides) must be exported using --format.
+
+Examples:
+  gro drive download <file-id>                  # Download regular file
+  gro drive download <file-id> -o ./report.pdf  # Download to specific path
+  gro drive download <file-id> --format pdf     # Export Google Doc as PDF
+  gro drive download <file-id> --format xlsx    # Export Sheet as Excel
+  gro drive download <file-id> --stdout         # Write to stdout
+
+Export formats:
+  Documents:     pdf, docx, txt, html, md, rtf, odt
+  Spreadsheets:  pdf, xlsx, csv, tsv, ods
+  Presentations: pdf, pptx, odp
+  Drawings:      pdf, png, svg, jpg`,
+		Args: cobra.ExactArgs(1),
+		RunE: runDownload,
+	}
+
+	cmd.Flags().StringVarP(&downloadOutput, "output", "o", "", "Output file path")
+	cmd.Flags().StringVarP(&downloadFormat, "format", "f", "", "Export format for Google Workspace files")
+	cmd.Flags().BoolVar(&downloadStdout, "stdout", false, "Write to stdout instead of file")
+
+	return cmd
+}
+
+func runDownload(cmd *cobra.Command, args []string) error {
+	client, err := newDriveClient()
+	if err != nil {
+		return err
+	}
+
+	fileID := args[0]
+
+	// Get file metadata first
+	file, err := client.GetFile(fileID)
+	if err != nil {
+		return fmt.Errorf("failed to get file info: %w", err)
+	}
+
+	var data []byte
+
+	if drive.IsGoogleWorkspaceFile(file.MimeType) {
+		// Google Workspace file - must export
+		if downloadFormat == "" {
+			formats := drive.GetSupportedExportFormats(file.MimeType)
+			return fmt.Errorf("google %s requires --format flag (supported: %s)",
+				drive.GetTypeName(file.MimeType), strings.Join(formats, ", "))
+		}
+
+		exportMime, err := drive.GetExportMimeType(file.MimeType, downloadFormat)
+		if err != nil {
+			return err
+		}
+
+		if !downloadStdout {
+			fmt.Printf("Exporting: %s\n", file.Name)
+			fmt.Printf("Format: %s\n", downloadFormat)
+		}
+
+		data, err = client.ExportFile(fileID, exportMime)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Regular file - download directly
+		if downloadFormat != "" {
+			return fmt.Errorf("--format flag is only for Google Workspace files; %s is a %s",
+				file.Name, drive.GetTypeName(file.MimeType))
+		}
+
+		if !downloadStdout {
+			fmt.Printf("Downloading: %s\n", file.Name)
+		}
+
+		data, err = client.DownloadFile(fileID)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Output to stdout or file
+	if downloadStdout {
+		_, err = os.Stdout.Write(data)
+		return err
+	}
+
+	outputPath := determineOutputPath(file.Name, downloadFormat, downloadOutput)
+
+	if err := os.WriteFile(outputPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+
+	fmt.Printf("Size: %s\n", formatSize(int64(len(data))))
+	fmt.Printf("Saved to: %s\n", outputPath)
+	return nil
+}
+
+// determineOutputPath figures out where to save the downloaded file
+func determineOutputPath(originalName, format, userOutput string) string {
+	if userOutput != "" {
+		return userOutput
+	}
+
+	// If exporting with a format, replace the extension
+	if format != "" {
+		// Remove any existing extension and add the new one
+		baseName := strings.TrimSuffix(originalName, filepath.Ext(originalName))
+		return baseName + drive.GetFileExtension(format)
+	}
+
+	return originalName
+}

--- a/internal/cmd/drive/download_test.go
+++ b/internal/cmd/drive/download_test.go
@@ -1,0 +1,93 @@
+package drive
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDownloadCommand(t *testing.T) {
+	cmd := newDownloadCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "download <file-id>", cmd.Use)
+	})
+
+	t.Run("requires exactly one argument", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.Error(t, err)
+
+		err = cmd.Args(cmd, []string{"file-id"})
+		assert.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"file-id", "extra"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has output flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("output")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "o", flag.Shorthand)
+	})
+
+	t.Run("has format flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("format")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "f", flag.Shorthand)
+	})
+
+	t.Run("has stdout flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("stdout")
+		assert.NotNil(t, flag)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.Contains(t, cmd.Short, "Download")
+	})
+}
+
+func TestDetermineOutputPath(t *testing.T) {
+	t.Run("uses user-specified output path", func(t *testing.T) {
+		result := determineOutputPath("original.doc", "pdf", "/custom/path.pdf")
+		assert.Equal(t, "/custom/path.pdf", result)
+	})
+
+	t.Run("uses original name when no format or output", func(t *testing.T) {
+		result := determineOutputPath("document.pdf", "", "")
+		assert.Equal(t, "document.pdf", result)
+	})
+
+	t.Run("replaces extension when format specified", func(t *testing.T) {
+		result := determineOutputPath("Report", "pdf", "")
+		assert.Equal(t, "Report.pdf", result)
+	})
+
+	t.Run("replaces existing extension when format specified", func(t *testing.T) {
+		result := determineOutputPath("Report.gdoc", "docx", "")
+		assert.Equal(t, "Report.docx", result)
+	})
+
+	t.Run("handles various export formats", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			format   string
+			expected string
+		}{
+			{"Document", "pdf", "Document.pdf"},
+			{"Document", "docx", "Document.docx"},
+			{"Document", "txt", "Document.txt"},
+			{"Spreadsheet", "xlsx", "Spreadsheet.xlsx"},
+			{"Spreadsheet", "csv", "Spreadsheet.csv"},
+			{"Presentation", "pptx", "Presentation.pptx"},
+			{"Drawing", "png", "Drawing.png"},
+			{"Drawing", "svg", "Drawing.svg"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.format, func(t *testing.T) {
+				result := determineOutputPath(tt.name, tt.format, "")
+				assert.Equal(t, tt.expected, result)
+			})
+		}
+	})
+}

--- a/internal/cmd/drive/drive.go
+++ b/internal/cmd/drive/drive.go
@@ -29,6 +29,7 @@ Examples:
 	cmd.AddCommand(newListCommand())
 	cmd.AddCommand(newSearchCommand())
 	cmd.AddCommand(newGetCommand())
+	cmd.AddCommand(newDownloadCommand())
 
 	return cmd
 }

--- a/internal/drive/interfaces.go
+++ b/internal/drive/interfaces.go
@@ -8,6 +8,12 @@ type DriveClientInterface interface {
 
 	// GetFile retrieves a single file by ID
 	GetFile(fileID string) (*File, error)
+
+	// DownloadFile downloads a regular (non-Google Workspace) file
+	DownloadFile(fileID string) ([]byte, error)
+
+	// ExportFile exports a Google Workspace file to the specified MIME type
+	ExportFile(fileID string, mimeType string) ([]byte, error)
 }
 
 // Verify that Client implements DriveClientInterface


### PR DESCRIPTION
## Summary
- Add `gro drive download <file-id>` command for downloading files
- Regular files download directly; Google Workspace files require `--format` flag for export
- Support `--output`, `--format`, and `--stdout` flags
- Add `DownloadFile()` and `ExportFile()` methods to Drive client
- Add export format mappings for Documents, Spreadsheets, Presentations, Drawings

## Export Formats
- **Documents:** pdf, docx, txt, html, md, rtf, odt
- **Spreadsheets:** pdf, xlsx, csv, tsv, ods
- **Presentations:** pdf, pptx, odp
- **Drawings:** pdf, png, svg, jpg

## Test Plan
- [x] `gro drive download --help` shows correct usage
- [x] Tests for command flags and argument validation
- [x] Tests for output path determination
- [x] Tests for export MIME type mapping
- [x] Tests for file extension helpers
- [x] `make verify` passes

Closes #65