### PR TITLE
feat(calendar): add RSVP and color-coding operations

### DIFF
--- a/internal/architecture/architecture_test.go
+++ b/internal/architecture/architecture_test.go
@@ -311,6 +311,7 @@ var allowedScopes = map[string]bool{
 	"https://www.googleapis.com/auth/gmail.readonly":    true,
 	"https://www.googleapis.com/auth/gmail.modify":      true, // label, archive, star, read/unread (NOT send/delete)
 	"https://www.googleapis.com/auth/calendar.readonly": true,
+	"https://www.googleapis.com/auth/calendar.events":   true, // RSVP, color (NOT calendar settings)
 	"https://www.googleapis.com/auth/contacts.readonly": true,
 	"https://www.googleapis.com/auth/drive.readonly":    true,
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -21,9 +21,11 @@ import (
 // AllScopes contains all OAuth scopes used by the application.
 // Gmail uses the modify scope for organizational operations (label, archive, star, mark read/unread).
 // The modify scope is a superset of readonly — it includes all read access.
+// Calendar uses both readonly (for calendar list metadata) and events (for RSVP/color operations).
 var AllScopes = []string{
 	gmail.GmailModifyScope,
 	calendar.CalendarReadonlyScope,
+	calendar.CalendarEventsScope,
 	people.ContactsReadonlyScope,
 	drive.DriveReadonlyScope,
 }
@@ -33,6 +35,7 @@ var ScopeDescriptions = map[string]string{
 	gmail.GmailModifyScope:         "Gmail Modify — read messages, plus label, archive, star, and mark read/unread. No send or delete access.",
 	gmail.GmailReadonlyScope:       "Gmail Read-Only — read messages and metadata.",
 	calendar.CalendarReadonlyScope: "Calendar Read-Only — read calendars and events.",
+	calendar.CalendarEventsScope:   "Calendar Events — read and update events (RSVP, color). No calendar settings access.",
 	people.ContactsReadonlyScope:   "Contacts Read-Only — read contacts and groups.",
 	drive.DriveReadonlyScope:       "Drive Read-Only — read files and metadata.",
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -22,6 +22,8 @@ import (
 // Gmail uses the modify scope for organizational operations (label, archive, star, mark read/unread).
 // The modify scope is a superset of readonly — it includes all read access.
 // Calendar uses both readonly (for calendar list metadata) and events (for RSVP/color operations).
+// Note: calendar.events also permits event creation, which is an accepted trade-off for RSVP/color support.
+// The architecture test (TestNoDestructiveAPIMethodsInProductionCode) prevents accidental misuse.
 var AllScopes = []string{
 	gmail.GmailModifyScope,
 	calendar.CalendarReadonlyScope,

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -101,8 +101,8 @@ func TestDeprecatedWrappers(t *testing.T) {
 
 func TestAllScopes(t *testing.T) {
 	t.Parallel()
-	if len(AllScopes) != 4 {
-		t.Errorf("got length %d, want %d", len(AllScopes), 4)
+	if len(AllScopes) != 5 {
+		t.Errorf("got length %d, want %d", len(AllScopes), 5)
 	}
 	scopeSet := strings.Join(AllScopes, " ")
 	if !strings.Contains(scopeSet, "https://www.googleapis.com/auth/gmail.modify") {
@@ -110,6 +110,9 @@ func TestAllScopes(t *testing.T) {
 	}
 	if !strings.Contains(scopeSet, "https://www.googleapis.com/auth/calendar.readonly") {
 		t.Errorf("expected AllScopes to contain %q", "https://www.googleapis.com/auth/calendar.readonly")
+	}
+	if !strings.Contains(scopeSet, "https://www.googleapis.com/auth/calendar.events") {
+		t.Errorf("expected AllScopes to contain %q", "https://www.googleapis.com/auth/calendar.events")
 	}
 	if !strings.Contains(scopeSet, "https://www.googleapis.com/auth/contacts.readonly") {
 		t.Errorf("expected AllScopes to contain %q", "https://www.googleapis.com/auth/contacts.readonly")

--- a/internal/calendar/client.go
+++ b/internal/calendar/client.go
@@ -73,3 +73,46 @@ func (c *Client) GetEvent(ctx context.Context, calendarID, eventID string) (*cal
 	}
 	return event, nil
 }
+
+// RSVPEvent updates the current user's RSVP status on an event.
+// The response must be "accepted", "declined", or "tentative".
+func (c *Client) RSVPEvent(ctx context.Context, calendarID, eventID, response string) error {
+	event, err := c.service.Events.Get(calendarID, eventID).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("getting event for RSVP: %w", err)
+	}
+
+	// Find the current user's attendee entry
+	found := false
+	for _, a := range event.Attendees {
+		if a.Self {
+			a.ResponseStatus = response
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("you are not listed as an attendee on this event")
+	}
+
+	_, err = c.service.Events.Patch(calendarID, eventID, &calendar.Event{
+		Attendees: event.Attendees,
+	}).SendUpdates("none").Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("updating RSVP: %w", err)
+	}
+	return nil
+}
+
+// SetEventColor sets the color of a calendar event.
+// The colorID must be a valid Google Calendar event color ID (1-11).
+func (c *Client) SetEventColor(ctx context.Context, calendarID, eventID, colorID string) error {
+	_, err := c.service.Events.Patch(calendarID, eventID, &calendar.Event{
+		ColorId: colorID,
+	}).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("setting event color: %w", err)
+	}
+	return nil
+}

--- a/internal/calendar/client.go
+++ b/internal/calendar/client.go
@@ -98,11 +98,8 @@ func (c *Client) RSVPEvent(ctx context.Context, calendarID, eventID, response st
 
 	_, err = c.service.Events.Patch(calendarID, eventID, &calendar.Event{
 		Attendees: event.Attendees,
-	}).SendUpdates("none").Context(ctx).Do()
-	if err != nil {
-		return fmt.Errorf("updating RSVP: %w", err)
-	}
-	return nil
+	}).Context(ctx).Do()
+	return err
 }
 
 // SetEventColor sets the color of a calendar event.
@@ -111,8 +108,5 @@ func (c *Client) SetEventColor(ctx context.Context, calendarID, eventID, colorID
 	_, err := c.service.Events.Patch(calendarID, eventID, &calendar.Event{
 		ColorId: colorID,
 	}).Context(ctx).Do()
-	if err != nil {
-		return fmt.Errorf("setting event color: %w", err)
-	}
-	return nil
+	return err
 }

--- a/internal/cmd/calendar/calendar.go
+++ b/internal/cmd/calendar/calendar.go
@@ -11,7 +11,7 @@ func NewCommand() *cobra.Command {
 		Use:     "calendar",
 		Aliases: []string{"cal"},
 		Short:   "Google Calendar commands",
-		Long: `Read-only access to Google Calendar events and calendars.
+		Long: `Access to Google Calendar events and calendars.
 
 This command group provides Calendar functionality:
 - list: List all calendars
@@ -19,12 +19,16 @@ This command group provides Calendar functionality:
 - get: View a single event's details
 - today: Show today's events
 - week: Show this week's events
+- rsvp: Update your RSVP status on an event
+- color: Set event color
 
 Examples:
   gro calendar list
   gro cal events --max 20
   gro cal today --json
-  gro calendar get <event-id>`,
+  gro calendar get <event-id>
+  gro cal rsvp <event-id> accept
+  gro cal color <event-id> tomato`,
 	}
 
 	cmd.AddCommand(newListCommand())
@@ -32,6 +36,8 @@ Examples:
 	cmd.AddCommand(newGetCommand())
 	cmd.AddCommand(newTodayCommand())
 	cmd.AddCommand(newWeekCommand())
+	cmd.AddCommand(newRSVPCommand())
+	cmd.AddCommand(newColorCommand())
 
 	return cmd
 }

--- a/internal/cmd/calendar/color.go
+++ b/internal/cmd/calendar/color.go
@@ -1,0 +1,140 @@
+package calendar
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// eventColors maps Google Calendar event color names to their IDs (1-11).
+var eventColors = map[string]string{
+	"lavender":  "1",
+	"sage":      "2",
+	"grape":     "3",
+	"flamingo":  "4",
+	"banana":    "5",
+	"tangerine": "6",
+	"peacock":   "7",
+	"graphite":  "8",
+	"blueberry": "9",
+	"basil":     "10",
+	"tomato":    "11",
+}
+
+// colorIDToName provides reverse lookup from color ID to name.
+var colorIDToName = func() map[string]string {
+	m := make(map[string]string, len(eventColors))
+	for name, id := range eventColors {
+		m[id] = name
+	}
+	return m
+}()
+
+func newColorCommand() *cobra.Command {
+	var (
+		calendarID string
+		jsonOutput bool
+		dryRun     bool
+	)
+
+	colorNames := make([]string, 0, len(eventColors))
+	for name := range eventColors {
+		colorNames = append(colorNames, name)
+	}
+	sort.Strings(colorNames)
+
+	cmd := &cobra.Command{
+		Use:   "color <event-id> <color>",
+		Short: "Set event color",
+		Long: fmt.Sprintf(`Set the color of a calendar event.
+
+Accepts a color name or ID (1-11).
+
+Color names: %s
+
+Examples:
+  gro calendar color abc123 tomato
+  gro cal color abc123 7
+  gro cal color abc123 sage --dry-run --json`, strings.Join(colorNames, ", ")),
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			eventID := args[0]
+			colorInput := strings.ToLower(args[1])
+
+			// Resolve color input to ID and name
+			colorID, colorName, err := resolveColor(colorInput)
+			if err != nil {
+				return err
+			}
+
+			if dryRun {
+				result := map[string]any{
+					"action":    fmt.Sprintf("set event color to %s", colorName),
+					"eventId":   eventID,
+					"colorId":   colorID,
+					"colorName": colorName,
+					"dryRun":    true,
+				}
+				if jsonOutput {
+					return printJSON(result)
+				}
+				fmt.Printf("[dry-run] Would set event %s color to %s.\n", eventID, colorName)
+				return nil
+			}
+
+			client, err := newCalendarClient(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("creating Calendar client: %w", err)
+			}
+
+			if err := client.SetEventColor(cmd.Context(), calendarID, eventID, colorID); err != nil {
+				return fmt.Errorf("setting event color: %w", err)
+			}
+
+			result := map[string]any{
+				"action":    fmt.Sprintf("set event color to %s", colorName),
+				"eventId":   eventID,
+				"colorId":   colorID,
+				"colorName": colorName,
+				"dryRun":    false,
+			}
+			if jsonOutput {
+				return printJSON(result)
+			}
+			fmt.Printf("Set event %s color to %s.\n", eventID, colorName)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&calendarID, "calendar", "c", "primary", "Calendar ID containing the event")
+	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output as JSON")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
+
+	return cmd
+}
+
+// resolveColor resolves a color name or numeric ID to (colorID, colorName).
+func resolveColor(input string) (string, string, error) {
+	// Try as color name first
+	if id, ok := eventColors[input]; ok {
+		return id, input, nil
+	}
+
+	// Try as numeric ID
+	n, err := strconv.Atoi(input)
+	if err == nil && n >= 1 && n <= 11 {
+		id := strconv.Itoa(n)
+		name := colorIDToName[id]
+		return id, name, nil
+	}
+
+	colorNames := make([]string, 0, len(eventColors))
+	for name := range eventColors {
+		colorNames = append(colorNames, name)
+	}
+	sort.Strings(colorNames)
+	return "", "", fmt.Errorf("invalid color %q; valid colors: %s (or 1-11)", input, strings.Join(colorNames, ", "))
+}

--- a/internal/cmd/calendar/color_test.go
+++ b/internal/cmd/calendar/color_test.go
@@ -1,0 +1,246 @@
+package calendar
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/open-cli-collective/google-readonly/internal/testutil"
+)
+
+func TestColorCommand(t *testing.T) {
+	cmd := newColorCommand()
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		testutil.NotNil(t, flag)
+		testutil.Equal(t, flag.Shorthand, "j")
+	})
+
+	t.Run("has dry-run flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("dry-run")
+		testutil.NotNil(t, flag)
+		testutil.Equal(t, flag.Shorthand, "n")
+	})
+
+	t.Run("has calendar flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("calendar")
+		testutil.NotNil(t, flag)
+		testutil.Equal(t, flag.Shorthand, "c")
+	})
+}
+
+func TestColorCommand_ByName(t *testing.T) {
+	var capturedColorID string
+	mock := &MockCalendarClient{
+		SetEventColorFunc: func(_ context.Context, _, _, colorID string) error {
+			capturedColorID = colorID
+			return nil
+		},
+	}
+
+	cmd := newColorCommand()
+	cmd.SetArgs([]string{"event123", "tomato"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Equal(t, capturedColorID, "11")
+		testutil.Contains(t, output, "Set event event123 color to tomato.")
+	})
+}
+
+func TestColorCommand_ByID(t *testing.T) {
+	var capturedColorID string
+	mock := &MockCalendarClient{
+		SetEventColorFunc: func(_ context.Context, _, _, colorID string) error {
+			capturedColorID = colorID
+			return nil
+		},
+	}
+
+	cmd := newColorCommand()
+	cmd.SetArgs([]string{"event123", "7"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Equal(t, capturedColorID, "7")
+		testutil.Contains(t, output, "Set event event123 color to peacock.")
+	})
+}
+
+func TestColorCommand_InvalidColor(t *testing.T) {
+	cmd := newColorCommand()
+	cmd.SetArgs([]string{"event123", "purple"})
+
+	withMockClient(&MockCalendarClient{}, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "invalid color")
+	})
+}
+
+func TestColorCommand_InvalidNumericID(t *testing.T) {
+	cmd := newColorCommand()
+	cmd.SetArgs([]string{"event123", "99"})
+
+	withMockClient(&MockCalendarClient{}, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "invalid color")
+	})
+}
+
+func TestColorCommand_DryRun(t *testing.T) {
+	mock := &MockCalendarClient{
+		SetEventColorFunc: func(_ context.Context, _, _, _ string) error {
+			t.Fatal("SetEventColor should not be called in dry-run")
+			return nil
+		},
+	}
+
+	cmd := newColorCommand()
+	cmd.SetArgs([]string{"event123", "sage", "--dry-run"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Contains(t, output, "[dry-run] Would set event event123 color to sage.")
+	})
+}
+
+func TestColorCommand_DryRunJSON(t *testing.T) {
+	cmd := newColorCommand()
+	cmd.SetArgs([]string{"event123", "flamingo", "--dry-run", "--json"})
+
+	withMockClient(&MockCalendarClient{}, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		var result map[string]any
+		err := json.Unmarshal([]byte(output), &result)
+		testutil.NoError(t, err)
+		testutil.Equal(t, result["colorName"], "flamingo")
+		testutil.Equal(t, result["colorId"], "4")
+		testutil.Equal(t, result["dryRun"], true)
+	})
+}
+
+func TestColorCommand_JSON(t *testing.T) {
+	mock := &MockCalendarClient{
+		SetEventColorFunc: func(_ context.Context, _, _, _ string) error {
+			return nil
+		},
+	}
+
+	cmd := newColorCommand()
+	cmd.SetArgs([]string{"event123", "grape", "--json"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		var result map[string]any
+		err := json.Unmarshal([]byte(output), &result)
+		testutil.NoError(t, err)
+		testutil.Equal(t, result["colorName"], "grape")
+		testutil.Equal(t, result["colorId"], "3")
+		testutil.Equal(t, result["dryRun"], false)
+	})
+}
+
+func TestColorCommand_APIError(t *testing.T) {
+	mock := &MockCalendarClient{
+		SetEventColorFunc: func(_ context.Context, _, _, _ string) error {
+			return errors.New("permission denied")
+		},
+	}
+
+	cmd := newColorCommand()
+	cmd.SetArgs([]string{"event123", "tomato"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "setting event color")
+	})
+}
+
+func TestColorCommand_ClientCreationError(t *testing.T) {
+	cmd := newColorCommand()
+	cmd.SetArgs([]string{"event123", "tomato"})
+
+	withFailingClientFactory(func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "creating Calendar client")
+	})
+}
+
+func TestColorCommand_CaseInsensitive(t *testing.T) {
+	mock := &MockCalendarClient{
+		SetEventColorFunc: func(_ context.Context, _, _, colorID string) error {
+			testutil.Equal(t, colorID, "11")
+			return nil
+		},
+	}
+
+	cmd := newColorCommand()
+	cmd.SetArgs([]string{"event123", "Tomato"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Contains(t, output, "tomato")
+	})
+}
+
+func TestResolveColor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input     string
+		wantID    string
+		wantName  string
+		wantError bool
+	}{
+		{"tomato", "11", "tomato", false},
+		{"lavender", "1", "lavender", false},
+		{"1", "1", "lavender", false},
+		{"11", "11", "tomato", false},
+		{"0", "", "", true},
+		{"12", "", "", true},
+		{"purple", "", "", true},
+		{"abc", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			id, name, err := resolveColor(tt.input)
+			if tt.wantError {
+				testutil.Error(t, err)
+			} else {
+				testutil.NoError(t, err)
+				testutil.Equal(t, id, tt.wantID)
+				testutil.Equal(t, name, tt.wantName)
+			}
+		})
+	}
+}

