### PR TITLE
docs: add guidance about OAuth app publishing status

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,19 @@ go install github.com/open-cli-collective/google-readonly/cmd/gro@latest
 5. Click **Create**
 6. Download the JSON file
 
-### 3. Configure gro
+### 3. Publish Your OAuth App (Recommended)
+
+By default, new OAuth apps are in **"Testing"** mode, which causes **tokens to expire after 7 days**. To avoid frequent re-authentication:
+
+1. Go to **Google Auth Platform** > **Audience** (or **OAuth consent screen** in older UI)
+2. Find the **Publishing status** section
+3. Click **Publish app**
+
+For personal use with read-only scopes, publishing is straightforward and doesn't require Google verification. Once published, tokens will last until revoked or unused for 6 months.
+
+> **Note:** If you skip this step, you'll need to run `gro init` every 7 days to re-authenticate.
+
+### 4. Configure gro
 
 1. Create the config directory:
    ```bash
@@ -133,7 +145,7 @@ go install github.com/open-cli-collective/google-readonly/cmd/gro@latest
    mv ~/Downloads/client_secret_*.json ~/.config/google-readonly/credentials.json
    ```
 
-### 4. Authenticate
+### 5. Authenticate
 
 Run the init command to complete OAuth setup:
 
@@ -836,6 +848,10 @@ Your token may be missing scopes for a newly added service. Clear and re-authent
 gro config clear
 gro init
 ```
+
+### Token expires every 7 days
+
+Your OAuth app is likely still in **"Testing"** mode. See [Publish Your OAuth App](#3-publish-your-oauth-app-recommended) in the setup guide. Apps in testing mode have tokens that expire after 7 days.
 
 ## License
 

--- a/internal/cmd/initcmd/init.go
+++ b/internal/cmd/initcmd/init.go
@@ -211,6 +211,9 @@ func verifyConnectivity() error {
 	fmt.Printf("Authenticated as: %s\n", profile.EmailAddress)
 	fmt.Println()
 	fmt.Println("Setup complete! Try: gro mail search \"is:unread\"")
+	fmt.Println()
+	fmt.Println("Tip: If your token expires every 7 days, your OAuth app may be in 'Testing' mode.")
+	fmt.Println("     Publish it at: Google Cloud Console > OAuth consent screen > Publish app")
 	return nil
 }
 
@@ -228,6 +231,9 @@ func printCredentialsInstructions(credPath string) {
 	fmt.Println("   - Select 'Desktop app' as application type")
 	fmt.Println("   - Download the JSON file")
 	fmt.Printf("5. Save the downloaded file to:\n   %s\n", credPath)
+	fmt.Println()
+	fmt.Println("Optional but recommended: Publish your OAuth app to avoid 7-day token expiry:")
+	fmt.Println("   - Go to 'OAuth consent screen' > 'Publish app'")
 	fmt.Println()
 	fmt.Println("Then run 'gro init' again.")
 }


### PR DESCRIPTION
## Summary
- Add new setup step in README explaining Testing vs Production mode
- Add troubleshooting entry for "token expires every 7 days"
- Add tip after `gro init` success about publishing the app
- Add note in credentials setup instructions

## Problem
When users create their own OAuth credentials in Google Cloud Console, the app defaults to "Testing" publishing status. In testing mode, **refresh tokens expire after 7 days**, forcing users to re-authenticate frequently with no indication of why.

## Solution
Document that users should click "Publish app" in their OAuth consent screen settings. For personal use with read-only scopes, this is straightforward and doesn't require Google verification.

## Test plan
- [ ] Verify README renders correctly
- [ ] Run `gro init` and verify the tip appears after successful auth

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)