### PR TITLE
feat(mail): add non-destructive organizational operations for Gmail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ This file provides guidance for AI agents working with the gro codebase.
 
 ## Project Overview
 
-gro is a **read-only** command-line interface for Google services written in Go. It uses OAuth2 for authentication and only requests read-only scopes - no write, send, or delete operations are possible.
+gro is a **non-destructive** command-line interface for Google services written in Go. It uses OAuth2 for authentication and supports read-only access plus non-destructive organizational operations (labeling, archiving, starring, marking read/unread). No send, delete, or destructive operations are possible.
 
 **Binary name:** `gro`
 **Module:** `github.com/open-cli-collective/google-readonly`
 
 ### Features
-- Gmail: Search, read, thread viewing, labels, attachments
+- Gmail: Search, read, thread viewing, labels, attachments, archive, star, mark read/unread, label, categorize
 - Google Calendar: List calendars, view events, today/week shortcuts
 - Google Contacts: List contacts, search, view details, list groups
 - Google Drive: List files, search, get details, download, tree view, shared drives
@@ -37,7 +37,7 @@ make install        # Install to /usr/local/bin
 
 ## Key Constraints
 
-- **Read-only by design**: Only `*ReadonlyScope` in `auth.AllScopes`. No write API methods.
+- **Non-destructive by design**: Only allowlisted scopes in `auth.AllScopes`. No destructive API methods (send, delete, trash). Non-destructive modify operations (label, archive, star) are permitted.
 - **Interface-at-consumer**: Each `internal/cmd/{domain}/output.go` defines its client interface.
 - **ClientFactory DI**: Swappable factory for test mock injection.
 - **--json on all leaf commands**: Every leaf subcommand supports `--json/-j`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,6 +22,7 @@ All API clients depend on:
   internal/auth/    -> internal/keychain/, internal/config/
 
 Shared utilities (no internal deps):
+  internal/bulk/        Bulk operation ID resolution and result types
   internal/testutil/    Test fixtures and assertion helpers
   internal/output/      JSON output encoding
   internal/format/      Human-readable formatting

--- a/docs/golden-principles.md
+++ b/docs/golden-principles.md
@@ -32,11 +32,11 @@ All leaf subcommands (commands with no children) support `--json/-j` for machine
 
 **Enforced by:** `TestAllLeafCommandsHaveJSONFlag`
 
-## 5. Read-only only
+## 5. Non-destructive only
 
-Only `*ReadonlyScope` constants may appear in `auth.AllScopes`. No write API methods (`.Send()`, `.Trash()`, `.BatchModify()`, etc.) in production code.
+All OAuth scopes in `auth.AllScopes` must appear in the non-destructive allowlist. No destructive API methods (`.Send()`, `.Trash()`, `.BatchDelete()`, etc.) in production code. Non-destructive modify methods like `.BatchModify()` (used for labeling/archiving) are permitted.
 
-**Enforced by:** `TestAllScopesAreReadOnly`, `TestNoWriteAPIMethodsInProductionCode`
+**Enforced by:** `TestAllScopesAreNonDestructive`, `TestNoDestructiveAPIMethodsInProductionCode`
 
 ## 6. Dependency direction
 

--- a/internal/architecture/architecture_test.go
+++ b/internal/architecture/architecture_test.go
@@ -311,7 +311,7 @@ var allowedScopes = map[string]bool{
 	"https://www.googleapis.com/auth/gmail.readonly":    true,
 	"https://www.googleapis.com/auth/gmail.modify":      true, // label, archive, star, read/unread (NOT send/delete)
 	"https://www.googleapis.com/auth/calendar.readonly": true,
-	"https://www.googleapis.com/auth/calendar.events":   true, // RSVP, color (NOT delete) — reserved for future use
+	"https://www.googleapis.com/auth/calendar.events":   true, // full event CRUD — use only for non-destructive ops (RSVP, color). Reserved for future use.
 	"https://www.googleapis.com/auth/contacts.readonly": true,
 	"https://www.googleapis.com/auth/contacts":          true, // group membership — reserved for future use
 	"https://www.googleapis.com/auth/drive.readonly":    true,

--- a/internal/architecture/architecture_test.go
+++ b/internal/architecture/architecture_test.go
@@ -311,11 +311,8 @@ var allowedScopes = map[string]bool{
 	"https://www.googleapis.com/auth/gmail.readonly":    true,
 	"https://www.googleapis.com/auth/gmail.modify":      true, // label, archive, star, read/unread (NOT send/delete)
 	"https://www.googleapis.com/auth/calendar.readonly": true,
-	"https://www.googleapis.com/auth/calendar.events":   true, // full event CRUD — use only for non-destructive ops (RSVP, color). Reserved for future use.
 	"https://www.googleapis.com/auth/contacts.readonly": true,
-	"https://www.googleapis.com/auth/contacts":          true, // group membership — reserved for future use
 	"https://www.googleapis.com/auth/drive.readonly":    true,
-	"https://www.googleapis.com/auth/drive.metadata":    true, // star (metadata only) — reserved for future use
 }
 
 // TestAllScopesAreNonDestructive verifies that every OAuth scope in auth.AllScopes

--- a/internal/architecture/architecture_test.go
+++ b/internal/architecture/architecture_test.go
@@ -303,10 +303,24 @@ func TestAuthPackageDoesNotImportAPIClients(t *testing.T) {
 	}
 }
 
