### PR TITLE
test: Phase 6 testing infrastructure

### DIFF
--- a/internal/cmd/calendar/handlers_test.go
+++ b/internal/cmd/calendar/handlers_test.go
@@ -1,0 +1,341 @@
+package calendar
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/calendar/v3"
+
+	calendarapi "github.com/open-cli-collective/google-readonly/internal/calendar"
+	"github.com/open-cli-collective/google-readonly/internal/testutil"
+)
+
+// captureOutput captures stdout during test execution
+func captureOutput(t *testing.T, f func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	f()
+
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+// withMockClient sets up a mock client factory for tests
+func withMockClient(mock calendarapi.CalendarClientInterface, f func()) {
+	originalFactory := ClientFactory
+	ClientFactory = func() (calendarapi.CalendarClientInterface, error) {
+		return mock, nil
+	}
+	defer func() { ClientFactory = originalFactory }()
+	f()
+}
+
+// withFailingClientFactory sets up a factory that returns an error
+func withFailingClientFactory(f func()) {
+	originalFactory := ClientFactory
+	ClientFactory = func() (calendarapi.CalendarClientInterface, error) {
+		return nil, errors.New("connection failed")
+	}
+	defer func() { ClientFactory = originalFactory }()
+	f()
+}
+
+func TestListCommand_Success(t *testing.T) {
+	mock := &testutil.MockCalendarClient{
+		ListCalendarsFunc: func() ([]*calendar.CalendarListEntry, error) {
+			return testutil.SampleCalendars(), nil
+		},
+	}
+
+	cmd := newListCommand()
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "primary@example.com")
+		assert.Contains(t, output, "(primary)")
+		assert.Contains(t, output, "work@example.com")
+	})
+}
+
+func TestListCommand_JSONOutput(t *testing.T) {
+	mock := &testutil.MockCalendarClient{
+		ListCalendarsFunc: func() ([]*calendar.CalendarListEntry, error) {
+			return testutil.SampleCalendars(), nil
+		},
+	}
+
+	cmd := newListCommand()
+	cmd.SetArgs([]string{"--json"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		var calendars []*calendarapi.CalendarInfo
+		err := json.Unmarshal([]byte(output), &calendars)
+		assert.NoError(t, err)
+		assert.Len(t, calendars, 2)
+	})
+}
+
+func TestListCommand_Empty(t *testing.T) {
+	mock := &testutil.MockCalendarClient{
+		ListCalendarsFunc: func() ([]*calendar.CalendarListEntry, error) {
+			return []*calendar.CalendarListEntry{}, nil
+		},
+	}
+
+	cmd := newListCommand()
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "No calendars found")
+	})
+}
+
+func TestListCommand_APIError(t *testing.T) {
+	mock := &testutil.MockCalendarClient{
+		ListCalendarsFunc: func() ([]*calendar.CalendarListEntry, error) {
+			return nil, errors.New("API error")
+		},
+	}
+
+	cmd := newListCommand()
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to list calendars")
+	})
+}
+
+func TestListCommand_ClientCreationError(t *testing.T) {
+	cmd := newListCommand()
+
+	withFailingClientFactory(func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create Calendar client")
+	})
+}
+
+func TestEventsCommand_Success(t *testing.T) {
+	mock := &testutil.MockCalendarClient{
+		ListEventsFunc: func(calendarID, timeMin, timeMax string, maxResults int64) ([]*calendar.Event, error) {
+			assert.Equal(t, "primary", calendarID)
+			return []*calendar.Event{testutil.SampleEvent("event1")}, nil
+		},
+	}
+
+	cmd := newEventsCommand()
+	cmd.SetArgs([]string{}) // Uses default "primary" calendar
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "Test Meeting")
+	})
+}
+
+func TestEventsCommand_WithDateRange(t *testing.T) {
+	var capturedTimeMin, capturedTimeMax string
+	mock := &testutil.MockCalendarClient{
+		ListEventsFunc: func(calendarID, timeMin, timeMax string, maxResults int64) ([]*calendar.Event, error) {
+			capturedTimeMin = timeMin
+			capturedTimeMax = timeMax
+			return []*calendar.Event{}, nil
+		},
+	}
+
+	cmd := newEventsCommand()
+	cmd.SetArgs([]string{"--from", "2024-01-01", "--to", "2024-01-31"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		// Verify dates were parsed and passed
+		assert.Contains(t, capturedTimeMin, "2024-01-01")
+		assert.Contains(t, capturedTimeMax, "2024-01-31")
+		assert.Contains(t, output, "No events")
+	})
+}
+
+func TestEventsCommand_JSONOutput(t *testing.T) {
+	mock := &testutil.MockCalendarClient{
+		ListEventsFunc: func(calendarID, timeMin, timeMax string, maxResults int64) ([]*calendar.Event, error) {
+			return []*calendar.Event{testutil.SampleEvent("event1")}, nil
+		},
+	}
+
+	cmd := newEventsCommand()
+	cmd.SetArgs([]string{"--json"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		var events []*calendarapi.Event
+		err := json.Unmarshal([]byte(output), &events)
+		assert.NoError(t, err)
+		assert.Len(t, events, 1)
+	})
+}
+
+func TestEventsCommand_InvalidFromDate(t *testing.T) {
+	cmd := newEventsCommand()
+	cmd.SetArgs([]string{"--from", "invalid-date"})
+
+	withMockClient(&testutil.MockCalendarClient{}, func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid --from date")
+	})
+}
+
+func TestEventsCommand_InvalidToDate(t *testing.T) {
+	cmd := newEventsCommand()
+	cmd.SetArgs([]string{"--to", "invalid-date"})
+
+	withMockClient(&testutil.MockCalendarClient{}, func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid --to date")
+	})
+}
+
+func TestGetCommand_Success(t *testing.T) {
+	mock := &testutil.MockCalendarClient{
+		GetEventFunc: func(calendarID, eventID string) (*calendar.Event, error) {
+			assert.Equal(t, "primary", calendarID)
+			assert.Equal(t, "event123", eventID)
+			return testutil.SampleEvent("event123"), nil
+		},
+	}
+
+	cmd := newGetCommand()
+	cmd.SetArgs([]string{"event123"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "event123")
+		assert.Contains(t, output, "Test Meeting")
+		assert.Contains(t, output, "Conference Room A")
+	})
+}
+
+func TestGetCommand_JSONOutput(t *testing.T) {
+	mock := &testutil.MockCalendarClient{
+		GetEventFunc: func(calendarID, eventID string) (*calendar.Event, error) {
+			return testutil.SampleEvent("event123"), nil
+		},
+	}
+
+	cmd := newGetCommand()
+	cmd.SetArgs([]string{"event123", "--json"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		var event calendarapi.Event
+		err := json.Unmarshal([]byte(output), &event)
+		assert.NoError(t, err)
+		assert.Equal(t, "event123", event.ID)
+	})
+}
+
+func TestGetCommand_NotFound(t *testing.T) {
+	mock := &testutil.MockCalendarClient{
+		GetEventFunc: func(calendarID, eventID string) (*calendar.Event, error) {
+			return nil, errors.New("event not found")
+		},
+	}
+
+	cmd := newGetCommand()
+	cmd.SetArgs([]string{"nonexistent"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get event")
+	})
+}
+
+func TestTodayCommand_Success(t *testing.T) {
+	mock := &testutil.MockCalendarClient{
+		ListEventsFunc: func(calendarID, timeMin, timeMax string, maxResults int64) ([]*calendar.Event, error) {
+			return []*calendar.Event{testutil.SampleEvent("today_event")}, nil
+		},
+	}
+
+	cmd := newTodayCommand()
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "Test Meeting")
+	})
+}
+
+func TestWeekCommand_Success(t *testing.T) {
+	mock := &testutil.MockCalendarClient{
+		ListEventsFunc: func(calendarID, timeMin, timeMax string, maxResults int64) ([]*calendar.Event, error) {
+			return []*calendar.Event{
+				testutil.SampleEvent("week_event1"),
+				testutil.SampleEvent("week_event2"),
+			}, nil
+		},
+	}
+
+	cmd := newWeekCommand()
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		// Should show events
+		assert.Contains(t, output, "Test Meeting")
+	})
+}