--- a/internal/cmd/calendar/mock_test.go
+++ b/internal/cmd/calendar/mock_test.go
@@ -11,6 +11,8 @@ type MockCalendarClient struct {
 	ListCalendarsFunc func(ctx context.Context) ([]*calendar.CalendarListEntry, error)
 	ListEventsFunc    func(ctx context.Context, calendarID, timeMin, timeMax string, maxResults int64) ([]*calendar.Event, error)
 	GetEventFunc      func(ctx context.Context, calendarID, eventID string) (*calendar.Event, error)
+	RSVPEventFunc     func(ctx context.Context, calendarID, eventID, response string) error
+	SetEventColorFunc func(ctx context.Context, calendarID, eventID, colorID string) error
 }
 
 // Verify MockCalendarClient implements CalendarClient
@@ -35,4 +37,18 @@ func (m *MockCalendarClient) GetEvent(ctx context.Context, calendarID, eventID s
 		return m.GetEventFunc(ctx, calendarID, eventID)
 	}
 	return nil, nil
+}
+
+func (m *MockCalendarClient) RSVPEvent(ctx context.Context, calendarID, eventID, response string) error {
+	if m.RSVPEventFunc != nil {
+		return m.RSVPEventFunc(ctx, calendarID, eventID, response)
+	}
+	return nil
+}
+
+func (m *MockCalendarClient) SetEventColor(ctx context.Context, calendarID, eventID, colorID string) error {
+	if m.SetEventColorFunc != nil {
+		return m.SetEventColorFunc(ctx, calendarID, eventID, colorID)
+	}
+	return nil
 }