-// TestAllScopesAreReadOnly verifies that every OAuth scope in auth.AllScopes
-// is a read-only scope. This is the primary mechanical enforcement of the
-// read-only-by-design principle.
-func TestAllScopesAreReadOnly(t *testing.T) {
+// allowedScopes is the set of OAuth scopes permitted in auth.AllScopes.
+// Read-only scopes are always safe. Non-readonly scopes are allowed only when
+// they enable non-destructive organizational operations (label, archive, star, etc.)
+// without granting send or delete access.
+var allowedScopes = map[string]bool{
+	"https://www.googleapis.com/auth/gmail.readonly":    true,
+	"https://www.googleapis.com/auth/gmail.modify":      true, // label, archive, star, read/unread (NOT send/delete)
+	"https://www.googleapis.com/auth/calendar.readonly": true,
+	"https://www.googleapis.com/auth/calendar.events":   true, // RSVP, color (NOT delete) — reserved for future use
+	"https://www.googleapis.com/auth/contacts.readonly": true,
+	"https://www.googleapis.com/auth/contacts":          true, // group membership — reserved for future use
+	"https://www.googleapis.com/auth/drive.readonly":    true,
+	"https://www.googleapis.com/auth/drive.metadata":    true, // star (metadata only) — reserved for future use
+}
+
+// TestAllScopesAreNonDestructive verifies that every OAuth scope in auth.AllScopes
+// is in the allowlist of non-destructive scopes.
+func TestAllScopesAreNonDestructive(t *testing.T) {
 	t.Parallel()
 
 	if len(auth.AllScopes) == 0 {
@@ -314,28 +328,27 @@ func TestAllScopesAreReadOnly(t *testing.T) {
 	}
 
 	for _, scope := range auth.AllScopes {
-		if !strings.Contains(scope, "readonly") {
-			t.Errorf("scope %q is not a readonly scope; all scopes in AllScopes must be read-only", scope)
+		if !allowedScopes[scope] {
+			t.Errorf("scope %q is not in the non-destructive allowlist; update allowedScopes if this scope is safe", scope)
 		}
 	}
 }
 
-// TestNoWriteAPIMethodsInProductionCode scans all non-test Go source files
-// for Google API write method calls. This is defense-in-depth on top of the
-// scope check — even with readonly scopes, we don't want write method calls
-// in the codebase since they indicate incorrect intent.
-func TestNoWriteAPIMethodsInProductionCode(t *testing.T) {
+// TestNoDestructiveAPIMethodsInProductionCode scans all non-test Go source files
+// for Google API destructive method calls. Non-destructive modify methods like
+// BatchModify (used for labeling/archiving) are permitted.
+func TestNoDestructiveAPIMethodsInProductionCode(t *testing.T) {
 	t.Parallel()
 	root := findModuleRoot(t)
 
 	// These patterns are specific to Google API client libraries and unlikely
 	// to appear in other contexts. Generic method names like .Delete() or
 	// .Insert() are intentionally excluded to avoid false positives.
+	// Note: .BatchModify( is intentionally allowed — it's used for bulk label operations.
 	forbiddenPatterns := []string{
 		".Send(",
 		".Trash(",
 		".Untrash(",
-		".BatchModify(",
 		".BatchDelete(",
 	}
 
@@ -364,7 +377,7 @@ func TestNoWriteAPIMethodsInProductionCode(t *testing.T) {
 
 		for _, pattern := range forbiddenPatterns {
 			if strings.Contains(content, pattern) {
-				t.Errorf("file %s contains forbidden write API method %q — this CLI is read-only by design", rel, pattern)
+				t.Errorf("file %s contains forbidden destructive API method %q — this CLI only allows non-destructive operations", rel, pattern)
 			}
 		}
 		return nil

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -18,12 +18,57 @@ import (
 	"github.com/open-cli-collective/google-readonly/internal/keychain"
 )
 
-// AllScopes contains all OAuth scopes used by the application
+// AllScopes contains all OAuth scopes used by the application.
+// Gmail uses the modify scope for organizational operations (label, archive, star, mark read/unread).
+// The modify scope is a superset of readonly — it includes all read access.
 var AllScopes = []string{
-	gmail.GmailReadonlyScope,
+	gmail.GmailModifyScope,
 	calendar.CalendarReadonlyScope,
 	people.ContactsReadonlyScope,
 	drive.DriveReadonlyScope,
+}
+
+// ScopeDescriptions maps OAuth scope URLs to human-friendly descriptions.
+var ScopeDescriptions = map[string]string{
+	gmail.GmailModifyScope:         "Gmail Modify — read messages, plus label, archive, star, and mark read/unread. No send or delete access.",
+	gmail.GmailReadonlyScope:       "Gmail Read-Only — read messages and metadata.",
+	calendar.CalendarReadonlyScope: "Calendar Read-Only — read calendars and events.",
+	people.ContactsReadonlyScope:   "Contacts Read-Only — read contacts and groups.",
+	drive.DriveReadonlyScope:       "Drive Read-Only — read files and metadata.",
+}
+
+// CheckScopesMigration compares the currently required scopes against the
+// previously granted scopes. Returns a non-empty message if re-auth is needed.
+func CheckScopesMigration(grantedScopes []string) string {
+	if len(grantedScopes) == 0 {
+		return ""
+	}
+
+	granted := make(map[string]bool, len(grantedScopes))
+	for _, s := range grantedScopes {
+		granted[s] = true
+	}
+
+	var missing []string
+	for _, required := range AllScopes {
+		if !granted[required] {
+			missing = append(missing, required)
+		}
+	}
+
+	if len(missing) == 0 {
+		return ""
+	}
+
+	msg := "This command requires additional permissions.\nYour current token only has read-only access.\n\nRun 'gro init' to re-authenticate with the updated scopes.\n\nNew scopes:\n"
+	for _, s := range missing {
+		desc := ScopeDescriptions[s]
+		if desc == "" {
+			desc = s
+		}
+		msg += "  - " + desc + "\n"
+	}
+	return msg
 }
 
 // GetOAuthConfig loads OAuth configuration from credentials file with all scopes

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -105,8 +105,8 @@ func TestAllScopes(t *testing.T) {
 		t.Errorf("got length %d, want %d", len(AllScopes), 4)
 	}
 	scopeSet := strings.Join(AllScopes, " ")
-	if !strings.Contains(scopeSet, "https://www.googleapis.com/auth/gmail.readonly") {
-		t.Errorf("expected AllScopes to contain %q", "https://www.googleapis.com/auth/gmail.readonly")
+	if !strings.Contains(scopeSet, "https://www.googleapis.com/auth/gmail.modify") {
+		t.Errorf("expected AllScopes to contain %q", "https://www.googleapis.com/auth/gmail.modify")
 	}
 	if !strings.Contains(scopeSet, "https://www.googleapis.com/auth/calendar.readonly") {
 		t.Errorf("expected AllScopes to contain %q", "https://www.googleapis.com/auth/calendar.readonly")
@@ -116,6 +116,42 @@ func TestAllScopes(t *testing.T) {
 	}
 	if !strings.Contains(scopeSet, "https://www.googleapis.com/auth/drive.readonly") {
 		t.Errorf("expected AllScopes to contain %q", "https://www.googleapis.com/auth/drive.readonly")
+	}
+}
+
+func TestCheckScopesMigration_NoGrantedScopes(t *testing.T) {
+	t.Parallel()
+	msg := CheckScopesMigration(nil)
+	if msg != "" {
+		t.Errorf("expected empty message, got %q", msg)
+	}
+}
+
+func TestCheckScopesMigration_AllGranted(t *testing.T) {
+	t.Parallel()
+	msg := CheckScopesMigration(AllScopes)
+	if msg != "" {
+		t.Errorf("expected empty message, got %q", msg)
+	}
+}
+
+func TestCheckScopesMigration_MissingScope(t *testing.T) {
+	t.Parallel()
+	oldScopes := []string{
+		"https://www.googleapis.com/auth/gmail.readonly",
+		"https://www.googleapis.com/auth/calendar.readonly",
+		"https://www.googleapis.com/auth/contacts.readonly",
+		"https://www.googleapis.com/auth/drive.readonly",
+	}
+	msg := CheckScopesMigration(oldScopes)
+	if msg == "" {
+		t.Fatal("expected non-empty message")
+	}
+	if !strings.Contains(msg, "gro init") {
+		t.Errorf("expected message to mention 'gro init', got %q", msg)
+	}
+	if !strings.Contains(msg, "Gmail Modify") {
+		t.Errorf("expected message to mention 'Gmail Modify', got %q", msg)
 	}
 }
 

--- a/internal/bulk/resolve.go
+++ b/internal/bulk/resolve.go
@@ -1,0 +1,67 @@
+// Package bulk provides shared ID resolution and result types for bulk operations.
+package bulk
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Config specifies how to resolve IDs for a bulk operation.
+type Config struct {
+	Args  []string // positional args
+	Stdin bool     // --stdin flag
+	Query string   // --query value
+}
+
+// ResolveIDs returns IDs from exactly one input source.
+// queryFn is called when Query is set; caller provides domain-specific search.
+// Returns error if zero or multiple sources are provided.
+func ResolveIDs(cfg Config, queryFn func(string) ([]string, error)) ([]string, error) {
+	sources := 0
+	if len(cfg.Args) > 0 {
+		sources++
+	}
+	if cfg.Stdin {
+		sources++
+	}
+	if cfg.Query != "" {
+		sources++
+	}
+
+	if sources == 0 {
+		return nil, fmt.Errorf("provide message IDs as arguments, via --stdin, or via --query")
+	}
+	if sources > 1 {
+		return nil, fmt.Errorf("only one input source allowed: positional args, --stdin, or --query")
+	}
+
+	if len(cfg.Args) > 0 {
+		return cfg.Args, nil
+	}
+
+	if cfg.Stdin {
+		return readStdin()
+	}
+
+	return queryFn(cfg.Query)
+}
+
+func readStdin() ([]string, error) {
+	var ids []string
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			ids = append(ids, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading stdin: %w", err)
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("no IDs received from stdin")
+	}
+	return ids, nil
+}

--- a/internal/bulk/resolve_test.go
+++ b/internal/bulk/resolve_test.go
@@ -1,0 +1,68 @@
+package bulk
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/open-cli-collective/google-readonly/internal/testutil"
+)
+
+func TestResolveIDs_Args(t *testing.T) {
+	t.Parallel()
+	ids, err := ResolveIDs(Config{Args: []string{"id1", "id2"}}, nil)
+	testutil.NoError(t, err)
+	testutil.Len(t, ids, 2)
+	testutil.Equal(t, ids[0], "id1")
+	testutil.Equal(t, ids[1], "id2")
+}
+
+func TestResolveIDs_Query(t *testing.T) {
+	t.Parallel()
+	queryFn := func(q string) ([]string, error) {
+		testutil.Equal(t, q, "is:unread")
+		return []string{"msg1", "msg2", "msg3"}, nil
+	}
+
+	ids, err := ResolveIDs(Config{Query: "is:unread"}, queryFn)
+	testutil.NoError(t, err)
+	testutil.Len(t, ids, 3)
+}
+
+func TestResolveIDs_QueryError(t *testing.T) {
+	t.Parallel()
+	queryFn := func(_ string) ([]string, error) {
+		return nil, fmt.Errorf("search failed")
+	}
+
+	_, err := ResolveIDs(Config{Query: "is:unread"}, queryFn)
+	testutil.Error(t, err)
+	testutil.Contains(t, err.Error(), "search failed")
+}
+
+func TestResolveIDs_NoSources(t *testing.T) {
+	t.Parallel()
+	_, err := ResolveIDs(Config{}, nil)
+	testutil.Error(t, err)
+	testutil.Contains(t, err.Error(), "provide message IDs")
+}
+
+func TestResolveIDs_MultipleSources(t *testing.T) {
+	t.Parallel()
+	_, err := ResolveIDs(Config{Args: []string{"id1"}, Query: "test"}, nil)
+	testutil.Error(t, err)
+	testutil.Contains(t, err.Error(), "only one input source")
+}
+
+func TestResolveIDs_ArgsAndStdin(t *testing.T) {
+	t.Parallel()
+	_, err := ResolveIDs(Config{Args: []string{"id1"}, Stdin: true}, nil)
+	testutil.Error(t, err)
+	testutil.Contains(t, err.Error(), "only one input source")
+}
+
+func TestResolveIDs_AllThree(t *testing.T) {
+	t.Parallel()
+	_, err := ResolveIDs(Config{Args: []string{"id1"}, Stdin: true, Query: "test"}, nil)
+	testutil.Error(t, err)
+	testutil.Contains(t, err.Error(), "only one input source")
+}

--- a/internal/bulk/result.go
+++ b/internal/bulk/result.go
@@ -1,0 +1,36 @@
+package bulk
+
+import (
+	"fmt"
+
+	"github.com/open-cli-collective/google-readonly/internal/output"
+)
+
+// Result represents the outcome of a bulk operation.
+type Result struct {
+	Action  string   `json:"action"`
+	IDs     []string `json:"ids"`
+	Count   int      `json:"count"`
+	DryRun  bool     `json:"dryRun"`
+	Details any      `json:"details,omitempty"`
+}
+
+// Print outputs the result as text or JSON.
+func (r *Result) Print(jsonOutput bool) error {
+	if jsonOutput {
+		return output.JSONStdout(r)
+	}
+	if r.DryRun {
+		fmt.Printf("[dry-run] Would %s %d message(s).\n", r.Action, r.Count)
+	} else {
+		fmt.Printf("%s %d message(s).\n", capitalize(r.Action), r.Count)
+	}
+	return nil
+}
+
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return string(s[0]-32) + s[1:]
+}

--- a/internal/bulk/result.go
+++ b/internal/bulk/result.go
@@ -2,6 +2,7 @@ package bulk
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/open-cli-collective/google-readonly/internal/output"
 )
@@ -32,5 +33,5 @@ func capitalize(s string) string {
 	if s == "" {
 		return s
 	}
-	return string(s[0]-32) + s[1:]
+	return strings.ToUpper(s[:1]) + s[1:]
 }

--- a/internal/bulk/result_test.go
+++ b/internal/bulk/result_test.go
@@ -1,0 +1,46 @@
+package bulk
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/open-cli-collective/google-readonly/internal/testutil"
+)
+
+func TestResult_Print_Text(t *testing.T) {
+	r := &Result{Action: "archived", IDs: []string{"a", "b"}, Count: 2}
+	out := testutil.CaptureStdout(t, func() {
+		err := r.Print(false)
+		testutil.NoError(t, err)
+	})
+	testutil.Contains(t, out, "Archived 2 message(s).")
+}
+
+func TestResult_Print_TextDryRun(t *testing.T) {
+	r := &Result{Action: "archive", IDs: []string{"a", "b"}, Count: 2, DryRun: true}
+	out := testutil.CaptureStdout(t, func() {
+		err := r.Print(false)
+		testutil.NoError(t, err)
+	})
+	testutil.Contains(t, out, "[dry-run] Would archive 2 message(s).")
+}
+
+func TestResult_Print_JSON(t *testing.T) {
+	r := &Result{Action: "archived", IDs: []string{"a"}, Count: 1}
+	out := testutil.CaptureStdout(t, func() {
+		err := r.Print(true)
+		testutil.NoError(t, err)
+	})
+	var parsed Result
+	err := json.Unmarshal([]byte(out), &parsed)
+	testutil.NoError(t, err)
+	testutil.Equal(t, parsed.Action, "archived")
+	testutil.Equal(t, parsed.Count, 1)
+}
+
+func TestCapitalize(t *testing.T) {
+	t.Parallel()
+	testutil.Equal(t, capitalize("archived"), "Archived")
+	testutil.Equal(t, capitalize("starred"), "Starred")
+	testutil.Equal(t, capitalize(""), "")
+}

--- a/internal/cmd/initcmd/init.go
+++ b/internal/cmd/initcmd/init.go
@@ -65,7 +65,7 @@ func runInit(cmd *cobra.Command, _ []string) error {
 	fmt.Printf("Credentials: %s\n", shortPath)
 
 	// Step 2: Load OAuth config
-	config, err := auth.GetOAuthConfig()
+	oauthConfig, err := auth.GetOAuthConfig()
 	if err != nil {
 		return fmt.Errorf("loading OAuth config: %w", err)
 	}
@@ -114,7 +114,7 @@ func runInit(cmd *cobra.Command, _ []string) error {
 	fmt.Println("Token:       Not found - starting OAuth flow")
 	fmt.Println()
 
-	authURL := auth.GetAuthURL(config)
+	authURL := auth.GetAuthURL(oauthConfig)
 	fmt.Println("Open this URL in your browser:")
 	fmt.Println()
 	fmt.Println(authURL)
@@ -143,16 +143,24 @@ func runInit(cmd *cobra.Command, _ []string) error {
 	fmt.Println()
 	fmt.Println("Exchanging authorization code...")
 
-	token, err := auth.ExchangeAuthCode(cmd.Context(), config, code)
+	token, err := auth.ExchangeAuthCode(cmd.Context(), oauthConfig, code)
 	if err != nil {
 		return fmt.Errorf("exchanging authorization code: %w", err)
 	}
 
-	// Step 6: Save token
+	// Step 6: Save token and record granted scopes
 	if err := keychain.SetToken(token); err != nil {
 		return fmt.Errorf("saving token: %w", err)
 	}
 	fmt.Printf("Token saved to: %s\n", keychain.GetStorageBackend())
+
+	cfg, cfgErr := config.LoadConfig()
+	if cfgErr == nil {
+		cfg.GrantedScopes = auth.AllScopes
+		if saveErr := config.SaveConfig(cfg); saveErr != nil {
+			fmt.Printf("Warning: saving granted scopes: %v\n", saveErr)
+		}
+	}
 
 	// Step 7: Verify connectivity (unless --no-verify)
 	if !noVerify {

--- a/internal/cmd/initcmd/init.go
+++ b/internal/cmd/initcmd/init.go
@@ -155,11 +155,12 @@ func runInit(cmd *cobra.Command, _ []string) error {
 	fmt.Printf("Token saved to: %s\n", keychain.GetStorageBackend())
 
 	cfg, cfgErr := config.LoadConfig()
-	if cfgErr == nil {
-		cfg.GrantedScopes = auth.AllScopes
-		if saveErr := config.SaveConfig(cfg); saveErr != nil {
-			fmt.Printf("Warning: saving granted scopes: %v\n", saveErr)
-		}
+	if cfgErr != nil {
+		cfg = &config.Config{CacheTTLHours: config.DefaultCacheTTLHours}
+	}
+	cfg.GrantedScopes = auth.AllScopes
+	if saveErr := config.SaveConfig(cfg); saveErr != nil {
+		fmt.Printf("Warning: saving granted scopes: %v\n", saveErr)
 	}
 
 	// Step 7: Verify connectivity (unless --no-verify)

--- a/internal/cmd/mail/archive.go
+++ b/internal/cmd/mail/archive.go
@@ -1,0 +1,76 @@
+package mail
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/bulk"
+)
+
+func newArchiveCommand() *cobra.Command {
+	var (
+		jsonOutput bool
+		dryRun     bool
+		stdin      bool
+		query      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "archive [message-ids...]",
+		Short: "Archive messages (remove from inbox)",
+		Long: `Archive Gmail messages by removing the INBOX label.
+
+Messages can be specified as positional arguments, piped via --stdin, or
+resolved from a search query via --query. Only one input mode is allowed.
+
+Examples:
+  gro mail archive msg123 msg456
+  gro mail search "from:newsletter" --ids | gro mail archive --stdin
+  gro mail archive --query "from:noreply older_than:30d"
+  gro mail archive --query "is:inbox from:noreply" --dry-run`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newGmailClient(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("creating Gmail client: %w", err)
+			}
+
+			ctx := cmd.Context()
+			ids, err := bulk.ResolveIDs(bulk.Config{
+				Args:  args,
+				Stdin: stdin,
+				Query: query,
+			}, func(q string) ([]string, error) {
+				return client.SearchMessageIDs(ctx, q, 0)
+			})
+			if err != nil {
+				return err
+			}
+
+			result := &bulk.Result{
+				Action: "archived",
+				IDs:    ids,
+				Count:  len(ids),
+				DryRun: dryRun,
+			}
+
+			if dryRun {
+				result.Action = "archive"
+				return result.Print(jsonOutput)
+			}
+
+			if err := client.ModifyMessages(ctx, ids, nil, []string{"INBOX"}); err != nil {
+				return fmt.Errorf("archiving messages: %w", err)
+			}
+
+			return result.Print(jsonOutput)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
+	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read message IDs from stdin")
+	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve message IDs")
+
+	return cmd
+}

--- a/internal/cmd/mail/archive_test.go
+++ b/internal/cmd/mail/archive_test.go
@@ -1,0 +1,155 @@
+package mail
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/open-cli-collective/google-readonly/internal/bulk"
+	"github.com/open-cli-collective/google-readonly/internal/testutil"
+)
+
+func TestArchiveCommand(t *testing.T) {
+	cmd := newArchiveCommand()
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		testutil.NotNil(t, flag)
+		testutil.Equal(t, flag.Shorthand, "j")
+	})
+
+	t.Run("has dry-run flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("dry-run")
+		testutil.NotNil(t, flag)
+		testutil.Equal(t, flag.Shorthand, "n")
+	})
+
+	t.Run("has stdin flag", func(t *testing.T) {
+		testutil.NotNil(t, cmd.Flags().Lookup("stdin"))
+	})
+
+	t.Run("has query flag", func(t *testing.T) {
+		testutil.NotNil(t, cmd.Flags().Lookup("query"))
+	})
+}
+
+func TestArchiveCommand_Success(t *testing.T) {
+	var modifiedIDs []string
+	var removedLabels []string
+
+	mock := &MockGmailClient{
+		ModifyMessagesFunc: func(_ context.Context, ids []string, _ []string, remove []string) error {
+			modifiedIDs = ids
+			removedLabels = remove
+			return nil
+		},
+	}
+
+	cmd := newArchiveCommand()
+	cmd.SetArgs([]string{"msg1", "msg2"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Contains(t, output, "Archived 2 message(s).")
+		testutil.Len(t, modifiedIDs, 2)
+		testutil.SliceContains(t, removedLabels, "INBOX")
+	})
+}
+
+func TestArchiveCommand_DryRun(t *testing.T) {
+	mock := &MockGmailClient{}
+
+	cmd := newArchiveCommand()
+	cmd.SetArgs([]string{"msg1", "--dry-run"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Contains(t, output, "[dry-run] Would archive 1 message(s).")
+	})
+}
+
+func TestArchiveCommand_JSON(t *testing.T) {
+	mock := &MockGmailClient{
+		ModifyMessagesFunc: func(_ context.Context, _ []string, _, _ []string) error {
+			return nil
+		},
+	}
+
+	cmd := newArchiveCommand()
+	cmd.SetArgs([]string{"msg1", "--json"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		var result bulk.Result
+		err := json.Unmarshal([]byte(output), &result)
+		testutil.NoError(t, err)
+		testutil.Equal(t, result.Action, "archived")
+		testutil.Equal(t, result.Count, 1)
+	})
+}
+
+func TestArchiveCommand_Query(t *testing.T) {
+	mock := &MockGmailClient{
+		SearchMessageIDsFunc: func(_ context.Context, q string, _ int64) ([]string, error) {
+			testutil.Equal(t, q, "from:noreply")
+			return []string{"msg1", "msg2", "msg3"}, nil
+		},
+		ModifyMessagesFunc: func(_ context.Context, ids []string, _, _ []string) error {
+			testutil.Len(t, ids, 3)
+			return nil
+		},
+	}
+
+	cmd := newArchiveCommand()
+	cmd.SetArgs([]string{"--query", "from:noreply"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Contains(t, output, "Archived 3 message(s).")
+	})
+}
+
+func TestArchiveCommand_APIError(t *testing.T) {
+	mock := &MockGmailClient{
+		ModifyMessagesFunc: func(_ context.Context, _ []string, _, _ []string) error {
+			return errors.New("permission denied")
+		},
+	}
+
+	cmd := newArchiveCommand()
+	cmd.SetArgs([]string{"msg1"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "archiving messages")
+	})
+}
+
+func TestArchiveCommand_ClientCreationError(t *testing.T) {
+	cmd := newArchiveCommand()
+	cmd.SetArgs([]string{"msg1"})
+
+	withFailingClientFactory(func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "creating Gmail client")
+	})
+}

--- a/internal/cmd/mail/archive_test.go
+++ b/internal/cmd/mail/archive_test.go
@@ -62,7 +62,12 @@ func TestArchiveCommand_Success(t *testing.T) {
 }
 
 func TestArchiveCommand_DryRun(t *testing.T) {
-	mock := &MockGmailClient{}
+	mock := &MockGmailClient{
+		ModifyMessagesFunc: func(_ context.Context, _ []string, _, _ []string) error {
+			t.Fatal("ModifyMessages should not be called in dry-run")
+			return nil
+		},
+	}
 
 	cmd := newArchiveCommand()
 	cmd.SetArgs([]string{"msg1", "--dry-run"})

--- a/internal/cmd/mail/categorize.go
+++ b/internal/cmd/mail/categorize.go
@@ -1,0 +1,112 @@
+package mail
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/bulk"
+)
+
+// categoryLabels maps user-friendly category names to Gmail label IDs.
+var categoryLabels = map[string]string{
+	"personal":   "CATEGORY_PERSONAL",
+	"social":     "CATEGORY_SOCIAL",
+	"promotions": "CATEGORY_PROMOTIONS",
+	"updates":    "CATEGORY_UPDATES",
+	"forums":     "CATEGORY_FORUMS",
+}
+
+// allCategoryLabelIDs returns all category label IDs for removal when recategorizing.
+func allCategoryLabelIDs() []string {
+	ids := make([]string, 0, len(categoryLabels))
+	for _, id := range categoryLabels {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func newCategorizeCommand() *cobra.Command {
+	var (
+		jsonOutput bool
+		dryRun     bool
+		stdin      bool
+		query      string
+	)
+
+	validCategories := make([]string, 0, len(categoryLabels))
+	for name := range categoryLabels {
+		validCategories = append(validCategories, name)
+	}
+
+	cmd := &cobra.Command{
+		Use:   "categorize <category> [message-ids...]",
+		Short: "Recategorize messages",
+		Long: fmt.Sprintf(`Move Gmail messages to a different category tab.
+
+This removes all existing category labels and adds the target category.
+
+Valid categories: %s
+
+Examples:
+  gro mail categorize promotions msg123
+  gro mail categorize social --query "from:linkedin"
+  gro mail categorize promotions --query "category:updates from:noreply" --dry-run`, strings.Join(validCategories, ", ")),
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			category := strings.ToLower(args[0])
+			messageArgs := args[1:]
+
+			targetLabel, ok := categoryLabels[category]
+			if !ok {
+				return fmt.Errorf("invalid category %q; valid categories: %s", category, strings.Join(validCategories, ", "))
+			}
+
+			client, err := newGmailClient(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("creating Gmail client: %w", err)
+			}
+
+			ctx := cmd.Context()
+			ids, err := bulk.ResolveIDs(bulk.Config{
+				Args:  messageArgs,
+				Stdin: stdin,
+				Query: query,
+			}, func(q string) ([]string, error) {
+				return client.SearchMessageIDs(ctx, q, 0)
+			})
+			if err != nil {
+				return err
+			}
+
+			result := &bulk.Result{
+				Action:  fmt.Sprintf("recategorized to %s", category),
+				IDs:     ids,
+				Count:   len(ids),
+				DryRun:  dryRun,
+				Details: map[string]string{"category": category, "labelId": targetLabel},
+			}
+
+			if dryRun {
+				result.Action = fmt.Sprintf("recategorize to %s", category)
+				return result.Print(jsonOutput)
+			}
+
+			// Remove all category labels and add the target one
+			removeLabels := allCategoryLabelIDs()
+			if err := client.ModifyMessages(ctx, ids, []string{targetLabel}, removeLabels); err != nil {
+				return fmt.Errorf("recategorizing messages: %w", err)
+			}
+
+			return result.Print(jsonOutput)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
+	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read message IDs from stdin")
+	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve message IDs")
+
+	return cmd
+}

--- a/internal/cmd/mail/categorize.go
+++ b/internal/cmd/mail/categorize.go
@@ -25,6 +25,7 @@ func allCategoryLabelIDs() []string {
 	for _, id := range categoryLabels {
 		ids = append(ids, id)
 	}
+	sort.Strings(ids)
 	return ids
 }
 

--- a/internal/cmd/mail/categorize.go
+++ b/internal/cmd/mail/categorize.go
@@ -2,6 +2,7 @@ package mail
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -39,6 +40,7 @@ func newCategorizeCommand() *cobra.Command {
 	for name := range categoryLabels {
 		validCategories = append(validCategories, name)
 	}
+	sort.Strings(validCategories)
 
 	cmd := &cobra.Command{
 		Use:   "categorize <category> [message-ids...]",

--- a/internal/cmd/mail/categorize_test.go
+++ b/internal/cmd/mail/categorize_test.go
@@ -1,0 +1,94 @@
+package mail
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-cli-collective/google-readonly/internal/testutil"
+)
+
+func TestCategorizeCommand(t *testing.T) {
+	cmd := newCategorizeCommand()
+
+	t.Run("requires at least one argument", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		testutil.Error(t, err)
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		testutil.NotNil(t, cmd.Flags().Lookup("json"))
+	})
+}
+
+func TestCategorizeCommand_Success(t *testing.T) {
+	var addedLabels, removedLabels []string
+	mock := &MockGmailClient{
+		ModifyMessagesFunc: func(_ context.Context, _ []string, add, remove []string) error {
+			addedLabels = add
+			removedLabels = remove
+			return nil
+		},
+	}
+
+	cmd := newCategorizeCommand()
+	cmd.SetArgs([]string{"promotions", "msg1"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Contains(t, output, "Recategorized to promotions 1 message(s).")
+		testutil.SliceContains(t, addedLabels, "CATEGORY_PROMOTIONS")
+		// Should remove all category labels
+		testutil.Greater(t, len(removedLabels), 0)
+	})
+}
+
+func TestCategorizeCommand_InvalidCategory(t *testing.T) {
+	mock := &MockGmailClient{}
+
+	cmd := newCategorizeCommand()
+	cmd.SetArgs([]string{"invalid", "msg1"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "invalid category")
+	})
+}
+
+func TestCategorizeCommand_DryRun(t *testing.T) {
+	mock := &MockGmailClient{}
+
+	cmd := newCategorizeCommand()
+	cmd.SetArgs([]string{"social", "msg1", "--dry-run"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Contains(t, output, "[dry-run] Would recategorize to social 1 message(s).")
+	})
+}
+
+func TestCategorizeCommand_CaseInsensitive(t *testing.T) {
+	mock := &MockGmailClient{
+		ModifyMessagesFunc: func(_ context.Context, _ []string, add, _ []string) error {
+			testutil.SliceContains(t, add, "CATEGORY_FORUMS")
+			return nil
+		},
+	}
+
+	cmd := newCategorizeCommand()
+	cmd.SetArgs([]string{"Forums", "msg1"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Contains(t, output, "Recategorized to forums 1 message(s).")
+	})
+}

--- a/internal/cmd/mail/handlers_test.go
+++ b/internal/cmd/mail/handlers_test.go
@@ -147,6 +147,40 @@ func TestSearchCommand_ClientCreationError(t *testing.T) {
 	})
 }
 
+func TestSearchCommand_IDsOutput(t *testing.T) {
+	mock := &MockGmailClient{
+		SearchMessageIDsFunc: func(_ context.Context, query string, _ int64) ([]string, error) {
+			testutil.Equal(t, query, "is:inbox")
+			return []string{"msg1", "msg2", "msg3"}, nil
+		},
+	}
+
+	cmd := newSearchCommand()
+	cmd.SetArgs([]string{"is:inbox", "--ids"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Contains(t, output, "msg1")
+		testutil.Contains(t, output, "msg2")
+		testutil.Contains(t, output, "msg3")
+	})
+}
+
+func TestSearchCommand_IDsAndJSONMutuallyExclusive(t *testing.T) {
+	cmd := newSearchCommand()
+	cmd.SetArgs([]string{"is:inbox", "--ids", "--json"})
+
+	withMockClient(&MockGmailClient{}, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "mutually exclusive")
+	})
+}
+
 func TestSearchCommand_SkippedMessages(t *testing.T) {
 	mock := &MockGmailClient{
 		SearchMessagesFunc: func(_ context.Context, _ string, _ int64) ([]*gmailapi.Message, int, error) {

--- a/internal/cmd/mail/label.go
+++ b/internal/cmd/mail/label.go
@@ -1,0 +1,154 @@
+package mail
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/bulk"
+)
+
+func newLabelCommand() *cobra.Command {
+	var (
+		jsonOutput bool
+		dryRun     bool
+		stdin      bool
+		query      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "label <label-name> [message-ids...]",
+		Short: "Add a label to messages",
+		Long: `Add a user label to Gmail messages. The label is resolved by display name.
+
+Examples:
+  gro mail label "Work" msg123 msg456
+  gro mail search "from:boss" --ids | gro mail label "Important" --stdin
+  gro mail label "Projects" --query "subject:sprint"`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			labelName := args[0]
+			messageArgs := args[1:]
+
+			client, err := newGmailClient(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("creating Gmail client: %w", err)
+			}
+
+			ctx := cmd.Context()
+			labelID, err := client.GetLabelID(ctx, labelName)
+			if err != nil {
+				return fmt.Errorf("resolving label: %w", err)
+			}
+
+			ids, err := bulk.ResolveIDs(bulk.Config{
+				Args:  messageArgs,
+				Stdin: stdin,
+				Query: query,
+			}, func(q string) ([]string, error) {
+				return client.SearchMessageIDs(ctx, q, 0)
+			})
+			if err != nil {
+				return err
+			}
+
+			result := &bulk.Result{
+				Action:  fmt.Sprintf("added label '%s' to", labelName),
+				IDs:     ids,
+				Count:   len(ids),
+				DryRun:  dryRun,
+				Details: map[string]string{"label": labelName, "labelId": labelID},
+			}
+
+			if dryRun {
+				result.Action = fmt.Sprintf("add label '%s' to", labelName)
+				return result.Print(jsonOutput)
+			}
+
+			if err := client.ModifyMessages(ctx, ids, []string{labelID}, nil); err != nil {
+				return fmt.Errorf("adding label: %w", err)
+			}
+
+			return result.Print(jsonOutput)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
+	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read message IDs from stdin")
+	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve message IDs")
+
+	return cmd
+}
+
+func newUnlabelCommand() *cobra.Command {
+	var (
+		jsonOutput bool
+		dryRun     bool
+		stdin      bool
+		query      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "unlabel <label-name> [message-ids...]",
+		Short: "Remove a label from messages",
+		Long: `Remove a user label from Gmail messages. The label is resolved by display name.
+
+Examples:
+  gro mail unlabel "Work" msg123
+  gro mail unlabel "Old" --query "label:Old older_than:90d"`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			labelName := args[0]
+			messageArgs := args[1:]
+
+			client, err := newGmailClient(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("creating Gmail client: %w", err)
+			}
+
+			ctx := cmd.Context()
+			labelID, err := client.GetLabelID(ctx, labelName)
+			if err != nil {
+				return fmt.Errorf("resolving label: %w", err)
+			}
+
+			ids, err := bulk.ResolveIDs(bulk.Config{
+				Args:  messageArgs,
+				Stdin: stdin,
+				Query: query,
+			}, func(q string) ([]string, error) {
+				return client.SearchMessageIDs(ctx, q, 0)
+			})
+			if err != nil {
+				return err
+			}
+
+			result := &bulk.Result{
+				Action:  fmt.Sprintf("removed label '%s' from", labelName),
+				IDs:     ids,
+				Count:   len(ids),
+				DryRun:  dryRun,
+				Details: map[string]string{"label": labelName, "labelId": labelID},
+			}
+
+			if dryRun {
+				result.Action = fmt.Sprintf("remove label '%s' from", labelName)
+				return result.Print(jsonOutput)
+			}
+
+			if err := client.ModifyMessages(ctx, ids, nil, []string{labelID}); err != nil {
+				return fmt.Errorf("removing label: %w", err)
+			}
+
+			return result.Print(jsonOutput)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
+	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read message IDs from stdin")
+	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve message IDs")
+
+	return cmd
+}

--- a/internal/cmd/mail/label_test.go
+++ b/internal/cmd/mail/label_test.go
@@ -1,0 +1,115 @@
+package mail
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/open-cli-collective/google-readonly/internal/testutil"
+)
+
+func TestLabelCommand(t *testing.T) {
+	cmd := newLabelCommand()
+
+	t.Run("requires at least one argument", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		testutil.Error(t, err)
+	})
+
+	t.Run("accepts label name only", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{"Work"})
+		testutil.NoError(t, err)
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		testutil.NotNil(t, cmd.Flags().Lookup("json"))
+	})
+}
+
+func TestLabelCommand_Success(t *testing.T) {
+	var addedLabels []string
+	mock := &MockGmailClient{
+		GetLabelIDFunc: func(_ context.Context, name string) (string, error) {
+			testutil.Equal(t, name, "Work")
+			return "Label_1", nil
+		},
+		ModifyMessagesFunc: func(_ context.Context, _ []string, add, _ []string) error {
+			addedLabels = add
+			return nil
+		},
+	}
+
+	cmd := newLabelCommand()
+	cmd.SetArgs([]string{"Work", "msg1", "msg2"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Contains(t, output, "Added label 'Work' to 2 message(s).")
+		testutil.SliceContains(t, addedLabels, "Label_1")
+	})
+}
+
+func TestLabelCommand_LabelNotFound(t *testing.T) {
+	mock := &MockGmailClient{
+		GetLabelIDFunc: func(_ context.Context, _ string) (string, error) {
+			return "", errors.New("label \"Nonexistent\" not found")
+		},
+	}
+
+	cmd := newLabelCommand()
+	cmd.SetArgs([]string{"Nonexistent", "msg1"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "resolving label")
+	})
+}
+
+func TestLabelCommand_DryRun(t *testing.T) {
+	mock := &MockGmailClient{
+		GetLabelIDFunc: func(_ context.Context, _ string) (string, error) {
+			return "Label_1", nil
+		},
+	}
+
+	cmd := newLabelCommand()
+	cmd.SetArgs([]string{"Work", "msg1", "--dry-run"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Contains(t, output, "[dry-run] Would add label 'Work' to 1 message(s).")
+	})
+}
+
+func TestUnlabelCommand_Success(t *testing.T) {
+	var removedLabels []string
+	mock := &MockGmailClient{
+		GetLabelIDFunc: func(_ context.Context, name string) (string, error) {
+			testutil.Equal(t, name, "Work")
+			return "Label_1", nil
+		},
+		ModifyMessagesFunc: func(_ context.Context, _ []string, _, remove []string) error {
+			removedLabels = remove
+			return nil
+		},
+	}
+
+	cmd := newUnlabelCommand()
+	cmd.SetArgs([]string{"Work", "msg1"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Contains(t, output, "Removed label 'Work' from 1 message(s).")
+		testutil.SliceContains(t, removedLabels, "Label_1")
+	})
+}

