### PR TITLE
Add missing CI/CD workflows: test, manual publish, and snap support

### DIFF
--- a/.github/workflows/chocolatey-publish.yml
+++ b/.github/workflows/chocolatey-publish.yml
@@ -1,0 +1,75 @@
+name: Publish to Chocolatey
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 1.0.25)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate release exists
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $release = gh release view "v${{ inputs.version }}" --json tagName 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Release v${{ inputs.version }} not found"
+            exit 1
+          }
+          Write-Host "Found release v${{ inputs.version }}"
+
+      - name: Get checksums from release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "v${{ inputs.version }}" --pattern "checksums.txt" --dir .
+
+          $checksums = Get-Content checksums.txt
+          $x64Hash = ($checksums | Select-String "windows_amd64.zip").Line.Split()[0]
+          $arm64Hash = ($checksums | Select-String "windows_arm64.zip").Line.Split()[0]
+
+          Write-Host "x64 SHA256: $x64Hash"
+          Write-Host "arm64 SHA256: $arm64Hash"
+
+          echo "X64_HASH=$x64Hash" >> $env:GITHUB_ENV
+          echo "ARM64_HASH=$arm64Hash" >> $env:GITHUB_ENV
+
+      - name: Update version and checksums
+        shell: pwsh
+        run: |
+          $version = "${{ inputs.version }}"
+
+          # Update version in nuspec
+          $nuspec = 'packaging/chocolatey/google-readonly.nuspec'
+          (Get-Content $nuspec) -replace '<version>0.0.0</version>', "<version>$version</version>" | Set-Content $nuspec
+          Write-Host "Updated nuspec to version $version"
+
+          # Inject checksums into install script
+          $script = 'packaging/chocolatey/tools/chocolateyInstall.ps1'
+          $content = Get-Content $script -Raw
+          $content = $content -replace 'CHECKSUM_AMD64_PLACEHOLDER', $env:X64_HASH
+          $content = $content -replace 'CHECKSUM_ARM64_PLACEHOLDER', $env:ARM64_HASH
+          Set-Content $script $content
+          Write-Host "Injected checksums into install script"
+
+      - name: Pack Chocolatey package
+        shell: pwsh
+        run: |
+          cd packaging/chocolatey
+          choco pack
+          Get-ChildItem *.nupkg
+
+      - name: Push to Chocolatey
+        shell: pwsh
+        run: |
+          cd packaging/chocolatey
+          choco push (Get-ChildItem *.nupkg).Name --source https://push.chocolatey.org/ --key ${{ secrets.CHOCOLATEY_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,106 +36,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  update-homebrew:
-    needs: goreleaser
-    runs-on: ubuntu-latest
-    env:
-      TAG: ${{ github.ref_name || inputs.tag }}
-    steps:
-      - name: Download checksums from release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release download "${{ env.TAG }}" --repo ${{ github.repository }} --pattern "checksums.txt"
-          cat checksums.txt
-
-      - name: Parse checksums
-        id: checksums
-        run: |
-          VERSION="${{ env.TAG }}"
-          VERSION_NUM="${VERSION#v}"
-
-          # GoReleaser checksums.txt format: <hash>  <filename>
-          DARWIN_ARM64_SHA=$(grep "darwin_arm64.tar.gz" checksums.txt | cut -d' ' -f1)
-          DARWIN_AMD64_SHA=$(grep "darwin_amd64.tar.gz" checksums.txt | cut -d' ' -f1)
-          LINUX_ARM64_SHA=$(grep "linux_arm64.tar.gz" checksums.txt | cut -d' ' -f1)
-          LINUX_AMD64_SHA=$(grep "linux_amd64.tar.gz" checksums.txt | cut -d' ' -f1)
-
-          echo "version=${VERSION_NUM}" >> $GITHUB_OUTPUT
-          echo "darwin_arm64_sha=${DARWIN_ARM64_SHA}" >> $GITHUB_OUTPUT
-          echo "darwin_amd64_sha=${DARWIN_AMD64_SHA}" >> $GITHUB_OUTPUT
-          echo "linux_arm64_sha=${LINUX_ARM64_SHA}" >> $GITHUB_OUTPUT
-          echo "linux_amd64_sha=${LINUX_AMD64_SHA}" >> $GITHUB_OUTPUT
-
-      # TAP_GITHUB_TOKEN (a PAT) is required to push to the open-cli-collective/homebrew-tap
-      # repository. The default GITHUB_TOKEN only has access to this repository.
-      - name: Update Homebrew Cask
-        env:
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
-        run: |
-          VERSION="${{ steps.checksums.outputs.version }}"
-          DARWIN_ARM64_SHA="${{ steps.checksums.outputs.darwin_arm64_sha }}"
-          DARWIN_AMD64_SHA="${{ steps.checksums.outputs.darwin_amd64_sha }}"
-          LINUX_ARM64_SHA="${{ steps.checksums.outputs.linux_arm64_sha }}"
-          LINUX_AMD64_SHA="${{ steps.checksums.outputs.linux_amd64_sha }}"
-
-          git clone https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/open-cli-collective/homebrew-tap.git
-          cd homebrew-tap
-
-          mkdir -p Casks
-
-          cat > Casks/google-readonly.rb << CASKEOF
-          cask "google-readonly" do
-            name "google-readonly"
-            desc "Read-only command-line interface for Google services"
-            homepage "https://github.com/open-cli-collective/google-readonly"
-            version "${VERSION}"
-
-            binary "gro"
-
-            on_macos do
-              on_arm do
-                url "https://github.com/open-cli-collective/google-readonly/releases/download/v#{version}/gro_v#{version}_darwin_arm64.tar.gz"
-                sha256 "${DARWIN_ARM64_SHA}"
-              end
-              on_intel do
-                url "https://github.com/open-cli-collective/google-readonly/releases/download/v#{version}/gro_v#{version}_darwin_amd64.tar.gz"
-                sha256 "${DARWIN_AMD64_SHA}"
-              end
-            end
-
-            on_linux do
-              on_arm do
-                url "https://github.com/open-cli-collective/google-readonly/releases/download/v#{version}/gro_v#{version}_linux_arm64.tar.gz"
-                sha256 "${LINUX_ARM64_SHA}"
-              end
-              on_intel do
-                url "https://github.com/open-cli-collective/google-readonly/releases/download/v#{version}/gro_v#{version}_linux_amd64.tar.gz"
-                sha256 "${LINUX_AMD64_SHA}"
-              end
-            end
-
-            postflight do
-              system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/gro"]
-            end
-
-            caveats <<~EOS
-              To configure gro, run:
-                gro init
-
-              This will guide you through Google OAuth setup.
-              On macOS, your token is stored securely in the system Keychain.
-              On Linux with libsecret, your token is stored in the secret service.
-            EOS
-          end
-          CASKEOF
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "Update google-readonly to ${VERSION}"
-          git push
 
   chocolatey:
     needs: goreleaser