--- a/internal/cmd/contacts/handlers_test.go
+++ b/internal/cmd/contacts/handlers_test.go
@@ -1,0 +1,415 @@
+package contacts
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/people/v1"
+
+	contactsapi "github.com/open-cli-collective/google-readonly/internal/contacts"
+	"github.com/open-cli-collective/google-readonly/internal/testutil"
+)
+
+// captureOutput captures stdout during test execution
+func captureOutput(t *testing.T, f func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	f()
+
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+// withMockClient sets up a mock client factory for tests
+func withMockClient(mock contactsapi.ContactsClientInterface, f func()) {
+	originalFactory := ClientFactory
+	ClientFactory = func() (contactsapi.ContactsClientInterface, error) {
+		return mock, nil
+	}
+	defer func() { ClientFactory = originalFactory }()
+	f()
+}
+
+// withFailingClientFactory sets up a factory that returns an error
+func withFailingClientFactory(f func()) {
+	originalFactory := ClientFactory
+	ClientFactory = func() (contactsapi.ContactsClientInterface, error) {
+		return nil, errors.New("connection failed")
+	}
+	defer func() { ClientFactory = originalFactory }()
+	f()
+}
+
+func TestListCommand_Success(t *testing.T) {
+	mock := &testutil.MockContactsClient{
+		ListContactsFunc: func(pageToken string, pageSize int64) (*people.ListConnectionsResponse, error) {
+			return &people.ListConnectionsResponse{
+				Connections: []*people.Person{
+					testutil.SamplePerson("people/c123"),
+					testutil.SamplePerson("people/c456"),
+				},
+			}, nil
+		},
+	}
+
+	cmd := newListCommand()
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "people/c123")
+		assert.Contains(t, output, "John Doe")
+		assert.Contains(t, output, "2 contact(s)")
+	})
+}
+
+func TestListCommand_JSONOutput(t *testing.T) {
+	mock := &testutil.MockContactsClient{
+		ListContactsFunc: func(pageToken string, pageSize int64) (*people.ListConnectionsResponse, error) {
+			return &people.ListConnectionsResponse{
+				Connections: []*people.Person{
+					testutil.SamplePerson("people/c123"),
+				},
+			}, nil
+		},
+	}
+
+	cmd := newListCommand()
+	cmd.SetArgs([]string{"--json"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		var contacts []*contactsapi.Contact
+		err := json.Unmarshal([]byte(output), &contacts)
+		assert.NoError(t, err)
+		assert.Len(t, contacts, 1)
+	})
+}
+
+func TestListCommand_Empty(t *testing.T) {
+	mock := &testutil.MockContactsClient{
+		ListContactsFunc: func(pageToken string, pageSize int64) (*people.ListConnectionsResponse, error) {
+			return &people.ListConnectionsResponse{
+				Connections: []*people.Person{},
+			}, nil
+		},
+	}
+
+	cmd := newListCommand()
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "No contacts found")
+	})
+}
+
+func TestListCommand_APIError(t *testing.T) {
+	mock := &testutil.MockContactsClient{
+		ListContactsFunc: func(pageToken string, pageSize int64) (*people.ListConnectionsResponse, error) {
+			return nil, errors.New("API error")
+		},
+	}
+
+	cmd := newListCommand()
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to list contacts")
+	})
+}
+
+func TestListCommand_ClientCreationError(t *testing.T) {
+	cmd := newListCommand()
+
+	withFailingClientFactory(func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create Contacts client")
+	})
+}
+
+func TestSearchCommand_Success(t *testing.T) {
+	mock := &testutil.MockContactsClient{
+		SearchContactsFunc: func(query string, pageSize int64) (*people.SearchResponse, error) {
+			assert.Equal(t, "John", query)
+			return &people.SearchResponse{
+				Results: []*people.SearchResult{
+					{Person: testutil.SamplePerson("people/c123")},
+				},
+			}, nil
+		},
+	}
+
+	cmd := newSearchCommand()
+	cmd.SetArgs([]string{"John"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "John Doe")
+		assert.Contains(t, output, "1 contact(s)")
+	})
+}
+
+func TestSearchCommand_JSONOutput(t *testing.T) {
+	mock := &testutil.MockContactsClient{
+		SearchContactsFunc: func(query string, pageSize int64) (*people.SearchResponse, error) {
+			return &people.SearchResponse{
+				Results: []*people.SearchResult{
+					{Person: testutil.SamplePerson("people/c123")},
+				},
+			}, nil
+		},
+	}
+
+	cmd := newSearchCommand()
+	cmd.SetArgs([]string{"John", "--json"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		var contacts []*contactsapi.Contact
+		err := json.Unmarshal([]byte(output), &contacts)
+		assert.NoError(t, err)
+		assert.Len(t, contacts, 1)
+	})
+}
+
+func TestSearchCommand_NoResults(t *testing.T) {
+	mock := &testutil.MockContactsClient{
+		SearchContactsFunc: func(query string, pageSize int64) (*people.SearchResponse, error) {
+			return &people.SearchResponse{
+				Results: []*people.SearchResult{},
+			}, nil
+		},
+	}
+
+	cmd := newSearchCommand()
+	cmd.SetArgs([]string{"nonexistent"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "No contacts found")
+	})
+}
+
+func TestSearchCommand_APIError(t *testing.T) {
+	mock := &testutil.MockContactsClient{
+		SearchContactsFunc: func(query string, pageSize int64) (*people.SearchResponse, error) {
+			return nil, errors.New("API error")
+		},
+	}
+
+	cmd := newSearchCommand()
+	cmd.SetArgs([]string{"John"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to search contacts")
+	})
+}
+
+func TestGetCommand_Success(t *testing.T) {
+	mock := &testutil.MockContactsClient{
+		GetContactFunc: func(resourceName string) (*people.Person, error) {
+			assert.Equal(t, "people/c123", resourceName)
+			return testutil.SamplePerson("people/c123"), nil
+		},
+	}
+
+	cmd := newGetCommand()
+	cmd.SetArgs([]string{"people/c123"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "people/c123")
+		assert.Contains(t, output, "John Doe")
+		assert.Contains(t, output, "john@example.com")
+	})
+}
+
+func TestGetCommand_JSONOutput(t *testing.T) {
+	mock := &testutil.MockContactsClient{
+		GetContactFunc: func(resourceName string) (*people.Person, error) {
+			return testutil.SamplePerson("people/c123"), nil
+		},
+	}
+
+	cmd := newGetCommand()
+	cmd.SetArgs([]string{"people/c123", "--json"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		var contact contactsapi.Contact
+		err := json.Unmarshal([]byte(output), &contact)
+		assert.NoError(t, err)
+		assert.Equal(t, "people/c123", contact.ResourceName)
+	})
+}
+
+func TestGetCommand_NotFound(t *testing.T) {
+	mock := &testutil.MockContactsClient{
+		GetContactFunc: func(resourceName string) (*people.Person, error) {
+			return nil, errors.New("contact not found")
+		},
+	}
+
+	cmd := newGetCommand()
+	cmd.SetArgs([]string{"people/nonexistent"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get contact")
+	})
+}
+
+func TestGroupsCommand_Success(t *testing.T) {
+	mock := &testutil.MockContactsClient{
+		ListContactGroupsFunc: func(pageToken string, pageSize int64) (*people.ListContactGroupsResponse, error) {
+			return &people.ListContactGroupsResponse{
+				ContactGroups: []*people.ContactGroup{
+					{
+						ResourceName: "contactGroups/123",
+						Name:         "Friends",
+						GroupType:    "USER_CONTACT_GROUP",
+						MemberCount:  5,
+					},
+					{
+						ResourceName: "contactGroups/456",
+						Name:         "Family",
+						GroupType:    "USER_CONTACT_GROUP",
+						MemberCount:  10,
+					},
+				},
+			}, nil
+		},
+	}
+
+	cmd := newGroupsCommand()
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "Friends")
+		assert.Contains(t, output, "Family")
+		assert.Contains(t, output, "2 contact group(s)")
+	})
+}
+
+func TestGroupsCommand_JSONOutput(t *testing.T) {
+	mock := &testutil.MockContactsClient{
+		ListContactGroupsFunc: func(pageToken string, pageSize int64) (*people.ListContactGroupsResponse, error) {
+			return &people.ListContactGroupsResponse{
+				ContactGroups: []*people.ContactGroup{
+					{
+						ResourceName: "contactGroups/123",
+						Name:         "Friends",
+						GroupType:    "USER_CONTACT_GROUP",
+						MemberCount:  5,
+					},
+				},
+			}, nil
+		},
+	}
+
+	cmd := newGroupsCommand()
+	cmd.SetArgs([]string{"--json"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		var groups []*contactsapi.ContactGroup
+		err := json.Unmarshal([]byte(output), &groups)
+		assert.NoError(t, err)
+		assert.Len(t, groups, 1)
+		assert.Equal(t, "Friends", groups[0].Name)
+	})
+}
+
+func TestGroupsCommand_Empty(t *testing.T) {
+	mock := &testutil.MockContactsClient{
+		ListContactGroupsFunc: func(pageToken string, pageSize int64) (*people.ListContactGroupsResponse, error) {
+			return &people.ListContactGroupsResponse{
+				ContactGroups: []*people.ContactGroup{},
+			}, nil
+		},
+	}
+
+	cmd := newGroupsCommand()
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "No contact groups found")
+	})
+}
+
+func TestGroupsCommand_APIError(t *testing.T) {
+	mock := &testutil.MockContactsClient{
+		ListContactGroupsFunc: func(pageToken string, pageSize int64) (*people.ListContactGroupsResponse, error) {
+			return nil, errors.New("API error")
+		},
+	}
+
+	cmd := newGroupsCommand()
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to list contact groups")
+	})
+}