--- a/internal/cmd/mail/label_test.go
+++ b/internal/cmd/mail/label_test.go
@@ -113,3 +113,59 @@ func TestUnlabelCommand_Success(t *testing.T) {
 		testutil.SliceContains(t, removedLabels, "Label_1")
 	})
 }
+
+func TestUnlabelCommand_DryRun(t *testing.T) {
+	mock := &MockGmailClient{
+		GetLabelIDFunc: func(_ context.Context, _ string) (string, error) {
+			return "Label_1", nil
+		},
+	}
+
+	cmd := newUnlabelCommand()
+	cmd.SetArgs([]string{"Work", "msg1", "--dry-run"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Contains(t, output, "[dry-run] Would remove label 'Work' from 1 message(s).")
+	})
+}
+
+func TestUnlabelCommand_LabelNotFound(t *testing.T) {
+	mock := &MockGmailClient{
+		GetLabelIDFunc: func(_ context.Context, _ string) (string, error) {
+			return "", errors.New("label \"Nope\" not found")
+		},
+	}
+
+	cmd := newUnlabelCommand()
+	cmd.SetArgs([]string{"Nope", "msg1"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "resolving label")
+	})
+}
+
+func TestUnlabelCommand_APIError(t *testing.T) {
+	mock := &MockGmailClient{
+		GetLabelIDFunc: func(_ context.Context, _ string) (string, error) {
+			return "Label_1", nil
+		},
+		ModifyMessagesFunc: func(_ context.Context, _ []string, _, _ []string) error {
+			return errors.New("API error")
+		},
+	}
+
+	cmd := newUnlabelCommand()
+	cmd.SetArgs([]string{"Work", "msg1"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "removing label")
+	})
+}