@@ -293,6 +194,30 @@ jobs:
 
           Write-Host "`nSubmitting new package to Winget..."
           ./wingetcreate.exe submit --token $env:WINGET_GITHUB_TOKEN $manifestDir
+
+  snap:
+    if: false  # Temporarily disabled - waiting for personal-files interface approval
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.ref_name || inputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG }}
+          fetch-depth: 0
+
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: build
+
+      - name: Publish to Snapcraft Store
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: stable
 
   linux-packages:
     needs: goreleaser

--- a/.github/workflows/test-chocolatey.yml
+++ b/.github/workflows/test-chocolatey.yml
@@ -1,0 +1,83 @@
+name: Test Chocolatey Package
+
+on:
+  pull_request:
+    paths:
+      - 'packaging/chocolatey/**'
+      - '.github/workflows/test-chocolatey.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packaging/chocolatey/**'
+      - '.github/workflows/test-chocolatey.yml'
+
+jobs:
+  test-chocolatey:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Build binary for testing
+        run: go build -o packaging/chocolatey/tools/gro.exe ./cmd/gro
+
+      - name: Prepare test package
+        shell: pwsh
+        working-directory: packaging/chocolatey
+        run: |
+          # Replace placeholder version with test version (must not be prerelease)
+          (Get-Content google-readonly.nuspec) `
+            -replace '<version>0.0.0</version>', '<version>0.0.1</version>' |
+            Set-Content google-readonly.nuspec
+
+          # Create a simple install script that uses the local binary
+          # (the real script downloads from GitHub, but we test structure here)
+          @'
+          $ErrorActionPreference = 'Stop'
+          $toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+
+          # Binary is already in tools/ from CI build
+          Write-Host "google-readonly installed from local build for testing"
+
+          # Exclude non-executables from shimming
+          New-Item "$toolsDir\LICENSE.ignore" -Type File -Force | Out-Null
+          New-Item "$toolsDir\README.md.ignore" -Type File -Force | Out-Null
+          '@ | Set-Content tools/chocolateyInstall.ps1
+
+      - name: Pack Chocolatey package
+        shell: pwsh
+        working-directory: packaging/chocolatey
+        run: choco pack
+
+      - name: Install package locally
+        shell: pwsh
+        working-directory: packaging/chocolatey
+        run: choco install google-readonly -dv -s . --force
+
+      - name: Verify installation
+        shell: pwsh
+        run: |
+          Write-Host "Testing gro --version..."
+          gro --version
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "gro --version failed"
+            exit 1
+          }
+          Write-Host "gro is working!"
+
+      - name: Test uninstall
+        shell: pwsh
+        run: |
+          choco uninstall google-readonly -y
+
+          # Verify gro is no longer available
+          $groPath = Get-Command gro -ErrorAction SilentlyContinue
+          if ($groPath) {
+            Write-Error "gro should not be available after uninstall"
+            exit 1
+          }
+          Write-Host "Uninstall successful!"

--- a/.github/workflows/test-winget.yml
+++ b/.github/workflows/test-winget.yml
@@ -1,0 +1,60 @@
+name: Test Winget Manifest
+
+on:
+  pull_request:
+    paths:
+      - 'packaging/winget/**'
+      - '.github/workflows/test-winget.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packaging/winget/**'
+      - '.github/workflows/test-winget.yml'
+
+jobs:
+  validate-winget:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate manifest schema
+        shell: pwsh
+        run: |
+          $testDir = "winget-validate-test"
+          $testVersion = "0.0.1"
+          $testHash1 = "0000000000000000000000000000000000000000000000000000000000000001"
+          $testHash2 = "0000000000000000000000000000000000000000000000000000000000000002"
+
+          New-Item -ItemType Directory -Path $testDir -Force | Out-Null
+
+          # Read actual templates and substitute placeholders for validation
+          Write-Host "Reading and processing actual template files..."
+
+          # Version manifest
+          $content = Get-Content "packaging/winget/OpenCLICollective.google-readonly.yaml" -Raw
+          $content = $content -replace "0\.0\.0", $testVersion
+          Set-Content "$testDir/OpenCLICollective.google-readonly.yaml" $content -Encoding UTF8
+
+          # Locale manifest
+          $content = Get-Content "packaging/winget/OpenCLICollective.google-readonly.locale.en-US.yaml" -Raw
+          $content = $content -replace "0\.0\.0", $testVersion
+          Set-Content "$testDir/OpenCLICollective.google-readonly.locale.en-US.yaml" $content -Encoding UTF8
+
+          # Installer manifest (substitute version and checksums)
+          $content = Get-Content "packaging/winget/OpenCLICollective.google-readonly.installer.yaml" -Raw
+          $content = $content -replace "0\.0\.0", $testVersion
+          $regex = [regex]"0{64}"
+          $content = $regex.Replace($content, $testHash1, 1)
+          $content = $regex.Replace($content, $testHash2, 1)
+          Set-Content "$testDir/OpenCLICollective.google-readonly.installer.yaml" $content -Encoding UTF8
+
+          Write-Host "Generated test manifests:"
+          Get-ChildItem $testDir | ForEach-Object { Write-Host "  $_" }
+
+          Write-Host "`nValidating winget manifest schema..."
+          winget validate --manifest $testDir/
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Manifest schema validation failed"
+            exit 1
+          }
+          Write-Host "Manifest schema validation passed!"

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,0 +1,115 @@
+name: Publish to Winget
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 1.0.25)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install wingetcreate
+        shell: pwsh
+        run: |
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+
+      - name: Validate release exists
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $release = gh release view "v${{ inputs.version }}" --repo open-cli-collective/google-readonly --json tagName 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Release v${{ inputs.version }} not found"
+            exit 1
+          }
+          Write-Host "Found release v${{ inputs.version }}"
+
+      - name: Check if manifest exists in winget-pkgs
+        id: check-manifest
+        shell: pwsh
+        run: |
+          $response = Invoke-WebRequest -Uri "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/o/OpenCLICollective/google-readonly" -Method Head -SkipHttpErrorCheck
+          if ($response.StatusCode -eq 200) {
+            Write-Host "Manifest exists - will use wingetcreate update"
+            echo "exists=true" >> $env:GITHUB_OUTPUT
+          } else {
+            Write-Host "Manifest does not exist - will use wingetcreate new"
+            echo "exists=false" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Get checksums from release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $version = "${{ inputs.version }}"
+          gh release download "v$version" --repo open-cli-collective/google-readonly --pattern "checksums.txt" --dir .
+
+          $checksums = Get-Content checksums.txt
+          $x64Hash = ($checksums | Select-String "windows_amd64.zip").Line.Split()[0]
+          $arm64Hash = ($checksums | Select-String "windows_arm64.zip").Line.Split()[0]
+
+          Write-Host "x64 SHA256: $x64Hash"
+          Write-Host "arm64 SHA256: $arm64Hash"
+
+          echo "X64_HASH=$x64Hash" >> $env:GITHUB_ENV
+          echo "ARM64_HASH=$arm64Hash" >> $env:GITHUB_ENV
+
+      - name: Update manifest (existing package)
+        if: steps.check-manifest.outputs.exists == 'true'
+        shell: pwsh
+        run: |
+          $version = "${{ inputs.version }}"
+          $x64 = "https://github.com/open-cli-collective/google-readonly/releases/download/v$version/gro_v${version}_windows_amd64.zip"
+          $arm64 = "https://github.com/open-cli-collective/google-readonly/releases/download/v$version/gro_v${version}_windows_arm64.zip"
+
+          Write-Host "Updating existing manifest to version $version"
+          ./wingetcreate.exe update OpenCLICollective.google-readonly --version $version --urls $x64 $arm64 --submit --token ${{ secrets.WINGET_GITHUB_TOKEN }}
+
+      - name: Create manifest (new package)
+        if: steps.check-manifest.outputs.exists == 'false'
+        shell: pwsh
+        run: |
+          $version = "${{ inputs.version }}"
+          $manifestDir = "manifests"
+          New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+
+          # Update version manifest
+          $versionManifest = Get-Content "packaging/winget/OpenCLICollective.google-readonly.yaml" -Raw
+          $versionManifest = $versionManifest -replace "0\.0\.0", $version
+          Set-Content "$manifestDir/OpenCLICollective.google-readonly.yaml" $versionManifest
+
+          # Update locale manifest
+          $localeManifest = Get-Content "packaging/winget/OpenCLICollective.google-readonly.locale.en-US.yaml" -Raw
+          $localeManifest = $localeManifest -replace "0\.0\.0", $version
+          Set-Content "$manifestDir/OpenCLICollective.google-readonly.locale.en-US.yaml" $localeManifest
+
+          # Update installer manifest with version and real checksums
+          $installerManifest = Get-Content "packaging/winget/OpenCLICollective.google-readonly.installer.yaml" -Raw
+          $installerManifest = $installerManifest -replace "0\.0\.0", $version
+          # Replace checksums one at a time using .NET regex (PowerShell -replace doesn't support count)
+          $regex = [regex]"0{64}"
+          $installerManifest = $regex.Replace($installerManifest, $env:X64_HASH, 1)
+          $installerManifest = $regex.Replace($installerManifest, $env:ARM64_HASH, 1)
+          Set-Content "$manifestDir/OpenCLICollective.google-readonly.installer.yaml" $installerManifest
+
+          Write-Host "Generated manifests:"
+          Get-ChildItem $manifestDir | ForEach-Object { Write-Host "  $_" }
+
+          Write-Host "`nValidating manifests..."
+          winget validate --manifest $manifestDir
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Manifest validation failed"
+            exit 1
+          }
+          Write-Host "Validation passed!"
+
+          Write-Host "`nSubmitting new package to Winget..."
+          ./wingetcreate.exe submit --token ${{ secrets.WINGET_GITHUB_TOKEN }} $manifestDir

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,6 +56,24 @@ nfpms:
       - src: LICENSE
         dst: /usr/share/licenses/google-readonly/LICENSE
 
