### PR TITLE
feat(drive): add tree command

### DIFF
--- a/internal/cmd/drive/drive.go
+++ b/internal/cmd/drive/drive.go
@@ -30,6 +30,7 @@ Examples:
 	cmd.AddCommand(newSearchCommand())
 	cmd.AddCommand(newGetCommand())
 	cmd.AddCommand(newDownloadCommand())
+	cmd.AddCommand(newTreeCommand())
 
 	return cmd
 }

--- a/internal/cmd/drive/tree.go
+++ b/internal/cmd/drive/tree.go
@@ -1,0 +1,174 @@
+package drive
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/drive"
+)
+
+var (
+	treeDepth      int
+	treeFiles      bool
+	treeJSONOutput bool
+)
+
+// TreeNode represents a node in the folder tree
+type TreeNode struct {
+	ID       string      `json:"id"`
+	Name     string      `json:"name"`
+	Type     string      `json:"type"`
+	Children []*TreeNode `json:"children,omitempty"`
+}
+
+func newTreeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tree [folder-id]",
+		Short: "Display folder structure",
+		Long: `Display the folder structure of Google Drive in a tree format.
+
+Examples:
+  gro drive tree                    # Show folder tree from root
+  gro drive tree <folder-id>        # Show tree from specific folder
+  gro drive tree --depth 3          # Limit depth
+  gro drive tree --files            # Include files, not just folders
+  gro drive tree --json             # Output as JSON`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runTree,
+	}
+
+	cmd.Flags().IntVarP(&treeDepth, "depth", "d", 2, "Maximum depth to traverse")
+	cmd.Flags().BoolVar(&treeFiles, "files", false, "Include files in addition to folders")
+	cmd.Flags().BoolVarP(&treeJSONOutput, "json", "j", false, "Output results as JSON")
+
+	return cmd
+}
+
+func runTree(cmd *cobra.Command, args []string) error {
+	client, err := newDriveClient()
+	if err != nil {
+		return err
+	}
+
+	folderID := "root"
+	if len(args) > 0 {
+		folderID = args[0]
+	}
+
+	// Build the tree
+	tree, err := buildTree(client, folderID, treeDepth, treeFiles)
+	if err != nil {
+		return err
+	}
+
+	if treeJSONOutput {
+		return printJSON(tree)
+	}
+
+	printTree(tree, "", true)
+	return nil
+}
+
+// buildTree recursively builds the folder tree structure
+func buildTree(client drive.DriveClientInterface, folderID string, depth int, includeFiles bool) (*TreeNode, error) {
+	// Get folder info
+	var folderName string
+	var folderType string
+
+	if folderID == "root" {
+		folderName = "My Drive"
+		folderType = "Folder"
+	} else {
+		folder, err := client.GetFile(folderID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get folder info: %w", err)
+		}
+		folderName = folder.Name
+		folderType = drive.GetTypeName(folder.MimeType)
+	}
+
+	node := &TreeNode{
+		ID:   folderID,
+		Name: folderName,
+		Type: folderType,
+	}
+
+	// Stop if we've reached the depth limit
+	if depth <= 0 {
+		return node, nil
+	}
+
+	// Build query to list children
+	query := fmt.Sprintf("'%s' in parents and trashed = false", folderID)
+	if !includeFiles {
+		query += fmt.Sprintf(" and mimeType = '%s'", drive.MimeTypeFolder)
+	}
+
+	children, err := client.ListFiles(query, 100)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list children: %w", err)
+	}
+
+	// Sort children: folders first, then by name
+	sort.Slice(children, func(i, j int) bool {
+		iIsFolder := children[i].MimeType == drive.MimeTypeFolder
+		jIsFolder := children[j].MimeType == drive.MimeTypeFolder
+		if iIsFolder != jIsFolder {
+			return iIsFolder // folders first
+		}
+		return children[i].Name < children[j].Name
+	})
+
+	// Process children
+	for _, child := range children {
+		if child.MimeType == drive.MimeTypeFolder {
+			// Recursively build subtree for folders
+			childNode, err := buildTree(client, child.ID, depth-1, includeFiles)
+			if err != nil {
+				// Log error but continue with other children
+				continue
+			}
+			node.Children = append(node.Children, childNode)
+		} else {
+			// Add file as leaf node
+			node.Children = append(node.Children, &TreeNode{
+				ID:   child.ID,
+				Name: child.Name,
+				Type: drive.GetTypeName(child.MimeType),
+			})
+		}
+	}
+
+	return node, nil
+}
+
+// printTree prints the tree structure with tree characters
+func printTree(node *TreeNode, prefix string, isRoot bool) {
+	if isRoot {
+		fmt.Println(node.Name)
+	}
+
+	for i, child := range node.Children {
+		isLast := i == len(node.Children)-1
+
+		// Print the current line
+		if isLast {
+			fmt.Printf("%s└── %s\n", prefix, child.Name)
+		} else {
+			fmt.Printf("%s├── %s\n", prefix, child.Name)
+		}
+
+		// Print children with updated prefix
+		if len(child.Children) > 0 {
+			var newPrefix string
+			if isLast {
+				newPrefix = prefix + "    "
+			} else {
+				newPrefix = prefix + "│   "
+			}
+			printTree(child, newPrefix, false)
+		}
+	}
+}

