### PR TITLE
ci: make secondary distribution jobs non-blocking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
   chocolatey:
     needs: goreleaser
     runs-on: windows-latest
+    continue-on-error: true
     env:
       TAG: ${{ github.ref_name || inputs.tag }}
     steps:
@@ -97,6 +98,7 @@ jobs:
   winget:
     needs: goreleaser
     runs-on: windows-latest
+    continue-on-error: true
     env:
       TAG: ${{ github.ref_name || inputs.tag }}
     steps:
@@ -222,6 +224,7 @@ jobs:
   linux-packages:
     needs: goreleaser
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Trigger linux-packages repo update
         uses: peter-evans/repository-dispatch@v3


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to `chocolatey`, `winget`, and `linux-packages` jobs
- Prevents secondary distribution failures from marking the release workflow as failed
- The primary GitHub release (goreleaser) is what matters for release success

## Context
Chocolatey has a moderation queue that requires previous versions to be approved before new versions can be pushed. This causes the release workflow to fail even when the GitHub release completes successfully.

Example failure: https://github.com/open-cli-collective/google-readonly/actions/runs/21395699553

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Next release should show as successful even if Chocolatey push fails

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)