--- a/internal/cmd/drive/handlers_test.go
+++ b/internal/cmd/drive/handlers_test.go
@@ -1,0 +1,512 @@
+package drive
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	driveapi "github.com/open-cli-collective/google-readonly/internal/drive"
+	"github.com/open-cli-collective/google-readonly/internal/testutil"
+)
+
+// captureOutput captures stdout during test execution
+func captureOutput(t *testing.T, f func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	f()
+
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+// withMockClient sets up a mock client factory for tests
+func withMockClient(mock driveapi.DriveClientInterface, f func()) {
+	originalFactory := ClientFactory
+	ClientFactory = func() (driveapi.DriveClientInterface, error) {
+		return mock, nil
+	}
+	defer func() { ClientFactory = originalFactory }()
+	f()
+}
+
+// withFailingClientFactory sets up a factory that returns an error
+func withFailingClientFactory(f func()) {
+	originalFactory := ClientFactory
+	ClientFactory = func() (driveapi.DriveClientInterface, error) {
+		return nil, errors.New("connection failed")
+	}
+	defer func() { ClientFactory = originalFactory }()
+	f()
+}
+
+func TestListCommand_Success(t *testing.T) {
+	mock := &testutil.MockDriveClient{
+		ListFilesFunc: func(query string, pageSize int64) ([]*driveapi.File, error) {
+			assert.Contains(t, query, "'root' in parents")
+			return testutil.SampleDriveFiles(2), nil
+		},
+	}
+
+	cmd := newListCommand()
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "file_a")
+		assert.Contains(t, output, "test-document.pdf")
+	})
+}
+
+func TestListCommand_JSONOutput(t *testing.T) {
+	mock := &testutil.MockDriveClient{
+		ListFilesFunc: func(query string, pageSize int64) ([]*driveapi.File, error) {
+			return testutil.SampleDriveFiles(1), nil
+		},
+	}
+
+	cmd := newListCommand()
+	cmd.SetArgs([]string{"--json"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		var files []*driveapi.File
+		err := json.Unmarshal([]byte(output), &files)
+		assert.NoError(t, err)
+		assert.Len(t, files, 1)
+	})
+}
+
+func TestListCommand_Empty(t *testing.T) {
+	mock := &testutil.MockDriveClient{
+		ListFilesFunc: func(query string, pageSize int64) ([]*driveapi.File, error) {
+			return []*driveapi.File{}, nil
+		},
+	}
+
+	cmd := newListCommand()
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "No files found")
+	})
+}
+
+func TestListCommand_WithFolder(t *testing.T) {
+	mock := &testutil.MockDriveClient{
+		ListFilesFunc: func(query string, pageSize int64) ([]*driveapi.File, error) {
+			assert.Contains(t, query, "'folder123' in parents")
+			return testutil.SampleDriveFiles(1), nil
+		},
+	}
+
+	cmd := newListCommand()
+	cmd.SetArgs([]string{"folder123"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "file_a")
+	})
+}
+
+func TestListCommand_WithTypeFilter(t *testing.T) {
+	mock := &testutil.MockDriveClient{
+		ListFilesFunc: func(query string, pageSize int64) ([]*driveapi.File, error) {
+			assert.Contains(t, query, "mimeType")
+			return testutil.SampleDriveFiles(1), nil
+		},
+	}
+
+	cmd := newListCommand()
+	cmd.SetArgs([]string{"--type", "document"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "file_a")
+	})
+}
+
+func TestListCommand_InvalidType(t *testing.T) {
+	cmd := newListCommand()
+	cmd.SetArgs([]string{"--type", "invalid"})
+
+	withMockClient(&testutil.MockDriveClient{}, func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown file type")
+	})
+}
+
+func TestListCommand_APIError(t *testing.T) {
+	mock := &testutil.MockDriveClient{
+		ListFilesFunc: func(query string, pageSize int64) ([]*driveapi.File, error) {
+			return nil, errors.New("API error")
+		},
+	}
+
+	cmd := newListCommand()
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to list files")
+	})
+}
+
+func TestListCommand_ClientCreationError(t *testing.T) {
+	cmd := newListCommand()
+
+	withFailingClientFactory(func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create Drive client")
+	})
+}
+
+func TestSearchCommand_Success(t *testing.T) {
+	mock := &testutil.MockDriveClient{
+		ListFilesFunc: func(query string, pageSize int64) ([]*driveapi.File, error) {
+			assert.Contains(t, query, "fullText contains 'report'")
+			return testutil.SampleDriveFiles(2), nil
+		},
+	}
+
+	cmd := newSearchCommand()
+	cmd.SetArgs([]string{"report"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "file_a")
+		assert.Contains(t, output, "2 file(s)")
+	})
+}
+
+func TestSearchCommand_NameOnly(t *testing.T) {
+	mock := &testutil.MockDriveClient{
+		ListFilesFunc: func(query string, pageSize int64) ([]*driveapi.File, error) {
+			assert.Contains(t, query, "name contains 'budget'")
+			return testutil.SampleDriveFiles(1), nil
+		},
+	}
+
+	cmd := newSearchCommand()
+	cmd.SetArgs([]string{"budget", "--name"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "file_a")
+	})
+}
+
+func TestSearchCommand_JSONOutput(t *testing.T) {
+	mock := &testutil.MockDriveClient{
+		ListFilesFunc: func(query string, pageSize int64) ([]*driveapi.File, error) {
+			return testutil.SampleDriveFiles(1), nil
+		},
+	}
+
+	cmd := newSearchCommand()
+	cmd.SetArgs([]string{"test", "--json"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		var files []*driveapi.File
+		err := json.Unmarshal([]byte(output), &files)
+		assert.NoError(t, err)
+		assert.Len(t, files, 1)
+	})
+}
+
+func TestSearchCommand_NoResults(t *testing.T) {
+	mock := &testutil.MockDriveClient{
+		ListFilesFunc: func(query string, pageSize int64) ([]*driveapi.File, error) {
+			return []*driveapi.File{}, nil
+		},
+	}
+
+	cmd := newSearchCommand()
+	cmd.SetArgs([]string{"nonexistent"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "No files found")
+	})
+}
+
+func TestSearchCommand_APIError(t *testing.T) {
+	mock := &testutil.MockDriveClient{
+		ListFilesFunc: func(query string, pageSize int64) ([]*driveapi.File, error) {
+			return nil, errors.New("API error")
+		},
+	}
+
+	cmd := newSearchCommand()
+	cmd.SetArgs([]string{"test"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to search files")
+	})
+}
+
+func TestGetCommand_Success(t *testing.T) {
+	mock := &testutil.MockDriveClient{
+		GetFileFunc: func(fileID string) (*driveapi.File, error) {
+			assert.Equal(t, "file123", fileID)
+			return testutil.SampleDriveFile("file123"), nil
+		},
+	}
+
+	cmd := newGetCommand()
+	cmd.SetArgs([]string{"file123"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "file123")
+		assert.Contains(t, output, "test-document.pdf")
+		assert.Contains(t, output, "owner@example.com")
+	})
+}
+
+func TestGetCommand_JSONOutput(t *testing.T) {
+	mock := &testutil.MockDriveClient{
+		GetFileFunc: func(fileID string) (*driveapi.File, error) {
+			return testutil.SampleDriveFile("file123"), nil
+		},
+	}
+
+	cmd := newGetCommand()
+	cmd.SetArgs([]string{"file123", "--json"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		var file driveapi.File
+		err := json.Unmarshal([]byte(output), &file)
+		assert.NoError(t, err)
+		assert.Equal(t, "file123", file.ID)
+	})
+}
+
+func TestGetCommand_NotFound(t *testing.T) {
+	mock := &testutil.MockDriveClient{
+		GetFileFunc: func(fileID string) (*driveapi.File, error) {
+			return nil, errors.New("file not found")
+		},
+	}
+
+	cmd := newGetCommand()
+	cmd.SetArgs([]string{"nonexistent"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get file")
+	})
+}
+
+func TestDownloadCommand_RegularFile(t *testing.T) {
+	// Create a temp directory for download
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(origDir)
+
+	mock := &testutil.MockDriveClient{
+		GetFileFunc: func(fileID string) (*driveapi.File, error) {
+			return testutil.SampleDriveFile("file123"), nil
+		},
+		DownloadFileFunc: func(fileID string) ([]byte, error) {
+			assert.Equal(t, "file123", fileID)
+			return []byte("test content"), nil
+		},
+	}
+
+	cmd := newDownloadCommand()
+	cmd.SetArgs([]string{"file123"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "Downloading")
+		assert.Contains(t, output, "Saved to")
+	})
+}
+
+func TestDownloadCommand_ToStdout(t *testing.T) {
+	mock := &testutil.MockDriveClient{
+		GetFileFunc: func(fileID string) (*driveapi.File, error) {
+			return testutil.SampleDriveFile("file123"), nil
+		},
+		DownloadFileFunc: func(fileID string) ([]byte, error) {
+			return []byte("test content"), nil
+		},
+	}
+
+	cmd := newDownloadCommand()
+	cmd.SetArgs([]string{"file123", "--stdout"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Equal(t, "test content", output)
+	})
+}
+
+func TestDownloadCommand_GoogleDocRequiresFormat(t *testing.T) {
+	mock := &testutil.MockDriveClient{
+		GetFileFunc: func(fileID string) (*driveapi.File, error) {
+			return testutil.SampleGoogleDoc("doc123"), nil
+		},
+	}
+
+	cmd := newDownloadCommand()
+	cmd.SetArgs([]string{"doc123"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "requires --format flag")
+	})
+}
+
+func TestDownloadCommand_ExportGoogleDoc(t *testing.T) {
+	// Create a temp directory for download
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(origDir)
+
+	mock := &testutil.MockDriveClient{
+		GetFileFunc: func(fileID string) (*driveapi.File, error) {
+			return testutil.SampleGoogleDoc("doc123"), nil
+		},
+		ExportFileFunc: func(fileID, mimeType string) ([]byte, error) {
+			assert.Equal(t, "doc123", fileID)
+			assert.Contains(t, mimeType, "pdf")
+			return []byte("pdf content"), nil
+		},
+	}
+
+	cmd := newDownloadCommand()
+	cmd.SetArgs([]string{"doc123", "--format", "pdf"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "Exporting")
+		assert.Contains(t, output, "Saved to")
+	})
+}
+
+func TestDownloadCommand_RegularFileCannotUseFormat(t *testing.T) {
+	mock := &testutil.MockDriveClient{
+		GetFileFunc: func(fileID string) (*driveapi.File, error) {
+			return testutil.SampleDriveFile("file123"), nil
+		},
+	}
+
+	cmd := newDownloadCommand()
+	cmd.SetArgs([]string{"file123", "--format", "pdf"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "--format flag is only for Google Workspace files")
+	})
+}
+
+func TestDownloadCommand_APIError(t *testing.T) {
+	mock := &testutil.MockDriveClient{
+		GetFileFunc: func(fileID string) (*driveapi.File, error) {
+			return testutil.SampleDriveFile("file123"), nil
+		},
+		DownloadFileFunc: func(fileID string) ([]byte, error) {
+			return nil, errors.New("download failed")
+		},
+	}
+
+	cmd := newDownloadCommand()
+	cmd.SetArgs([]string{"file123", "--stdout"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to download file")
+	})
+}
+
+func TestDownloadCommand_ClientCreationError(t *testing.T) {
+	cmd := newDownloadCommand()
+	cmd.SetArgs([]string{"file123"})
+
+	withFailingClientFactory(func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create Drive client")
+	})
+}