--- a/internal/cmd/calendar/output.go
+++ b/internal/cmd/calendar/output.go
@@ -15,6 +15,8 @@ type CalendarClient interface {
 	ListCalendars(ctx context.Context) ([]*calendarv3.CalendarListEntry, error)
 	ListEvents(ctx context.Context, calendarID string, timeMin, timeMax string, maxResults int64) ([]*calendarv3.Event, error)
 	GetEvent(ctx context.Context, calendarID, eventID string) (*calendarv3.Event, error)
+	RSVPEvent(ctx context.Context, calendarID, eventID, response string) error
+	SetEventColor(ctx context.Context, calendarID, eventID, colorID string) error
 }
 
 // ClientFactory is the function used to create Calendar clients.

--- a/internal/cmd/calendar/rsvp.go
+++ b/internal/cmd/calendar/rsvp.go
@@ -1,0 +1,87 @@
+package calendar
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// validResponses maps user-friendly input to Google Calendar API response values.
+var validResponses = map[string]string{
+	"accept":    "accepted",
+	"decline":   "declined",
+	"tentative": "tentative",
+}
+
+func newRSVPCommand() *cobra.Command {
+	var (
+		calendarID string
+		jsonOutput bool
+		dryRun     bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "rsvp <event-id> <accept|decline|tentative>",
+		Short: "Update your RSVP status on an event",
+		Long: `Update your RSVP response for a calendar event.
+
+Valid responses: accept, decline, tentative
+
+Examples:
+  gro calendar rsvp abc123 accept
+  gro cal rsvp abc123 decline --dry-run
+  gro cal rsvp abc123 tentative --calendar work@group.calendar.google.com --json`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			eventID := args[0]
+			input := strings.ToLower(args[1])
+
+			apiResponse, ok := validResponses[input]
+			if !ok {
+				return fmt.Errorf("invalid response %q; must be accept, decline, or tentative", input)
+			}
+
+			if dryRun {
+				result := map[string]any{
+					"action":   fmt.Sprintf("RSVP '%s' to event", apiResponse),
+					"eventId":  eventID,
+					"response": apiResponse,
+					"dryRun":   true,
+				}
+				if jsonOutput {
+					return printJSON(result)
+				}
+				fmt.Printf("[dry-run] Would RSVP '%s' to event %s.\n", apiResponse, eventID)
+				return nil
+			}
+
+			client, err := newCalendarClient(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("creating Calendar client: %w", err)
+			}
+
+			if err := client.RSVPEvent(cmd.Context(), calendarID, eventID, apiResponse); err != nil {
+				return fmt.Errorf("updating RSVP: %w", err)
+			}
+
+			result := map[string]any{
+				"action":   fmt.Sprintf("RSVP'd '%s' to event", apiResponse),
+				"eventId":  eventID,
+				"response": apiResponse,
+				"dryRun":   false,
+			}
+			if jsonOutput {
+				return printJSON(result)
+			}
+			fmt.Printf("RSVP'd '%s' to event %s.\n", apiResponse, eventID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&calendarID, "calendar", "c", "primary", "Calendar ID containing the event")
+	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output as JSON")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
+
+	return cmd
+}

--- a/internal/cmd/calendar/rsvp_test.go
+++ b/internal/cmd/calendar/rsvp_test.go
@@ -1,0 +1,244 @@
+package calendar
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/open-cli-collective/google-readonly/internal/testutil"
+)
+
+func TestRSVPCommand(t *testing.T) {
+	cmd := newRSVPCommand()
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		testutil.NotNil(t, flag)
+		testutil.Equal(t, flag.Shorthand, "j")
+	})
+
+	t.Run("has dry-run flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("dry-run")
+		testutil.NotNil(t, flag)
+		testutil.Equal(t, flag.Shorthand, "n")
+	})
+
+	t.Run("has calendar flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("calendar")
+		testutil.NotNil(t, flag)
+		testutil.Equal(t, flag.Shorthand, "c")
+	})
+}
+
+func TestRSVPCommand_Accept(t *testing.T) {
+	var capturedCalID, capturedEventID, capturedResponse string
+	mock := &MockCalendarClient{
+		RSVPEventFunc: func(_ context.Context, calID, eventID, response string) error {
+			capturedCalID = calID
+			capturedEventID = eventID
+			capturedResponse = response
+			return nil
+		},
+	}
+
+	cmd := newRSVPCommand()
+	cmd.SetArgs([]string{"event123", "accept"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Equal(t, capturedCalID, "primary")
+		testutil.Equal(t, capturedEventID, "event123")
+		testutil.Equal(t, capturedResponse, "accepted")
+		testutil.Contains(t, output, "RSVP'd 'accepted' to event event123.")
+	})
+}
+
+func TestRSVPCommand_Decline(t *testing.T) {
+	mock := &MockCalendarClient{
+		RSVPEventFunc: func(_ context.Context, _, _, response string) error {
+			testutil.Equal(t, response, "declined")
+			return nil
+		},
+	}
+
+	cmd := newRSVPCommand()
+	cmd.SetArgs([]string{"event123", "decline"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Contains(t, output, "RSVP'd 'declined'")
+	})
+}
+
+func TestRSVPCommand_Tentative(t *testing.T) {
+	mock := &MockCalendarClient{
+		RSVPEventFunc: func(_ context.Context, _, _, response string) error {
+			testutil.Equal(t, response, "tentative")
+			return nil
+		},
+	}
+
+	cmd := newRSVPCommand()
+	cmd.SetArgs([]string{"event123", "tentative"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Contains(t, output, "RSVP'd 'tentative'")
+	})
+}
+
+func TestRSVPCommand_InvalidResponse(t *testing.T) {
+	cmd := newRSVPCommand()
+	cmd.SetArgs([]string{"event123", "maybe"})
+
+	withMockClient(&MockCalendarClient{}, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "invalid response")
+	})
+}
+
+func TestRSVPCommand_DryRun(t *testing.T) {
+	mock := &MockCalendarClient{
+		RSVPEventFunc: func(_ context.Context, _, _, _ string) error {
+			t.Fatal("RSVPEvent should not be called in dry-run")
+			return nil
+		},
+	}
+
+	cmd := newRSVPCommand()
+	cmd.SetArgs([]string{"event123", "accept", "--dry-run"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Contains(t, output, "[dry-run] Would RSVP 'accepted' to event event123.")
+	})
+}
+
+func TestRSVPCommand_DryRunJSON(t *testing.T) {
+	cmd := newRSVPCommand()
+	cmd.SetArgs([]string{"event123", "decline", "--dry-run", "--json"})
+
+	withMockClient(&MockCalendarClient{}, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		var result map[string]any
+		err := json.Unmarshal([]byte(output), &result)
+		testutil.NoError(t, err)
+		testutil.Equal(t, result["response"], "declined")
+		testutil.Equal(t, result["dryRun"], true)
+	})
+}
+
+func TestRSVPCommand_JSON(t *testing.T) {
+	mock := &MockCalendarClient{
+		RSVPEventFunc: func(_ context.Context, _, _, _ string) error {
+			return nil
+		},
+	}
+
+	cmd := newRSVPCommand()
+	cmd.SetArgs([]string{"event123", "accept", "--json"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		var result map[string]any
+		err := json.Unmarshal([]byte(output), &result)
+		testutil.NoError(t, err)
+		testutil.Equal(t, result["response"], "accepted")
+		testutil.Equal(t, result["eventId"], "event123")
+		testutil.Equal(t, result["dryRun"], false)
+	})
+}
+
+func TestRSVPCommand_WithCalendar(t *testing.T) {
+	var capturedCalID string
+	mock := &MockCalendarClient{
+		RSVPEventFunc: func(_ context.Context, calID, _, _ string) error {
+			capturedCalID = calID
+			return nil
+		},
+	}
+
+	cmd := newRSVPCommand()
+	cmd.SetArgs([]string{"event123", "accept", "--calendar", "work@group.calendar.google.com"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Equal(t, capturedCalID, "work@group.calendar.google.com")
+		testutil.Contains(t, output, "RSVP'd 'accepted'")
+	})
+}
+
+func TestRSVPCommand_APIError(t *testing.T) {
+	mock := &MockCalendarClient{
+		RSVPEventFunc: func(_ context.Context, _, _, _ string) error {
+			return errors.New("not an attendee")
+		},
+	}
+
+	cmd := newRSVPCommand()
+	cmd.SetArgs([]string{"event123", "accept"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "updating RSVP")
+	})
+}
+
+func TestRSVPCommand_ClientCreationError(t *testing.T) {
+	cmd := newRSVPCommand()
+	cmd.SetArgs([]string{"event123", "accept"})
+
+	withFailingClientFactory(func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "creating Calendar client")
+	})
+}
+
+func TestRSVPCommand_CaseInsensitive(t *testing.T) {
+	mock := &MockCalendarClient{
+		RSVPEventFunc: func(_ context.Context, _, _, response string) error {
+			testutil.Equal(t, response, "accepted")
+			return nil
+		},
+	}
+
+	cmd := newRSVPCommand()
+	cmd.SetArgs([]string{"event123", "Accept"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Contains(t, output, "RSVP'd 'accepted'")
+	})
+}


