### PR TITLE
Standardize branding to google-readonly across all platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,7 +210,7 @@ jobs:
         id: check-manifest
         shell: pwsh
         run: |
-          $response = Invoke-WebRequest -Uri "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/o/OpenCLICollective/gro" -Method Head -SkipHttpErrorCheck
+          $response = Invoke-WebRequest -Uri "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/o/OpenCLICollective/google-readonly" -Method Head -SkipHttpErrorCheck
           if ($response.StatusCode -eq 200) {
             Write-Host "Manifest exists - will use wingetcreate update"
             echo "exists=true" >> $env:GITHUB_OUTPUT
@@ -249,7 +249,7 @@ jobs:
           Write-Host "Updating existing manifest to version $version"
           Write-Host "x64 URL: $x64"
           Write-Host "arm64 URL: $arm64"
-          ./wingetcreate.exe update OpenCLICollective.gro --version $version --urls $x64 $arm64 --submit --token $env:WINGET_GITHUB_TOKEN
+          ./wingetcreate.exe update OpenCLICollective.google-readonly --version $version --urls $x64 $arm64 --submit --token $env:WINGET_GITHUB_TOKEN
 
       - name: Create manifest (new package)
         if: steps.check-manifest.outputs.exists == 'false'
@@ -262,23 +262,23 @@ jobs:
           New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
 
           # Update version manifest
-          $versionManifest = Get-Content "packaging/winget/OpenCLICollective.gro.yaml" -Raw
+          $versionManifest = Get-Content "packaging/winget/OpenCLICollective.google-readonly.yaml" -Raw
           $versionManifest = $versionManifest -replace "0\.0\.0", $version
-          Set-Content "$manifestDir/OpenCLICollective.gro.yaml" $versionManifest
+          Set-Content "$manifestDir/OpenCLICollective.google-readonly.yaml" $versionManifest
 
           # Update locale manifest
-          $localeManifest = Get-Content "packaging/winget/OpenCLICollective.gro.locale.en-US.yaml" -Raw
+          $localeManifest = Get-Content "packaging/winget/OpenCLICollective.google-readonly.locale.en-US.yaml" -Raw
           $localeManifest = $localeManifest -replace "0\.0\.0", $version
-          Set-Content "$manifestDir/OpenCLICollective.gro.locale.en-US.yaml" $localeManifest
+          Set-Content "$manifestDir/OpenCLICollective.google-readonly.locale.en-US.yaml" $localeManifest
 
           # Update installer manifest with version and real checksums
-          $installerManifest = Get-Content "packaging/winget/OpenCLICollective.gro.installer.yaml" -Raw
+          $installerManifest = Get-Content "packaging/winget/OpenCLICollective.google-readonly.installer.yaml" -Raw
           $installerManifest = $installerManifest -replace "0\.0\.0", $version
           # Use .NET regex for sequential replacement (PowerShell -replace doesn't support count)
           $regex = [regex]"0{64}"
           $installerManifest = $regex.Replace($installerManifest, $env:X64_HASH, 1)
           $installerManifest = $regex.Replace($installerManifest, $env:ARM64_HASH, 1)
-          Set-Content "$manifestDir/OpenCLICollective.gro.installer.yaml" $installerManifest
+          Set-Content "$manifestDir/OpenCLICollective.google-readonly.installer.yaml" $installerManifest
 
           Write-Host "Generated manifests:"
           Get-ChildItem $manifestDir | ForEach-Object { Write-Host "  $_" }
@@ -306,7 +306,7 @@ jobs:
           event-type: package-release
           client-payload: |-
             {
-              "package": "gro",
+              "package": "google-readonly",
               "version": "${{ github.ref_name }}",
               "repo": "open-cli-collective/google-readonly"
             }

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,8 +41,8 @@ archives:
 
 # Linux packages (.deb and .rpm)
 nfpms:
-  - id: gro
-    package_name: gro
+  - id: google-readonly
+    package_name: google-readonly
     vendor: Open CLI Collective
     homepage: https://github.com/open-cli-collective/google-readonly
     maintainer: Open CLI Collective <https://github.com/open-cli-collective>
@@ -54,7 +54,7 @@ nfpms:
     bindir: /usr/bin
     contents:
       - src: LICENSE
-        dst: /usr/share/licenses/gro/LICENSE
+        dst: /usr/share/licenses/google-readonly/LICENSE
 
 checksum:
   name_template: "checksums.txt"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gro
+# google-readonly
 
 A read-only command-line interface for Google services. Search, read, and view Gmail messages, threads, and attachments without any ability to modify, send, or delete data.
 
@@ -19,7 +19,7 @@ A read-only command-line interface for Google services. Search, read, and view G
 **Homebrew (recommended)**
 
 ```bash
-brew install open-cli-collective/tap/gro
+brew install open-cli-collective/tap/google-readonly
 ```
 
 > Note: This installs from our third-party tap.
@@ -37,7 +37,7 @@ choco install google-readonly
 **Winget**
 
 ```powershell
-winget install OpenCLICollective.gro
+winget install OpenCLICollective.google-readonly
 ```
 
 ---
@@ -55,7 +55,7 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/open-
 
 # Install
 sudo apt update
-sudo apt install gro
+sudo apt install google-readonly
 ```
 
 > Note: This is our third-party APT repository, not official Debian/Ubuntu repos.
@@ -74,7 +74,7 @@ gpgkey=https://open-cli-collective.github.io/linux-packages/keys/gpg.asc
 EOF
 
 # Install
-sudo dnf install gro
+sudo dnf install google-readonly
 ```
 
 > Note: This is our third-party RPM repository, not official Fedora/RHEL repos.

--- a/packaging/winget/OpenCLICollective.google-readonly.installer.yaml
+++ b/packaging/winget/OpenCLICollective.google-readonly.installer.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 
-PackageIdentifier: OpenCLICollective.gro
+PackageIdentifier: OpenCLICollective.google-readonly
 PackageVersion: 0.0.0
 InstallerType: zip
 NestedInstallerType: portable

--- a/packaging/winget/OpenCLICollective.google-readonly.locale.en-US.yaml
+++ b/packaging/winget/OpenCLICollective.google-readonly.locale.en-US.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
-PackageIdentifier: OpenCLICollective.gro
+PackageIdentifier: OpenCLICollective.google-readonly
 PackageVersion: 0.0.0
 PackageLocale: en-US
 Publisher: Open CLI Collective

--- a/packaging/winget/OpenCLICollective.google-readonly.yaml
+++ b/packaging/winget/OpenCLICollective.google-readonly.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 
-PackageIdentifier: OpenCLICollective.gro
+PackageIdentifier: OpenCLICollective.google-readonly
 PackageVersion: 0.0.0
 DefaultLocale: en-US
 ManifestType: version


### PR DESCRIPTION
## Summary

Standardizes the project branding to consistently use `google-readonly` as the package/project name across all distribution channels, while keeping the binary name as `gro` for invocation.

## Changes

| Platform | Before | After |
|----------|--------|-------|
| README title | `# gro` | `# google-readonly` |
| Homebrew | `brew install .../tap/gro` | `brew install .../tap/google-readonly` |
| Winget | `OpenCLICollective.gro` | `OpenCLICollective.google-readonly` |
| Linux DEB/RPM | `gro` | `google-readonly` |

## Files Changed

- **README.md**: Updated title and installation commands
- **.goreleaser.yaml**: Changed nfpms package name and license path
- **.github/workflows/release.yml**: Updated winget and linux-packages references
- **packaging/winget/**: Renamed manifest files and updated identifiers

## Notes

- Binary name remains `gro` everywhere (no user-facing invocation changes)
- Winget will require a new package submission since the identifier changed
- This is a branding/packaging change only, no functional changes

## Test plan

- [x] `make verify` passes
- [ ] Verify release workflow syntax is valid
- [ ] First release after merge will test actual package distribution

Closes #79