--- a/internal/cmd/mail/mail.go
+++ b/internal/cmd/mail/mail.go
@@ -10,7 +10,7 @@ func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mail",
 		Short: "Gmail commands",
-		Long: `Read-only access to Gmail messages, threads, and attachments.
+		Long: `Access to Gmail messages, threads, attachments, and organizational operations.
 
 This command group provides Gmail functionality:
 - search: Search for messages using Gmail query syntax
@@ -19,12 +19,21 @@ This command group provides Gmail functionality:
 - labels: List all labels
 - attachments: List and download attachments
 
+Organizational operations (non-destructive):
+- archive: Remove messages from inbox
+- star/unstar: Star or unstar messages
+- mark-read/mark-unread: Toggle read status
+- label/unlabel: Add or remove user labels
+- categorize: Move messages between category tabs
+
+All organizational commands support bulk operations via positional IDs,
+--stdin (for piping), or --query (inline search).
+
 Examples:
   gro mail search "is:unread"
   gro mail read <message-id>
-  gro mail thread <thread-id>
-  gro mail labels
-  gro mail attachments list <message-id>`,
+  gro mail archive --query "from:noreply older_than:30d"
+  gro mail search "is:inbox" --ids | gro mail star --stdin`,
 	}
 
 	cmd.AddCommand(newSearchCommand())