+# Homebrew cask with auto-quarantine removal for unsigned binaries
+homebrew_casks:
+  - name: google-readonly
+    repository:
+      owner: open-cli-collective
+      name: homebrew-tap
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    homepage: https://github.com/open-cli-collective/google-readonly
+    description: "Read-only command-line interface for Google services"
+    binary: gro
+    hooks:
+      post:
+        install: |
+          system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/gro"]
+    caveats: |
+      gro has been installed. Run 'gro init' to configure.
+      On macOS, your token is stored securely in the system Keychain.
+
 checksum:
   name_template: "checksums.txt"
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,61 @@
+name: ocli-google-readonly
+base: core22
+version: git
+summary: Read-only command-line interface for Google services
+description: |
+  gro is a read-only CLI for accessing Google services.
+
+  Features:
+  - Gmail: Search, read, view threads, download attachments
+  - Google Calendar: List calendars, view events, today/week shortcuts
+  - Google Contacts: List, search, view details
+  - Google Drive: List, search, download files
+
+  Run 'gro init' to configure your Google API credentials.
+
+grade: stable
+confinement: strict
+
+architectures:
+  - build-on: amd64
+  - build-on: arm64
+
+plugs:
+  dot-config-google-readonly:
+    interface: personal-files
+    read:
+      - $HOME/.config/google-readonly
+    write:
+      - $HOME/.config/google-readonly
+
+apps:
+  ocli-google-readonly:
+    command: bin/gro
+    plugs:
+      - home
+      - network
+      - dot-config-google-readonly
+    aliases:
+      - gro
+
+parts:
+  gro:
+    plugin: go
+    source: .
+    build-snaps:
+      - go/1.24/stable
+    build-environment:
+      - CGO_ENABLED: "0"
+    override-build: |
+      # Get version from git
+      VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+      COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+      DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+      # Build with ldflags
+      go build -o $SNAPCRAFT_PART_INSTALL/bin/gro \
+        -ldflags "-s -w \
+          -X github.com/open-cli-collective/google-readonly/internal/version.Version=${VERSION} \
+          -X github.com/open-cli-collective/google-readonly/internal/version.Commit=${COMMIT} \
+          -X github.com/open-cli-collective/google-readonly/internal/version.Date=${DATE}" \
+        ./cmd/gro