### PR DESCRIPTION
## Summary

- Add `gro cal rsvp <event-id> <accept|decline|tentative>` for updating RSVP status
- Add `gro cal color <event-id> <color>` for setting event colors (by name or ID 1-11)
- Add `calendar.CalendarEventsScope` to OAuth scopes for event write access
- Both commands support `--calendar`, `--json/-j`, and `--dry-run/-n` flags

## Details

**Scope change:** Adds `calendar.events` scope alongside existing `calendar.readonly`. The events scope enables RSVP and color operations but doesn't cover calendar list metadata, so both scopes are needed.

**RSVP command:** Fetches the event, finds the current user's attendee entry (via `Self` field), updates `ResponseStatus`, and patches the event. Validates input to accept/decline/tentative.

**Color command:** Patches the event's `ColorId` field. Accepts Google Calendar's 11 named colors (lavender, sage, grape, flamingo, banana, tangerine, peacock, graphite, blueberry, basil, tomato) or numeric IDs 1-11.

**Architecture:** Both commands skip API calls entirely in dry-run mode. Architecture tests updated with `calendar.events` in the scope allowlist.

## Test plan

- [x] All existing tests pass (`make test` — 23 packages)
- [x] Lint clean (`make lint` — 0 issues)
- [x] Architecture tests pass (scope allowlist, JSON flag, client interface, etc.)
- [x] RSVP tests: accept/decline/tentative, invalid input, dry-run, JSON, --calendar flag, case insensitive, API error, client error
- [x] Color tests: by name, by ID, invalid color, invalid numeric ID, dry-run, JSON, API error, client error, case insensitive, resolveColor unit tests

Closes #99