@@ -32,6 +41,14 @@ Examples:
 	cmd.AddCommand(newThreadCommand())
 	cmd.AddCommand(newLabelsCommand())
 	cmd.AddCommand(newAttachmentsCommand())
+	cmd.AddCommand(newArchiveCommand())
+	cmd.AddCommand(newStarCommand())
+	cmd.AddCommand(newUnstarCommand())
+	cmd.AddCommand(newMarkReadCommand())
+	cmd.AddCommand(newMarkUnreadCommand())
+	cmd.AddCommand(newLabelCommand())
+	cmd.AddCommand(newUnlabelCommand())
+	cmd.AddCommand(newCategorizeCommand())
 
 	return cmd
 }

--- a/internal/cmd/mail/markread.go
+++ b/internal/cmd/mail/markread.go
@@ -1,0 +1,134 @@
+package mail
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/bulk"
+)
+
+func newMarkReadCommand() *cobra.Command {
+	var (
+		jsonOutput bool
+		dryRun     bool
+		stdin      bool
+		query      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "mark-read [message-ids...]",
+		Short: "Mark messages as read",
+		Long: `Mark Gmail messages as read by removing the UNREAD label.
+
+Examples:
+  gro mail mark-read msg123 msg456
+  gro mail search "is:unread" --ids | gro mail mark-read --stdin
+  gro mail mark-read --query "is:unread older_than:7d"`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newGmailClient(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("creating Gmail client: %w", err)
+			}
+
+			ctx := cmd.Context()
+			ids, err := bulk.ResolveIDs(bulk.Config{
+				Args:  args,
+				Stdin: stdin,
+				Query: query,
+			}, func(q string) ([]string, error) {
+				return client.SearchMessageIDs(ctx, q, 0)
+			})
+			if err != nil {
+				return err
+			}
+
+			result := &bulk.Result{
+				Action: "marked as read",
+				IDs:    ids,
+				Count:  len(ids),
+				DryRun: dryRun,
+			}
+
+			if dryRun {
+				result.Action = "mark as read"
+				return result.Print(jsonOutput)
+			}
+
+			if err := client.ModifyMessages(ctx, ids, nil, []string{"UNREAD"}); err != nil {
+				return fmt.Errorf("marking messages as read: %w", err)
+			}
+
+			return result.Print(jsonOutput)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
+	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read message IDs from stdin")
+	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve message IDs")
+
+	return cmd
+}
+
+func newMarkUnreadCommand() *cobra.Command {
+	var (
+		jsonOutput bool
+		dryRun     bool
+		stdin      bool
+		query      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "mark-unread [message-ids...]",
+		Short: "Mark messages as unread",
+		Long: `Mark Gmail messages as unread by adding the UNREAD label.
+
+Examples:
+  gro mail mark-unread msg123
+  gro mail mark-unread --query "subject:important"`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newGmailClient(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("creating Gmail client: %w", err)
+			}
+
+			ctx := cmd.Context()
+			ids, err := bulk.ResolveIDs(bulk.Config{
+				Args:  args,
+				Stdin: stdin,
+				Query: query,
+			}, func(q string) ([]string, error) {
+				return client.SearchMessageIDs(ctx, q, 0)
+			})
+			if err != nil {
+				return err
+			}
+
+			result := &bulk.Result{
+				Action: "marked as unread",
+				IDs:    ids,
+				Count:  len(ids),
+				DryRun: dryRun,
+			}
+
+			if dryRun {
+				result.Action = "mark as unread"
+				return result.Print(jsonOutput)
+			}
+
+			if err := client.ModifyMessages(ctx, ids, []string{"UNREAD"}, nil); err != nil {
+				return fmt.Errorf("marking messages as unread: %w", err)
+			}
+
+			return result.Print(jsonOutput)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
+	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read message IDs from stdin")
+	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve message IDs")
+
+	return cmd
+}

--- a/internal/cmd/mail/markread_test.go
+++ b/internal/cmd/mail/markread_test.go
@@ -1,0 +1,78 @@
+package mail
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-cli-collective/google-readonly/internal/testutil"
+)
+
+func TestMarkReadCommand(t *testing.T) {
+	cmd := newMarkReadCommand()
+
+	t.Run("has json flag", func(t *testing.T) {
+		testutil.NotNil(t, cmd.Flags().Lookup("json"))
+	})
+
+	t.Run("has dry-run flag", func(t *testing.T) {
+		testutil.NotNil(t, cmd.Flags().Lookup("dry-run"))
+	})
+}
+
+func TestMarkReadCommand_Success(t *testing.T) {
+	var removedLabels []string
+	mock := &MockGmailClient{
+		ModifyMessagesFunc: func(_ context.Context, _ []string, _, remove []string) error {
+			removedLabels = remove
+			return nil
+		},
+	}
+
+	cmd := newMarkReadCommand()
+	cmd.SetArgs([]string{"msg1", "msg2"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Contains(t, output, "Marked as read 2 message(s).")
+		testutil.SliceContains(t, removedLabels, "UNREAD")
+	})
+}
+
+func TestMarkReadCommand_DryRun(t *testing.T) {
+	mock := &MockGmailClient{}
+	cmd := newMarkReadCommand()
+	cmd.SetArgs([]string{"msg1", "--dry-run"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Contains(t, output, "[dry-run] Would mark as read 1 message(s).")
+	})
+}
+
+func TestMarkUnreadCommand_Success(t *testing.T) {
+	var addedLabels []string
+	mock := &MockGmailClient{
+		ModifyMessagesFunc: func(_ context.Context, _ []string, add, _ []string) error {
+			addedLabels = add
+			return nil
+		},
+	}
+
+	cmd := newMarkUnreadCommand()
+	cmd.SetArgs([]string{"msg1"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Contains(t, output, "Marked as unread 1 message(s).")
+		testutil.SliceContains(t, addedLabels, "UNREAD")
+	})
+}

--- a/internal/cmd/mail/markread_test.go
+++ b/internal/cmd/mail/markread_test.go
@@ -42,7 +42,12 @@ func TestMarkReadCommand_Success(t *testing.T) {
 }
 
 func TestMarkReadCommand_DryRun(t *testing.T) {
-	mock := &MockGmailClient{}
+	mock := &MockGmailClient{
+		ModifyMessagesFunc: func(_ context.Context, _ []string, _, _ []string) error {
+			t.Fatal("ModifyMessages should not be called in dry-run")
+			return nil
+		},
+	}
 	cmd := newMarkReadCommand()
 	cmd.SetArgs([]string{"msg1", "--dry-run"})
 

--- a/internal/cmd/mail/mock_test.go
+++ b/internal/cmd/mail/mock_test.go
@@ -13,10 +13,13 @@ import (
 type MockGmailClient struct {
 	GetMessageFunc               func(ctx context.Context, messageID string, includeBody bool) (*gmailapi.Message, error)
 	SearchMessagesFunc           func(ctx context.Context, query string, maxResults int64) ([]*gmailapi.Message, int, error)
+	SearchMessageIDsFunc         func(ctx context.Context, query string, maxResults int64) ([]string, error)
 	GetThreadFunc                func(ctx context.Context, id string) ([]*gmailapi.Message, error)
 	FetchLabelsFunc              func(ctx context.Context) error
 	GetLabelNameFunc             func(labelID string) string
+	GetLabelIDFunc               func(ctx context.Context, name string) (string, error)
 	GetLabelsFunc                func() []*gmail.Label
+	ModifyMessagesFunc           func(ctx context.Context, ids []string, addLabels, removeLabels []string) error
 	GetAttachmentsFunc           func(ctx context.Context, messageID string) ([]*gmailapi.Attachment, error)
 	DownloadAttachmentFunc       func(ctx context.Context, messageID, attachmentID string) ([]byte, error)
 	DownloadInlineAttachmentFunc func(ctx context.Context, messageID, partID string) ([]byte, error)
@@ -40,6 +43,13 @@ func (m *MockGmailClient) SearchMessages(ctx context.Context, query string, maxR
 	return nil, 0, nil
 }
 
+func (m *MockGmailClient) SearchMessageIDs(ctx context.Context, query string, maxResults int64) ([]string, error) {
+	if m.SearchMessageIDsFunc != nil {
+		return m.SearchMessageIDsFunc(ctx, query, maxResults)
+	}
+	return nil, nil
+}
+
 func (m *MockGmailClient) GetThread(ctx context.Context, id string) ([]*gmailapi.Message, error) {
 	if m.GetThreadFunc != nil {
 		return m.GetThreadFunc(ctx, id)
@@ -61,9 +71,23 @@ func (m *MockGmailClient) GetLabelName(labelID string) string {
 	return labelID
 }
 
+func (m *MockGmailClient) GetLabelID(ctx context.Context, name string) (string, error) {
+	if m.GetLabelIDFunc != nil {
+		return m.GetLabelIDFunc(ctx, name)
+	}
+	return "", nil
+}
+
 func (m *MockGmailClient) GetLabels() []*gmail.Label {
 	if m.GetLabelsFunc != nil {
 		return m.GetLabelsFunc()
+	}
+	return nil
+}
+
+func (m *MockGmailClient) ModifyMessages(ctx context.Context, ids []string, addLabels, removeLabels []string) error {
+	if m.ModifyMessagesFunc != nil {
+		return m.ModifyMessagesFunc(ctx, ids, addLabels, removeLabels)
 	}
 	return nil
 }

--- a/internal/cmd/mail/output.go
+++ b/internal/cmd/mail/output.go
@@ -15,10 +15,13 @@ import (
 type MailClient interface {
 	GetMessage(ctx context.Context, messageID string, includeBody bool) (*gmail.Message, error)
 	SearchMessages(ctx context.Context, query string, maxResults int64) ([]*gmail.Message, int, error)
+	SearchMessageIDs(ctx context.Context, query string, maxResults int64) ([]string, error)
 	GetThread(ctx context.Context, id string) ([]*gmail.Message, error)
 	FetchLabels(ctx context.Context) error
 	GetLabelName(labelID string) string
+	GetLabelID(ctx context.Context, name string) (string, error)
 	GetLabels() []*gmailv1.Label
+	ModifyMessages(ctx context.Context, ids []string, addLabels, removeLabels []string) error
 	GetAttachments(ctx context.Context, messageID string) ([]*gmail.Attachment, error)
 	DownloadAttachment(ctx context.Context, messageID string, attachmentID string) ([]byte, error)
 	DownloadInlineAttachment(ctx context.Context, messageID string, partID string) ([]byte, error)

--- a/internal/cmd/mail/search.go
+++ b/internal/cmd/mail/search.go
@@ -10,6 +10,7 @@ func newSearchCommand() *cobra.Command {
 	var (
 		maxResults int64
 		jsonOutput bool
+		idsOnly    bool
 	)
 
 	cmd := &cobra.Command{
@@ -22,13 +23,29 @@ Examples:
   gro mail search "subject:meeting" --max 20
   gro mail search "is:unread" --json
   gro mail search "after:2024/01/01 before:2024/02/01"
+  gro mail search "is:inbox" --ids | gro mail archive --stdin
 
 For more query operators, see: https://support.google.com/mail/answer/7190`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if idsOnly && jsonOutput {
+				return fmt.Errorf("--ids and --json are mutually exclusive")
+			}
+
 			client, err := newGmailClient(cmd.Context())
 			if err != nil {
 				return fmt.Errorf("creating Gmail client: %w", err)
+			}
+
+			if idsOnly {
+				ids, err := client.SearchMessageIDs(cmd.Context(), args[0], maxResults)
+				if err != nil {
+					return fmt.Errorf("searching messages: %w", err)
+				}
+				for _, id := range ids {
+					fmt.Println(id)
+				}
+				return nil
 			}
 
 			messages, skipped, err := client.SearchMessages(cmd.Context(), args[0], maxResults)
@@ -67,6 +84,7 @@ For more query operators, see: https://support.google.com/mail/answer/7190`,
 
 	cmd.Flags().Int64VarP(&maxResults, "max", "m", 10, "Maximum number of results to return")
 	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
+	cmd.Flags().BoolVar(&idsOnly, "ids", false, "Output only message IDs (one per line, for piping)")
 
 	return cmd
 }

--- a/internal/cmd/mail/search_test.go
+++ b/internal/cmd/mail/search_test.go
@@ -38,6 +38,12 @@ func TestSearchCommand(t *testing.T) {
 		testutil.Equal(t, flag.DefValue, "false")
 	})
 
+	t.Run("has ids flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("ids")
+		testutil.NotNil(t, flag)
+		testutil.Equal(t, flag.DefValue, "false")
+	})
+
 	t.Run("has examples in long description", func(t *testing.T) {
 		testutil.Contains(t, cmd.Long, "from:")
 		testutil.Contains(t, cmd.Long, "subject:")

--- a/internal/cmd/mail/star.go
+++ b/internal/cmd/mail/star.go
@@ -1,0 +1,134 @@
+package mail
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/bulk"
+)
+
+func newStarCommand() *cobra.Command {
+	var (
+		jsonOutput bool
+		dryRun     bool
+		stdin      bool
+		query      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "star [message-ids...]",
+		Short: "Star messages",
+		Long: `Star Gmail messages by adding the STARRED label.
+
+Examples:
+  gro mail star msg123
+  gro mail search "is:inbox" --ids | gro mail star --stdin
+  gro mail star --query "from:boss is:unread"`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newGmailClient(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("creating Gmail client: %w", err)
+			}
+
+			ctx := cmd.Context()
+			ids, err := bulk.ResolveIDs(bulk.Config{
+				Args:  args,
+				Stdin: stdin,
+				Query: query,
+			}, func(q string) ([]string, error) {
+				return client.SearchMessageIDs(ctx, q, 0)
+			})
+			if err != nil {
+				return err
+			}
+
+			result := &bulk.Result{
+				Action: "starred",
+				IDs:    ids,
+				Count:  len(ids),
+				DryRun: dryRun,
+			}
+
+			if dryRun {
+				result.Action = "star"
+				return result.Print(jsonOutput)
+			}
+
+			if err := client.ModifyMessages(ctx, ids, []string{"STARRED"}, nil); err != nil {
+				return fmt.Errorf("starring messages: %w", err)
+			}
+
+			return result.Print(jsonOutput)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
+	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read message IDs from stdin")
+	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve message IDs")
+
+	return cmd
+}
+
+func newUnstarCommand() *cobra.Command {
+	var (
+		jsonOutput bool
+		dryRun     bool
+		stdin      bool
+		query      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "unstar [message-ids...]",
+		Short: "Unstar messages",
+		Long: `Unstar Gmail messages by removing the STARRED label.
+
+Examples:
+  gro mail unstar msg123
+  gro mail search "is:starred" --ids | gro mail unstar --stdin`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newGmailClient(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("creating Gmail client: %w", err)
+			}
+
+			ctx := cmd.Context()
+			ids, err := bulk.ResolveIDs(bulk.Config{
+				Args:  args,
+				Stdin: stdin,
+				Query: query,
+			}, func(q string) ([]string, error) {
+				return client.SearchMessageIDs(ctx, q, 0)
+			})
+			if err != nil {
+				return err
+			}
+
+			result := &bulk.Result{
+				Action: "unstarred",
+				IDs:    ids,
+				Count:  len(ids),
+				DryRun: dryRun,
+			}
+
+			if dryRun {
+				result.Action = "unstar"
+				return result.Print(jsonOutput)
+			}
+
+			if err := client.ModifyMessages(ctx, ids, nil, []string{"STARRED"}); err != nil {
+				return fmt.Errorf("unstarring messages: %w", err)
+			}
+
+			return result.Print(jsonOutput)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
+	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read message IDs from stdin")
+	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve message IDs")
+
+	return cmd
+}

--- a/internal/cmd/mail/star_test.go
+++ b/internal/cmd/mail/star_test.go
@@ -42,7 +42,12 @@ func TestStarCommand_Success(t *testing.T) {
 }
 
 func TestStarCommand_DryRun(t *testing.T) {
-	mock := &MockGmailClient{}
+	mock := &MockGmailClient{
+		ModifyMessagesFunc: func(_ context.Context, _ []string, _, _ []string) error {
+			t.Fatal("ModifyMessages should not be called in dry-run")
+			return nil
+		},
+	}
 	cmd := newStarCommand()
 	cmd.SetArgs([]string{"msg1", "--dry-run"})
 

--- a/internal/cmd/mail/star_test.go
+++ b/internal/cmd/mail/star_test.go
@@ -1,0 +1,78 @@
+package mail
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-cli-collective/google-readonly/internal/testutil"
+)
+
+func TestStarCommand(t *testing.T) {
+	cmd := newStarCommand()
+
+	t.Run("has json flag", func(t *testing.T) {
+		testutil.NotNil(t, cmd.Flags().Lookup("json"))
+	})
+
+	t.Run("has dry-run flag", func(t *testing.T) {
+		testutil.NotNil(t, cmd.Flags().Lookup("dry-run"))
+	})
+}
+
+func TestStarCommand_Success(t *testing.T) {
+	var addedLabels []string
+	mock := &MockGmailClient{
+		ModifyMessagesFunc: func(_ context.Context, _ []string, add, _ []string) error {
+			addedLabels = add
+			return nil
+		},
+	}
+
+	cmd := newStarCommand()
+	cmd.SetArgs([]string{"msg1", "msg2"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Contains(t, output, "Starred 2 message(s).")
+		testutil.SliceContains(t, addedLabels, "STARRED")
+	})
+}
+
+func TestStarCommand_DryRun(t *testing.T) {
+	mock := &MockGmailClient{}
+	cmd := newStarCommand()
+	cmd.SetArgs([]string{"msg1", "--dry-run"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Contains(t, output, "[dry-run] Would star 1 message(s).")
+	})
+}
+
+func TestUnstarCommand_Success(t *testing.T) {
+	var removedLabels []string
+	mock := &MockGmailClient{
+		ModifyMessagesFunc: func(_ context.Context, _ []string, _, remove []string) error {
+			removedLabels = remove
+			return nil
+		},
+	}
+
+	cmd := newUnstarCommand()
+	cmd.SetArgs([]string{"msg1"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Contains(t, output, "Unstarred 1 message(s).")
+		testutil.SliceContains(t, removedLabels, "STARRED")
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,7 +43,7 @@ func GetConfigDir() (string, error) {
 	}
 	configDir := filepath.Join(configHome, DirName)
 
-	if err := os.MkdirAll(configDir, DirPerm); err != nil {
+	if err := os.MkdirAll(configDir, DirPerm); err != nil { //nolint:gosec // Path from user config directory, not user-controlled input
 		return "", err
 	}
 
@@ -90,7 +90,8 @@ const (
 
 // Config represents user-configurable settings
 type Config struct {
-	CacheTTLHours int `json:"cache_ttl_hours"`
+	CacheTTLHours int      `json:"cache_ttl_hours"`
+	GrantedScopes []string `json:"granted_scopes,omitempty"`
 }
 
 // GetConfigPath returns the full path to config.json

--- a/internal/gmail/client.go
+++ b/internal/gmail/client.go
@@ -17,6 +17,7 @@ type Client struct {
 	service      *gmail.Service
 	userID       string
 	labels       map[string]*gmail.Label
+	labelsByName map[string]string // display name -> label ID
 	labelsLoaded bool
 	labelsMu     sync.RWMutex
 }
@@ -64,8 +65,10 @@ func (c *Client) FetchLabels(ctx context.Context) error {
 	}
 
 	c.labels = make(map[string]*gmail.Label)
+	c.labelsByName = make(map[string]string)
 	for _, label := range resp.Labels {
 		c.labels[label.Id] = label
+		c.labelsByName[label.Name] = label.Id
 	}
 	c.labelsLoaded = true
 
@@ -96,6 +99,62 @@ func (c *Client) GetLabels() []*gmail.Label {
 		labels = append(labels, label)
 	}
 	return labels
+}
+
+// GetLabelID resolves a label display name to its ID. Calls FetchLabels if needed.
+func (c *Client) GetLabelID(ctx context.Context, name string) (string, error) {
+	if err := c.FetchLabels(ctx); err != nil {
+		return "", err
+	}
+
+	c.labelsMu.RLock()
+	defer c.labelsMu.RUnlock()
+
+	if id, ok := c.labelsByName[name]; ok {
+		return id, nil
+	}
+	return "", fmt.Errorf("label %q not found", name)
+}
+
+// ModifyMessages modifies labels on one or more messages.
+// Uses Messages.Modify for a single message; Messages.BatchModify for multiple.
+// Gmail limits batch operations to 1000 IDs, so this method chunks automatically.
+func (c *Client) ModifyMessages(ctx context.Context, ids []string, addLabels, removeLabels []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	if len(ids) == 1 {
+		req := &gmail.ModifyMessageRequest{
+			AddLabelIds:    addLabels,
+			RemoveLabelIds: removeLabels,
+		}
+		_, err := c.service.Users.Messages.Modify(c.userID, ids[0], req).Context(ctx).Do()
+		if err != nil {
+			return fmt.Errorf("modifying message %s: %w", ids[0], err)
+		}
+		return nil
+	}
+
+	const batchSize = 1000
+	for i := 0; i < len(ids); i += batchSize {
+		end := i + batchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		chunk := ids[i:end]
+
+		req := &gmail.BatchModifyMessagesRequest{
+			Ids:            chunk,
+			AddLabelIds:    addLabels,
+			RemoveLabelIds: removeLabels,
+		}
+		err := c.service.Users.Messages.BatchModify(c.userID, req).Context(ctx).Do()
+		if err != nil {
+			return fmt.Errorf("batch modifying messages: %w", err)
+		}
+	}
+	return nil
 }
 
 // Profile represents a Gmail user profile.

--- a/internal/gmail/messages.go
+++ b/internal/gmail/messages.go
@@ -70,6 +70,9 @@ func (c *Client) SearchMessages(ctx context.Context, query string, maxResults in
 
 // SearchMessageIDs returns only message IDs matching the query (no metadata fetch).
 // This is more efficient than SearchMessages when only IDs are needed.
+// Note: returns a single page of results (up to ~100 when maxResults is 0).
+// This matches SearchMessages behavior. For very large result sets, use a more
+// specific query to narrow results.
 func (c *Client) SearchMessageIDs(ctx context.Context, query string, maxResults int64) ([]string, error) {
 	call := c.service.Users.Messages.List(c.userID).Q(query)
 	if maxResults > 0 {

--- a/internal/gmail/messages.go
+++ b/internal/gmail/messages.go
@@ -68,6 +68,26 @@ func (c *Client) SearchMessages(ctx context.Context, query string, maxResults in
 	return messages, skipped, nil
 }
 
+// SearchMessageIDs returns only message IDs matching the query (no metadata fetch).
+// This is more efficient than SearchMessages when only IDs are needed.
+func (c *Client) SearchMessageIDs(ctx context.Context, query string, maxResults int64) ([]string, error) {
+	call := c.service.Users.Messages.List(c.userID).Q(query)
+	if maxResults > 0 {
+		call = call.MaxResults(maxResults)
+	}
+
+	resp, err := call.Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("searching message IDs: %w", err)
+	}
+
+	ids := make([]string, 0, len(resp.Messages))
+	for _, msg := range resp.Messages {
+		ids = append(ids, msg.Id)
+	}
+	return ids, nil
+}
+
 // GetMessage retrieves a single message by ID
 func (c *Client) GetMessage(ctx context.Context, messageID string, includeBody bool) (*Message, error) {
 	format := "metadata"


### PR DESCRIPTION
## Summary

- Add bulk organizational commands for Gmail: `archive`, `star`/`unstar`, `mark-read`/`mark-unread`, `label`/`unlabel`, `categorize`
- All commands support 3 input modes: positional IDs, `--stdin` (piping), `--query` (inline search), plus `--dry-run` and `--json`
- New `internal/bulk/` package with shared ID resolution and result types (reusable by Calendar/Drive/Contacts in future PRs)
- Gmail OAuth scope upgraded from `readonly` to `modify` (superset — adds label/archive/star, no send/delete)
- Architecture tests evolved from "readonly check" to non-destructive allowlist
- `gro mail search --ids` flag for efficient piping: `gro mail search "is:unread" --ids | gro mail archive --stdin`
- Scope migration detection: clear error + re-auth instructions if user has old read-only token

## Test plan

- [x] `make check` passes (lint, test with race detection, build)
- [x] All new commands have unit tests covering success, dry-run, query, and error paths
- [x] Architecture tests verify scope allowlist and forbidden destructive methods
- [x] Bulk resolve tests cover all 3 input modes + mutual exclusion errors
- [x] Search `--ids` + `--json` mutual exclusion tested
- [ ] Integration tests: run `gro mail archive --dry-run --query "is:inbox"` against live account
- [ ] Scope migration: verify old token triggers clear re-auth message

Closes #98