### PR TITLE
test: add missing tests for cache infrastructure

### DIFF
--- a/internal/cmd/config/config_test.go
+++ b/internal/cmd/config/config_test.go
@@ -19,7 +19,7 @@ func TestConfigCommand(t *testing.T) {
 
 	t.Run("has subcommands", func(t *testing.T) {
 		subcommands := cmd.Commands()
-		assert.GreaterOrEqual(t, len(subcommands), 3)
+		assert.GreaterOrEqual(t, len(subcommands), 4)
 
 		var names []string
 		for _, sub := range subcommands {
@@ -28,6 +28,7 @@ func TestConfigCommand(t *testing.T) {
 		assert.Contains(t, names, "show")
 		assert.Contains(t, names, "test")
 		assert.Contains(t, names, "clear")
+		assert.Contains(t, names, "cache")
 	})
 }
 
@@ -101,5 +102,119 @@ func TestConfigClearCommand(t *testing.T) {
 	t.Run("has long description", func(t *testing.T) {
 		assert.NotEmpty(t, cmd.Long)
 		assert.Contains(t, cmd.Long, "token")
+	})
+}
+
+func TestCacheCommand(t *testing.T) {
+	cmd := newCacheCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "cache", cmd.Use)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Short)
+	})
+
+	t.Run("has long description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Long)
+		assert.Contains(t, cmd.Long, "cache")
+	})
+
+	t.Run("has subcommands", func(t *testing.T) {
+		subcommands := cmd.Commands()
+		assert.Equal(t, 3, len(subcommands))
+
+		var names []string
+		for _, sub := range subcommands {
+			names = append(names, sub.Name())
+		}
+		assert.Contains(t, names, "show")
+		assert.Contains(t, names, "clear")
+		assert.Contains(t, names, "ttl")
+	})
+}
+
+func TestCacheShowCommand(t *testing.T) {
+	cmd := newCacheShowCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "show", cmd.Use)
+	})
+
+	t.Run("requires no arguments", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"extra"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Short)
+	})
+
+	t.Run("has long description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Long)
+		assert.Contains(t, cmd.Long, "cache")
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "j", flag.Shorthand)
+		assert.Equal(t, "false", flag.DefValue)
+	})
+}
+
+func TestCacheClearCommand(t *testing.T) {
+	cmd := newCacheClearCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "clear", cmd.Use)
+	})
+
+	t.Run("requires no arguments", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"extra"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Short)
+	})
+
+	t.Run("has long description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Long)
+	})
+}
+
+func TestCacheTTLCommand(t *testing.T) {
+	cmd := newCacheTTLCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "ttl <hours>", cmd.Use)
+	})
+
+	t.Run("requires exactly one argument", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		assert.Error(t, err)
+
+		err = cmd.Args(cmd, []string{"24"})
+		assert.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"24", "extra"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Short)
+	})
+
+	t.Run("has long description", func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Long)
+		assert.Contains(t, cmd.Long, "TTL")
 	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -114,4 +115,147 @@ func TestConstants(t *testing.T) {
 	assert.Equal(t, "google-readonly", DirName)
 	assert.Equal(t, "credentials.json", CredentialsFile)
 	assert.Equal(t, "token.json", TokenFile)
+	assert.Equal(t, "config.json", ConfigFile)
+	assert.Equal(t, 24, DefaultCacheTTLHours)
+}
+
+func TestGetConfigPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	path, err := GetConfigPath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(tmpDir, DirName, ConfigFile), path)
+}
+
+func TestLoadConfig(t *testing.T) {
+	t.Run("returns default config when file does not exist", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+		cfg, err := LoadConfig()
+		require.NoError(t, err)
+		assert.Equal(t, DefaultCacheTTLHours, cfg.CacheTTLHours)
+	})
+
+	t.Run("loads config from file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+		// Create config directory and file
+		configDir := filepath.Join(tmpDir, DirName)
+		require.NoError(t, os.MkdirAll(configDir, DirPerm))
+
+		configData := `{"cache_ttl_hours": 48}`
+		require.NoError(t, os.WriteFile(filepath.Join(configDir, ConfigFile), []byte(configData), TokenPerm))
+
+		cfg, err := LoadConfig()
+		require.NoError(t, err)
+		assert.Equal(t, 48, cfg.CacheTTLHours)
+	})
+
+	t.Run("applies default for zero or negative TTL", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+		configDir := filepath.Join(tmpDir, DirName)
+		require.NoError(t, os.MkdirAll(configDir, DirPerm))
+
+		configData := `{"cache_ttl_hours": 0}`
+		require.NoError(t, os.WriteFile(filepath.Join(configDir, ConfigFile), []byte(configData), TokenPerm))
+
+		cfg, err := LoadConfig()
+		require.NoError(t, err)
+		assert.Equal(t, DefaultCacheTTLHours, cfg.CacheTTLHours)
+	})
+
+	t.Run("returns error for invalid JSON", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+		configDir := filepath.Join(tmpDir, DirName)
+		require.NoError(t, os.MkdirAll(configDir, DirPerm))
+
+		require.NoError(t, os.WriteFile(filepath.Join(configDir, ConfigFile), []byte("not json"), TokenPerm))
+
+		_, err := LoadConfig()
+		assert.Error(t, err)
+	})
+}
+
+func TestSaveConfig(t *testing.T) {
+	t.Run("saves config to file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+		cfg := &Config{CacheTTLHours: 12}
+		err := SaveConfig(cfg)
+		require.NoError(t, err)
+
+		// Verify file was created
+		path, _ := GetConfigPath()
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"cache_ttl_hours": 12`)
+	})
+
+	t.Run("overwrites existing config", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+		// Save initial config
+		cfg1 := &Config{CacheTTLHours: 12}
+		require.NoError(t, SaveConfig(cfg1))
+
+		// Save new config
+		cfg2 := &Config{CacheTTLHours: 36}
+		require.NoError(t, SaveConfig(cfg2))
+
+		// Verify new value
+		loaded, err := LoadConfig()
+		require.NoError(t, err)
+		assert.Equal(t, 36, loaded.CacheTTLHours)
+	})
+}
+
+func TestGetCacheTTL(t *testing.T) {
+	t.Run("returns configured TTL as duration", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+		cfg := &Config{CacheTTLHours: 12}
+		require.NoError(t, SaveConfig(cfg))
+
+		ttl := GetCacheTTL()
+		assert.Equal(t, 12*time.Hour, ttl)
+	})
+
+	t.Run("returns default TTL when no config exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+		ttl := GetCacheTTL()
+		assert.Equal(t, time.Duration(DefaultCacheTTLHours)*time.Hour, ttl)
+	})
+}
+
+func TestGetCacheTTLHours(t *testing.T) {
+	t.Run("returns configured TTL in hours", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+		cfg := &Config{CacheTTLHours: 48}
+		require.NoError(t, SaveConfig(cfg))
+
+		hours := GetCacheTTLHours()
+		assert.Equal(t, 48, hours)
+	})
+
+	t.Run("returns default TTL when no config exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+		hours := GetCacheTTLHours()
+		assert.Equal(t, DefaultCacheTTLHours, hours)
+	})
 }


### PR DESCRIPTION
## Summary

Addresses test coverage gaps identified in [TDD assessment](https://github.com/open-cli-collective/google-readonly/pull/83#issuecomment-3804594661) for #84.

**Coverage improvements:**
| Package | Before | After |
|---------|--------|-------|
| `internal/config` | 33.3% | 78.9% |

**Tests added for `internal/config`:**
- `GetConfigPath()` - path construction
- `LoadConfig()` - default config, file loading, zero TTL handling, invalid JSON
- `SaveConfig()` - file creation, overwrite behavior
- `GetCacheTTL()` - configured and default values
- `GetCacheTTLHours()` - configured and default values

**Tests added for `internal/cmd/config`:**
- `newCacheCommand()` - subcommands verification
- `newCacheShowCommand()` - args, flags, descriptions
- `newCacheClearCommand()` - args, descriptions
- `newCacheTTLCommand()` - args, descriptions

## Test plan

- [x] `make verify` passes
- [x] All new tests pass
- [x] Coverage increased for config package

Relates to #84