--- a/internal/cmd/mail/handlers_test.go
+++ b/internal/cmd/mail/handlers_test.go
@@ -1,0 +1,401 @@
+package mail
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/gmail/v1"
+
+	gmailapi "github.com/open-cli-collective/google-readonly/internal/gmail"
+	"github.com/open-cli-collective/google-readonly/internal/testutil"
+)
+
+// captureOutput captures stdout during test execution
+func captureOutput(t *testing.T, f func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	f()
+
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+// withMockClient sets up a mock client factory for tests
+func withMockClient(mock gmailapi.GmailClientInterface, f func()) {
+	originalFactory := ClientFactory
+	ClientFactory = func() (gmailapi.GmailClientInterface, error) {
+		return mock, nil
+	}
+	defer func() { ClientFactory = originalFactory }()
+	f()
+}
+
+// withFailingClientFactory sets up a factory that returns an error
+func withFailingClientFactory(f func()) {
+	originalFactory := ClientFactory
+	ClientFactory = func() (gmailapi.GmailClientInterface, error) {
+		return nil, errors.New("connection failed")
+	}
+	defer func() { ClientFactory = originalFactory }()
+	f()
+}
+
+func TestSearchCommand_Success(t *testing.T) {
+	mock := &testutil.MockGmailClient{
+		SearchMessagesFunc: func(query string, maxResults int64) ([]*gmailapi.Message, int, error) {
+			assert.Equal(t, "is:unread", query)
+			assert.Equal(t, int64(10), maxResults)
+			return testutil.SampleMessages(2), 0, nil
+		},
+	}
+
+	cmd := newSearchCommand()
+	cmd.SetArgs([]string{"is:unread"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		// Verify output contains expected message data
+		assert.Contains(t, output, "ID: msg_a")
+		assert.Contains(t, output, "ID: msg_b")
+		assert.Contains(t, output, "Test Subject")
+	})
+}
+
+func TestSearchCommand_JSONOutput(t *testing.T) {
+	mock := &testutil.MockGmailClient{
+		SearchMessagesFunc: func(query string, maxResults int64) ([]*gmailapi.Message, int, error) {
+			return testutil.SampleMessages(1), 0, nil
+		},
+	}
+
+	cmd := newSearchCommand()
+	cmd.SetArgs([]string{"is:unread", "--json"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		// Verify JSON output is valid
+		var messages []*gmailapi.Message
+		err := json.Unmarshal([]byte(output), &messages)
+		assert.NoError(t, err)
+		assert.Len(t, messages, 1)
+		assert.Equal(t, "msg_a", messages[0].ID)
+	})
+}
+
+func TestSearchCommand_NoResults(t *testing.T) {
+	mock := &testutil.MockGmailClient{
+		SearchMessagesFunc: func(query string, maxResults int64) ([]*gmailapi.Message, int, error) {
+			return []*gmailapi.Message{}, 0, nil
+		},
+	}
+
+	cmd := newSearchCommand()
+	cmd.SetArgs([]string{"nonexistent"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "No messages found")
+	})
+}
+
+func TestSearchCommand_APIError(t *testing.T) {
+	mock := &testutil.MockGmailClient{
+		SearchMessagesFunc: func(query string, maxResults int64) ([]*gmailapi.Message, int, error) {
+			return nil, 0, errors.New("API quota exceeded")
+		},
+	}
+
+	cmd := newSearchCommand()
+	cmd.SetArgs([]string{"is:unread"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to search messages")
+	})
+}
+
+func TestSearchCommand_ClientCreationError(t *testing.T) {
+	cmd := newSearchCommand()
+	cmd.SetArgs([]string{"is:unread"})
+
+	withFailingClientFactory(func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create Gmail client")
+	})
+}
+
+func TestSearchCommand_SkippedMessages(t *testing.T) {
+	mock := &testutil.MockGmailClient{
+		SearchMessagesFunc: func(query string, maxResults int64) ([]*gmailapi.Message, int, error) {
+			return testutil.SampleMessages(2), 3, nil // 3 messages skipped
+		},
+	}
+
+	cmd := newSearchCommand()
+	cmd.SetArgs([]string{"is:unread"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "3 message(s) could not be retrieved")
+	})
+}
+
+func TestReadCommand_Success(t *testing.T) {
+	mock := &testutil.MockGmailClient{
+		GetMessageFunc: func(messageID string, includeBody bool) (*gmailapi.Message, error) {
+			assert.Equal(t, "msg123", messageID)
+			assert.True(t, includeBody)
+			return testutil.SampleMessage("msg123"), nil
+		},
+	}
+
+	cmd := newReadCommand()
+	cmd.SetArgs([]string{"msg123"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "ID: msg123")
+		assert.Contains(t, output, "Test Subject")
+		assert.Contains(t, output, "--- Body ---")
+	})
+}
+
+func TestReadCommand_JSONOutput(t *testing.T) {
+	mock := &testutil.MockGmailClient{
+		GetMessageFunc: func(messageID string, includeBody bool) (*gmailapi.Message, error) {
+			return testutil.SampleMessage("msg123"), nil
+		},
+	}
+
+	cmd := newReadCommand()
+	cmd.SetArgs([]string{"msg123", "--json"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		var msg gmailapi.Message
+		err := json.Unmarshal([]byte(output), &msg)
+		assert.NoError(t, err)
+		assert.Equal(t, "msg123", msg.ID)
+	})
+}
+
+func TestReadCommand_NotFound(t *testing.T) {
+	mock := &testutil.MockGmailClient{
+		GetMessageFunc: func(messageID string, includeBody bool) (*gmailapi.Message, error) {
+			return nil, errors.New("message not found")
+		},
+	}
+
+	cmd := newReadCommand()
+	cmd.SetArgs([]string{"nonexistent"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read message")
+	})
+}
+
+func TestThreadCommand_Success(t *testing.T) {
+	mock := &testutil.MockGmailClient{
+		GetThreadFunc: func(id string) ([]*gmailapi.Message, error) {
+			assert.Equal(t, "thread123", id)
+			return testutil.SampleMessages(3), nil
+		},
+	}
+
+	cmd := newThreadCommand()
+	cmd.SetArgs([]string{"thread123"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "Thread contains 3 message(s)")
+		assert.Contains(t, output, "Message 1 of 3")
+		assert.Contains(t, output, "Message 2 of 3")
+		assert.Contains(t, output, "Message 3 of 3")
+	})
+}
+
+func TestThreadCommand_JSONOutput(t *testing.T) {
+	mock := &testutil.MockGmailClient{
+		GetThreadFunc: func(id string) ([]*gmailapi.Message, error) {
+			return testutil.SampleMessages(2), nil
+		},
+	}
+
+	cmd := newThreadCommand()
+	cmd.SetArgs([]string{"thread123", "--json"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		var messages []*gmailapi.Message
+		err := json.Unmarshal([]byte(output), &messages)
+		assert.NoError(t, err)
+		assert.Len(t, messages, 2)
+	})
+}
+
+func TestLabelsCommand_Success(t *testing.T) {
+	mock := &testutil.MockGmailClient{
+		FetchLabelsFunc: func() error {
+			return nil
+		},
+		GetLabelsFunc: func() []*gmail.Label {
+			return testutil.SampleLabels()
+		},
+	}
+
+	cmd := newLabelsCommand()
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "NAME")
+		assert.Contains(t, output, "TYPE")
+		assert.Contains(t, output, "Work")
+		assert.Contains(t, output, "user")
+	})
+}
+
+func TestLabelsCommand_JSONOutput(t *testing.T) {
+	mock := &testutil.MockGmailClient{
+		FetchLabelsFunc: func() error {
+			return nil
+		},
+		GetLabelsFunc: func() []*gmail.Label {
+			return testutil.SampleLabels()
+		},
+	}
+
+	cmd := newLabelsCommand()
+	cmd.SetArgs([]string{"--json"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		var labels []Label
+		err := json.Unmarshal([]byte(output), &labels)
+		assert.NoError(t, err)
+		assert.Greater(t, len(labels), 0)
+	})
+}
+
+func TestLabelsCommand_Empty(t *testing.T) {
+	mock := &testutil.MockGmailClient{
+		FetchLabelsFunc: func() error {
+			return nil
+		},
+		GetLabelsFunc: func() []*gmail.Label {
+			return []*gmail.Label{}
+		},
+	}
+
+	cmd := newLabelsCommand()
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "No labels found")
+	})
+}
+
+func TestListAttachmentsCommand_Success(t *testing.T) {
+	mock := &testutil.MockGmailClient{
+		GetAttachmentsFunc: func(messageID string) ([]*gmailapi.Attachment, error) {
+			return []*gmailapi.Attachment{
+				testutil.SampleAttachment("report.pdf"),
+				testutil.SampleAttachment("data.xlsx"),
+			}, nil
+		},
+	}
+
+	cmd := newListAttachmentsCommand()
+	cmd.SetArgs([]string{"msg123"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "2 attachment(s)")
+		assert.Contains(t, output, "report.pdf")
+		assert.Contains(t, output, "data.xlsx")
+	})
+}
+
+func TestListAttachmentsCommand_NoAttachments(t *testing.T) {
+	mock := &testutil.MockGmailClient{
+		GetAttachmentsFunc: func(messageID string) ([]*gmailapi.Attachment, error) {
+			return []*gmailapi.Attachment{}, nil
+		},
+	}
+
+	cmd := newListAttachmentsCommand()
+	cmd.SetArgs([]string{"msg123"})
+
+	withMockClient(mock, func() {
+		output := captureOutput(t, func() {
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "No attachments found")
+	})
+}

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -1,0 +1,240 @@
+package testutil
+
+import (
+	"time"
+
+	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/gmail/v1"
+	"google.golang.org/api/people/v1"
+
+	calendarapi "github.com/open-cli-collective/google-readonly/internal/calendar"
+	contactsapi "github.com/open-cli-collective/google-readonly/internal/contacts"
+	driveapi "github.com/open-cli-collective/google-readonly/internal/drive"
+	gmailapi "github.com/open-cli-collective/google-readonly/internal/gmail"
+)
+
+// Gmail fixtures
+
+// SampleMessage returns a sample Gmail message for testing
+func SampleMessage(id string) *gmailapi.Message {
+	return &gmailapi.Message{
+		ID:       id,
+		ThreadID: "thread_" + id,
+		Subject:  "Test Subject",
+		From:     "sender@example.com",
+		To:       "recipient@example.com",
+		Date:     "Mon, 1 Jan 2024 12:00:00 -0800",
+		Snippet:  "This is a test message snippet...",
+		Body:     "This is the full body of the test message.",
+		Labels:   []string{"INBOX", "UNREAD"},
+	}
+}
+
+// SampleMessages returns a slice of sample messages
+func SampleMessages(count int) []*gmailapi.Message {
+	messages := make([]*gmailapi.Message, count)
+	for i := 0; i < count; i++ {
+		messages[i] = SampleMessage("msg_" + string(rune('a'+i)))
+	}
+	return messages
+}
+
+// SampleAttachment returns a sample attachment for testing
+func SampleAttachment(filename string) *gmailapi.Attachment {
+	return &gmailapi.Attachment{
+		Filename:     filename,
+		MimeType:     "application/pdf",
+		Size:         1024,
+		AttachmentID: "att_123",
+		PartID:       "1",
+		IsInline:     false,
+	}
+}
+
+// SampleLabels returns sample Gmail labels for testing
+func SampleLabels() []*gmail.Label {
+	return []*gmail.Label{
+		{Id: "INBOX", Name: "INBOX", Type: "system", MessagesTotal: 100, MessagesUnread: 5},
+		{Id: "SENT", Name: "SENT", Type: "system", MessagesTotal: 50, MessagesUnread: 0},
+		{Id: "Label_1", Name: "Work", Type: "user", MessagesTotal: 20, MessagesUnread: 2},
+		{Id: "Label_2", Name: "Personal", Type: "user", MessagesTotal: 10, MessagesUnread: 1},
+		{Id: "CATEGORY_SOCIAL", Name: "Social", Type: "system", MessagesTotal: 30, MessagesUnread: 10},
+	}
+}
+
+// SampleProfile returns a sample Gmail profile for testing
+func SampleProfile() *gmailapi.Profile {
+	return &gmailapi.Profile{
+		EmailAddress:  "user@example.com",
+		MessagesTotal: 1000,
+		ThreadsTotal:  500,
+	}
+}
+
+// Calendar fixtures
+
+// SampleCalendar returns a sample calendar for testing
+func SampleCalendar(id string, primary bool) *calendar.CalendarListEntry {
+	return &calendar.CalendarListEntry{
+		Id:          id,
+		Summary:     "Test Calendar",
+		Description: "A test calendar",
+		Primary:     primary,
+		AccessRole:  "owner",
+		TimeZone:    "America/Los_Angeles",
+	}
+}
+
+// SampleCalendars returns sample calendars for testing
+func SampleCalendars() []*calendar.CalendarListEntry {
+	return []*calendar.CalendarListEntry{
+		SampleCalendar("primary@example.com", true),
+		SampleCalendar("work@example.com", false),
+	}
+}
+
+// SampleEvent returns a sample calendar event for testing
+func SampleEvent(id string) *calendar.Event {
+	return &calendar.Event{
+		Id:      id,
+		Summary: "Test Meeting",
+		Start: &calendar.EventDateTime{
+			DateTime: "2024-01-15T10:00:00-08:00",
+			TimeZone: "America/Los_Angeles",
+		},
+		End: &calendar.EventDateTime{
+			DateTime: "2024-01-15T11:00:00-08:00",
+			TimeZone: "America/Los_Angeles",
+		},
+		Location:    "Conference Room A",
+		Description: "Discuss project progress",
+		Organizer: &calendar.EventOrganizer{
+			Email:       "organizer@example.com",
+			DisplayName: "Meeting Organizer",
+		},
+		Attendees: []*calendar.EventAttendee{
+			{Email: "alice@example.com", DisplayName: "Alice", ResponseStatus: "accepted"},
+			{Email: "bob@example.com", DisplayName: "Bob", ResponseStatus: "tentative"},
+		},
+	}
+}
+
+// SampleParsedEvent returns a parsed calendar event for testing
+func SampleParsedEvent(id string) *calendarapi.Event {
+	return &calendarapi.Event{
+		ID:      id,
+		Summary: "Test Meeting",
+		Start: &calendarapi.EventTime{
+			DateTime: "2024-01-15T10:00:00-08:00",
+			TimeZone: "America/Los_Angeles",
+		},
+		End: &calendarapi.EventTime{
+			DateTime: "2024-01-15T11:00:00-08:00",
+			TimeZone: "America/Los_Angeles",
+		},
+		AllDay:      false,
+		Location:    "Conference Room A",
+		Description: "Discuss project progress",
+		Organizer: &calendarapi.Person{
+			Email:       "organizer@example.com",
+			DisplayName: "Meeting Organizer",
+		},
+		Attendees: []calendarapi.Person{
+			{Email: "alice@example.com", DisplayName: "Alice", Status: "accepted"},
+			{Email: "bob@example.com", DisplayName: "Bob", Status: "tentative"},
+		},
+	}
+}
+
+// Contacts fixtures
+
+// SamplePerson returns a sample Google People API Person for testing
+func SamplePerson(resourceName string) *people.Person {
+	return &people.Person{
+		ResourceName: resourceName,
+		Names: []*people.Name{
+			{DisplayName: "John Doe", GivenName: "John", FamilyName: "Doe"},
+		},
+		EmailAddresses: []*people.EmailAddress{
+			{Value: "john@example.com", Type: "work"},
+		},
+		PhoneNumbers: []*people.PhoneNumber{
+			{Value: "+1-555-123-4567", Type: "mobile"},
+		},
+		Organizations: []*people.Organization{
+			{Name: "Acme Corp", Title: "Engineer"},
+		},
+	}
+}
+
+// SampleContact returns a parsed contact for testing
+func SampleContact(resourceName string) *contactsapi.Contact {
+	return &contactsapi.Contact{
+		ResourceName: resourceName,
+		Names: []contactsapi.Name{
+			{DisplayName: "John Doe", GivenName: "John", FamilyName: "Doe"},
+		},
+		Emails: []contactsapi.Email{
+			{Value: "john@example.com", Type: "work", Primary: true},
+		},
+		Phones: []contactsapi.Phone{
+			{Value: "+1-555-123-4567", Type: "mobile"},
+		},
+		Organizations: []contactsapi.Organization{
+			{Name: "Acme Corp", Title: "Engineer"},
+		},
+	}
+}
+
+// SampleContactGroup returns a sample contact group for testing
+func SampleContactGroup(resourceName string) *contactsapi.ContactGroup {
+	return &contactsapi.ContactGroup{
+		ResourceName: resourceName,
+		Name:         "Friends",
+		GroupType:    "USER_CONTACT_GROUP",
+		MemberCount:  5,
+	}
+}
+
+// Drive fixtures
+
+// SampleDriveFile returns a sample Drive file for testing
+func SampleDriveFile(id string) *driveapi.File {
+	return &driveapi.File{
+		ID:           id,
+		Name:         "test-document.pdf",
+		MimeType:     "application/pdf",
+		Size:         2048,
+		CreatedTime:  time.Date(2024, 1, 10, 9, 0, 0, 0, time.UTC),
+		ModifiedTime: time.Date(2024, 1, 15, 14, 30, 0, 0, time.UTC),
+		Parents:      []string{"root"},
+		Owners:       []string{"owner@example.com"},
+		WebViewLink:  "https://drive.google.com/file/d/" + id,
+		Shared:       false,
+	}
+}
+
+// SampleDriveFiles returns sample Drive files for testing
+func SampleDriveFiles(count int) []*driveapi.File {
+	files := make([]*driveapi.File, count)
+	for i := 0; i < count; i++ {
+		files[i] = SampleDriveFile("file_" + string(rune('a'+i)))
+	}
+	return files
+}
+
+// SampleGoogleDoc returns a Google Doc file for testing export scenarios
+func SampleGoogleDoc(id string) *driveapi.File {
+	return &driveapi.File{
+		ID:           id,
+		Name:         "My Document",
+		MimeType:     driveapi.MimeTypeDocument,
+		Size:         0, // Google Docs don't have size
+		CreatedTime:  time.Date(2024, 1, 10, 9, 0, 0, 0, time.UTC),
+		ModifiedTime: time.Date(2024, 1, 15, 14, 30, 0, 0, time.UTC),
+		Parents:      []string{"root"},
+		Owners:       []string{"owner@example.com"},
+		WebViewLink:  "https://docs.google.com/document/d/" + id,
+		Shared:       false,
+	}
+}

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -1,0 +1,211 @@
+// Package testutil provides test utilities including mock implementations
+// of client interfaces for unit testing command handlers.
+package testutil
+
+import (
+	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/gmail/v1"
+	"google.golang.org/api/people/v1"
+
+	calendarapi "github.com/open-cli-collective/google-readonly/internal/calendar"
+	contactsapi "github.com/open-cli-collective/google-readonly/internal/contacts"
+	driveapi "github.com/open-cli-collective/google-readonly/internal/drive"
+	gmailapi "github.com/open-cli-collective/google-readonly/internal/gmail"
+)
+
+// MockGmailClient is a configurable mock for GmailClientInterface.
+// Set the function fields to control behavior in tests.
+type MockGmailClient struct {
+	GetMessageFunc               func(messageID string, includeBody bool) (*gmailapi.Message, error)
+	SearchMessagesFunc           func(query string, maxResults int64) ([]*gmailapi.Message, int, error)
+	GetThreadFunc                func(id string) ([]*gmailapi.Message, error)
+	FetchLabelsFunc              func() error
+	GetLabelNameFunc             func(labelID string) string
+	GetLabelsFunc                func() []*gmail.Label
+	GetAttachmentsFunc           func(messageID string) ([]*gmailapi.Attachment, error)
+	DownloadAttachmentFunc       func(messageID, attachmentID string) ([]byte, error)
+	DownloadInlineAttachmentFunc func(messageID, partID string) ([]byte, error)
+	GetProfileFunc               func() (*gmailapi.Profile, error)
+}
+
+// Verify MockGmailClient implements GmailClientInterface
+var _ gmailapi.GmailClientInterface = (*MockGmailClient)(nil)
+
+func (m *MockGmailClient) GetMessage(messageID string, includeBody bool) (*gmailapi.Message, error) {
+	if m.GetMessageFunc != nil {
+		return m.GetMessageFunc(messageID, includeBody)
+	}
+	return nil, nil
+}
+
+func (m *MockGmailClient) SearchMessages(query string, maxResults int64) ([]*gmailapi.Message, int, error) {
+	if m.SearchMessagesFunc != nil {
+		return m.SearchMessagesFunc(query, maxResults)
+	}
+	return nil, 0, nil
+}
+
+func (m *MockGmailClient) GetThread(id string) ([]*gmailapi.Message, error) {
+	if m.GetThreadFunc != nil {
+		return m.GetThreadFunc(id)
+	}
+	return nil, nil
+}
+
+func (m *MockGmailClient) FetchLabels() error {
+	if m.FetchLabelsFunc != nil {
+		return m.FetchLabelsFunc()
+	}
+	return nil
+}
+
+func (m *MockGmailClient) GetLabelName(labelID string) string {
+	if m.GetLabelNameFunc != nil {
+		return m.GetLabelNameFunc(labelID)
+	}
+	return labelID
+}
+
+func (m *MockGmailClient) GetLabels() []*gmail.Label {
+	if m.GetLabelsFunc != nil {
+		return m.GetLabelsFunc()
+	}
+	return nil
+}
+
+func (m *MockGmailClient) GetAttachments(messageID string) ([]*gmailapi.Attachment, error) {
+	if m.GetAttachmentsFunc != nil {
+		return m.GetAttachmentsFunc(messageID)
+	}
+	return nil, nil
+}
+
+func (m *MockGmailClient) DownloadAttachment(messageID, attachmentID string) ([]byte, error) {
+	if m.DownloadAttachmentFunc != nil {
+		return m.DownloadAttachmentFunc(messageID, attachmentID)
+	}
+	return nil, nil
+}
+
+func (m *MockGmailClient) DownloadInlineAttachment(messageID, partID string) ([]byte, error) {
+	if m.DownloadInlineAttachmentFunc != nil {
+		return m.DownloadInlineAttachmentFunc(messageID, partID)
+	}
+	return nil, nil
+}
+
+func (m *MockGmailClient) GetProfile() (*gmailapi.Profile, error) {
+	if m.GetProfileFunc != nil {
+		return m.GetProfileFunc()
+	}
+	return nil, nil
+}
+
+// MockCalendarClient is a configurable mock for CalendarClientInterface.
+type MockCalendarClient struct {
+	ListCalendarsFunc func() ([]*calendar.CalendarListEntry, error)
+	ListEventsFunc    func(calendarID, timeMin, timeMax string, maxResults int64) ([]*calendar.Event, error)
+	GetEventFunc      func(calendarID, eventID string) (*calendar.Event, error)
+}
+
+// Verify MockCalendarClient implements CalendarClientInterface
+var _ calendarapi.CalendarClientInterface = (*MockCalendarClient)(nil)
+
+func (m *MockCalendarClient) ListCalendars() ([]*calendar.CalendarListEntry, error) {
+	if m.ListCalendarsFunc != nil {
+		return m.ListCalendarsFunc()
+	}
+	return nil, nil
+}
+
+func (m *MockCalendarClient) ListEvents(calendarID, timeMin, timeMax string, maxResults int64) ([]*calendar.Event, error) {
+	if m.ListEventsFunc != nil {
+		return m.ListEventsFunc(calendarID, timeMin, timeMax, maxResults)
+	}
+	return nil, nil
+}
+
+func (m *MockCalendarClient) GetEvent(calendarID, eventID string) (*calendar.Event, error) {
+	if m.GetEventFunc != nil {
+		return m.GetEventFunc(calendarID, eventID)
+	}
+	return nil, nil
+}
+
+// MockContactsClient is a configurable mock for ContactsClientInterface.
+type MockContactsClient struct {
+	ListContactsFunc      func(pageToken string, pageSize int64) (*people.ListConnectionsResponse, error)
+	SearchContactsFunc    func(query string, pageSize int64) (*people.SearchResponse, error)
+	GetContactFunc        func(resourceName string) (*people.Person, error)
+	ListContactGroupsFunc func(pageToken string, pageSize int64) (*people.ListContactGroupsResponse, error)
+}
+
+// Verify MockContactsClient implements ContactsClientInterface
+var _ contactsapi.ContactsClientInterface = (*MockContactsClient)(nil)
+
+func (m *MockContactsClient) ListContacts(pageToken string, pageSize int64) (*people.ListConnectionsResponse, error) {
+	if m.ListContactsFunc != nil {
+		return m.ListContactsFunc(pageToken, pageSize)
+	}
+	return nil, nil
+}
+
+func (m *MockContactsClient) SearchContacts(query string, pageSize int64) (*people.SearchResponse, error) {
+	if m.SearchContactsFunc != nil {
+		return m.SearchContactsFunc(query, pageSize)
+	}
+	return nil, nil
+}
+
+func (m *MockContactsClient) GetContact(resourceName string) (*people.Person, error) {
+	if m.GetContactFunc != nil {
+		return m.GetContactFunc(resourceName)
+	}
+	return nil, nil
+}
+
+func (m *MockContactsClient) ListContactGroups(pageToken string, pageSize int64) (*people.ListContactGroupsResponse, error) {
+	if m.ListContactGroupsFunc != nil {
+		return m.ListContactGroupsFunc(pageToken, pageSize)
+	}
+	return nil, nil
+}
+
+// MockDriveClient is a configurable mock for DriveClientInterface.
+type MockDriveClient struct {
+	ListFilesFunc    func(query string, pageSize int64) ([]*driveapi.File, error)
+	GetFileFunc      func(fileID string) (*driveapi.File, error)
+	DownloadFileFunc func(fileID string) ([]byte, error)
+	ExportFileFunc   func(fileID, mimeType string) ([]byte, error)
+}
+
+// Verify MockDriveClient implements DriveClientInterface
+var _ driveapi.DriveClientInterface = (*MockDriveClient)(nil)
+
+func (m *MockDriveClient) ListFiles(query string, pageSize int64) ([]*driveapi.File, error) {
+	if m.ListFilesFunc != nil {
+		return m.ListFilesFunc(query, pageSize)
+	}
+	return nil, nil
+}
+
+func (m *MockDriveClient) GetFile(fileID string) (*driveapi.File, error) {
+	if m.GetFileFunc != nil {
+		return m.GetFileFunc(fileID)
+	}
+	return nil, nil
+}
+
+func (m *MockDriveClient) DownloadFile(fileID string) ([]byte, error) {
+	if m.DownloadFileFunc != nil {
+		return m.DownloadFileFunc(fileID)
+	}
+	return nil, nil
+}
+
+func (m *MockDriveClient) ExportFile(fileID, mimeType string) ([]byte, error) {
+	if m.ExportFileFunc != nil {
+		return m.ExportFileFunc(fileID, mimeType)
+	}
+	return nil, nil
+}


### PR DESCRIPTION
## Summary

This PR implements Phase 6 of the codebase simplification plan, adding comprehensive unit test infrastructure for command handlers.

### Changes

**New test utilities (`internal/testutil/`)**
- `mocks.go`: Mock implementations for all client interfaces (Gmail, Calendar, Contacts, Drive) with configurable function fields for test control
- `fixtures.go`: Test data generators for sample messages, events, contacts, and files

**Handler tests**
- `internal/cmd/mail/handlers_test.go`: Tests for search, read, thread, labels, and list attachments commands
- `internal/cmd/calendar/handlers_test.go`: Tests for list, events, get, today, and week commands  
- `internal/cmd/contacts/handlers_test.go`: Tests for list, search, get, and groups commands
- `internal/cmd/drive/handlers_test.go`: Tests for list, search, get, and download commands

### Test patterns established

- `captureOutput` helper for capturing stdout during test execution
- `withMockClient` helper for injecting mock clients via ClientFactory
- `withFailingClientFactory` helper for testing client creation errors
- Comprehensive coverage: success paths, JSON output, empty results, API errors, and validation errors

### Note on Issue #51

Issue #51 (integration test infrastructure with recorded API responses) is documented but not implemented in this PR. The mock-based unit testing approach provides sufficient coverage for the current codebase. Integration tests with recorded responses can be added as needed for specific API compatibility concerns.

## Test plan
- [x] All existing tests pass (`make test`)
- [x] New handler tests pass for all command packages
- [x] Lint checks pass (`make lint`)

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)