### PR DESCRIPTION
## Summary

Aligns google-readonly's CI/CD setup with confluence-cli by adding missing workflows for testing, manual publishing, and snap package support.

## Changes

### New Workflows

| Workflow | Purpose |
|----------|---------|
| `test-chocolatey.yml` | Validates Chocolatey packaging on PRs touching `packaging/chocolatey/**` |
| `test-winget.yml` | Validates Winget manifest schema on PRs touching `packaging/winget/**` |
| `chocolatey-publish.yml` | Manual workflow to (re)publish a version to Chocolatey |
| `winget-publish.yml` | Manual workflow to (re)publish a version to Winget |

### Snap Support

- Added `snap/snapcraft.yaml` with:
  - Name: `ocli-google-readonly`
  - Alias: `gro`
  - Plugs: `home`, `network`, `personal-files` for `~/.config/google-readonly`
- Added snap job to `release.yml` (disabled with `if: false` while awaiting `personal-files` interface approval)

### Homebrew Migration

- Migrated from manual Homebrew cask generation to goreleaser's `homebrew_casks`
- Removed ~100 lines of manual cask generation from `release.yml`
- Added `homebrew_casks` section to `.goreleaser.yaml` with:
  - xattr quarantine removal hook for macOS
  - Caveats for `gro init`
- Added `TAP_GITHUB_TOKEN` to goreleaser env

## Test plan

- [x] `make verify` passes
- [ ] CI workflows validate on merge
- [ ] Test workflows will run on next PR touching packaging files
- [ ] Next release will test goreleaser homebrew_casks integration

Closes #81