--- a/internal/cmd/drive/tree_test.go
+++ b/internal/cmd/drive/tree_test.go
@@ -1,0 +1,213 @@
+package drive
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTreeCommand(t *testing.T) {
+	cmd := newTreeCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "tree [folder-id]", cmd.Use)
+	})
+
+	t.Run("accepts zero or one argument", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"folder-id"})
+		assert.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"folder-id", "extra"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has depth flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("depth")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "d", flag.Shorthand)
+		assert.Equal(t, "2", flag.DefValue)
+	})
+
+	t.Run("has files flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("files")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "false", flag.DefValue)
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "j", flag.Shorthand)
+		assert.Equal(t, "false", flag.DefValue)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.Contains(t, cmd.Short, "folder structure")
+	})
+}
+
+func TestPrintTree(t *testing.T) {
+	// Capture stdout for testing
+	captureOutput := func(fn func()) string {
+		old := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		fn()
+
+		w.Close()
+		os.Stdout = old
+
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		return buf.String()
+	}
+
+	t.Run("prints single node", func(t *testing.T) {
+		node := &TreeNode{
+			ID:   "root",
+			Name: "My Drive",
+			Type: "Folder",
+		}
+
+		output := captureOutput(func() {
+			printTree(node, "", true)
+		})
+
+		assert.Equal(t, "My Drive\n", output)
+	})
+
+	t.Run("prints tree with children", func(t *testing.T) {
+		node := &TreeNode{
+			ID:   "root",
+			Name: "My Drive",
+			Type: "Folder",
+			Children: []*TreeNode{
+				{ID: "1", Name: "Documents", Type: "Folder"},
+				{ID: "2", Name: "Photos", Type: "Folder"},
+			},
+		}
+
+		output := captureOutput(func() {
+			printTree(node, "", true)
+		})
+
+		assert.Contains(t, output, "My Drive")
+		assert.Contains(t, output, "├── Documents")
+		assert.Contains(t, output, "└── Photos")
+	})
+
+	t.Run("prints nested tree", func(t *testing.T) {
+		node := &TreeNode{
+			ID:   "root",
+			Name: "My Drive",
+			Type: "Folder",
+			Children: []*TreeNode{
+				{
+					ID:   "1",
+					Name: "Projects",
+					Type: "Folder",
+					Children: []*TreeNode{
+						{ID: "1a", Name: "Project A", Type: "Folder"},
+						{ID: "1b", Name: "Project B", Type: "Folder"},
+					},
+				},
+				{ID: "2", Name: "Documents", Type: "Folder"},
+			},
+		}
+
+		output := captureOutput(func() {
+			printTree(node, "", true)
+		})
+
+		assert.Contains(t, output, "My Drive")
+		assert.Contains(t, output, "├── Projects")
+		assert.Contains(t, output, "│   ├── Project A")
+		assert.Contains(t, output, "│   └── Project B")
+		assert.Contains(t, output, "└── Documents")
+	})
+
+	t.Run("prints deeply nested tree", func(t *testing.T) {
+		node := &TreeNode{
+			ID:   "root",
+			Name: "Root",
+			Type: "Folder",
+			Children: []*TreeNode{
+				{
+					ID:   "1",
+					Name: "Level1",
+					Type: "Folder",
+					Children: []*TreeNode{
+						{
+							ID:   "2",
+							Name: "Level2",
+							Type: "Folder",
+							Children: []*TreeNode{
+								{ID: "3", Name: "Level3", Type: "Folder"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		output := captureOutput(func() {
+			printTree(node, "", true)
+		})
+
+		assert.Contains(t, output, "Root")
+		assert.Contains(t, output, "└── Level1")
+		assert.Contains(t, output, "    └── Level2")
+		assert.Contains(t, output, "        └── Level3")
+	})
+
+	t.Run("handles empty children", func(t *testing.T) {
+		node := &TreeNode{
+			ID:       "root",
+			Name:     "Empty Folder",
+			Type:     "Folder",
+			Children: []*TreeNode{},
+		}
+
+		output := captureOutput(func() {
+			printTree(node, "", true)
+		})
+
+		assert.Equal(t, "Empty Folder\n", output)
+	})
+}
+
+func TestTreeNode(t *testing.T) {
+	t.Run("serializes to JSON correctly", func(t *testing.T) {
+		node := &TreeNode{
+			ID:   "abc123",
+			Name: "Test",
+			Type: "Folder",
+			Children: []*TreeNode{
+				{ID: "child1", Name: "Child", Type: "Document"},
+			},
+		}
+
+		assert.Equal(t, "abc123", node.ID)
+		assert.Equal(t, "Test", node.Name)
+		assert.Equal(t, "Folder", node.Type)
+		assert.Len(t, node.Children, 1)
+	})
+
+	t.Run("handles nil children", func(t *testing.T) {
+		node := &TreeNode{
+			ID:       "abc123",
+			Name:     "Test",
+			Type:     "Folder",
+			Children: nil,
+		}
+
+		assert.Nil(t, node.Children)
+	})
+}


### PR DESCRIPTION
## Summary
- Add `gro drive tree` command to display folder structure
- Show tree from root or specific folder
- Support `--depth` flag to limit traversal depth (default 2)
- Support `--files` flag to include files, not just folders
- Support `--json` flag for JSON output
- Tree characters (├── └── │) for visual hierarchy
- Sort folders before files, then alphabetically

## Test Plan
- [x] `gro drive tree --help` shows correct usage
- [x] Tests for command flags and argument validation
- [x] Tests for `printTree()` with various tree structures
- [x] Tests for nested and deeply nested trees
- [x] Tests for empty folders
- [x] `make verify` passes

Closes #66