### PR TITLE
feat(drive): add star/unstar operations and --ids flag

### DIFF
--- a/internal/architecture/architecture_test.go
+++ b/internal/architecture/architecture_test.go
@@ -313,6 +313,7 @@ var allowedScopes = map[string]bool{
 	"https://www.googleapis.com/auth/calendar.readonly": true,
 	"https://www.googleapis.com/auth/contacts.readonly": true,
 	"https://www.googleapis.com/auth/drive.readonly":    true,
+	"https://www.googleapis.com/auth/drive.metadata":    true, // star/unstar files (NOT file content write)
 }
 
 // TestAllScopesAreNonDestructive verifies that every OAuth scope in auth.AllScopes

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -26,6 +26,7 @@ var AllScopes = []string{
 	calendar.CalendarReadonlyScope,
 	people.ContactsReadonlyScope,
 	drive.DriveReadonlyScope,
+	drive.DriveMetadataScope,
 }
 
 // ScopeDescriptions maps OAuth scope URLs to human-friendly descriptions.
@@ -35,6 +36,7 @@ var ScopeDescriptions = map[string]string{
 	calendar.CalendarReadonlyScope: "Calendar Read-Only — read calendars and events.",
 	people.ContactsReadonlyScope:   "Contacts Read-Only — read contacts and groups.",
 	drive.DriveReadonlyScope:       "Drive Read-Only — read files and metadata.",
+	drive.DriveMetadataScope:       "Drive Metadata — read and update file metadata (star/unstar). No file content write access.",
 }
 
 // CheckScopesMigration compares the currently required scopes against the

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -101,8 +101,8 @@ func TestDeprecatedWrappers(t *testing.T) {
 
 func TestAllScopes(t *testing.T) {
 	t.Parallel()
-	if len(AllScopes) != 4 {
-		t.Errorf("got length %d, want %d", len(AllScopes), 4)
+	if len(AllScopes) != 5 {
+		t.Errorf("got length %d, want %d", len(AllScopes), 5)
 	}
 	scopeSet := strings.Join(AllScopes, " ")
 	if !strings.Contains(scopeSet, "https://www.googleapis.com/auth/gmail.modify") {
@@ -116,6 +116,9 @@ func TestAllScopes(t *testing.T) {
 	}
 	if !strings.Contains(scopeSet, "https://www.googleapis.com/auth/drive.readonly") {
 		t.Errorf("expected AllScopes to contain %q", "https://www.googleapis.com/auth/drive.readonly")
+	}
+	if !strings.Contains(scopeSet, "https://www.googleapis.com/auth/drive.metadata") {
+		t.Errorf("expected AllScopes to contain %q", "https://www.googleapis.com/auth/drive.metadata")
 	}
 }
 

--- a/internal/bulk/result.go
+++ b/internal/bulk/result.go
@@ -9,11 +9,12 @@ import (
 
 // Result represents the outcome of a bulk operation.
 type Result struct {
-	Action  string   `json:"action"`
-	IDs     []string `json:"ids"`
-	Count   int      `json:"count"`
-	DryRun  bool     `json:"dryRun"`
-	Details any      `json:"details,omitempty"`
+	Action   string   `json:"action"`
+	IDs      []string `json:"ids"`
+	Count    int      `json:"count"`
+	DryRun   bool     `json:"dryRun"`
+	Details  any      `json:"details,omitempty"`
+	ItemNoun string   `json:"-"` // e.g. "message", "file", "contact"; defaults to "message"
 }
 
 // Print outputs the result as text or JSON.
@@ -21,10 +22,14 @@ func (r *Result) Print(jsonOutput bool) error {
 	if jsonOutput {
 		return output.JSONStdout(r)
 	}
+	noun := r.ItemNoun
+	if noun == "" {
+		noun = "message"
+	}
 	if r.DryRun {
-		fmt.Printf("[dry-run] Would %s %d message(s).\n", r.Action, r.Count)
+		fmt.Printf("[dry-run] Would %s %d %s(s).\n", r.Action, r.Count, noun)
 	} else {
-		fmt.Printf("%s %d message(s).\n", capitalize(r.Action), r.Count)
+		fmt.Printf("%s %d %s(s).\n", capitalize(r.Action), r.Count, noun)
 	}
 	return nil
 }

--- a/internal/cmd/drive/drive.go
+++ b/internal/cmd/drive/drive.go
@@ -11,7 +11,7 @@ func NewCommand() *cobra.Command {
 		Use:     "drive",
 		Aliases: []string{"files"},
 		Short:   "Google Drive commands",
-		Long: `Read-only access to Google Drive files and folders.
+		Long: `Access to Google Drive files and folders.
 
 This command group provides Google Drive functionality:
 - list: List files in Drive or a specific folder
@@ -20,6 +20,8 @@ This command group provides Google Drive functionality:
 - download: Download files or export Google Docs
 - tree: Display folder structure
 - drives: List accessible shared drives
+- star: Star files
+- unstar: Unstar files
 
 Shared Drive Support:
   By default, search includes files from all drives (My Drive + shared drives).
@@ -32,6 +34,7 @@ Examples:
   gro drive search "budget" --drive "Finance Team"
   gro drive get <file-id>
   gro drive download <file-id> --format pdf
+  gro drive star <file-id>
   gro drive drives`,
 	}
 
@@ -41,6 +44,8 @@ Examples:
 	cmd.AddCommand(newDownloadCommand())
 	cmd.AddCommand(newTreeCommand())
 	cmd.AddCommand(newDrivesCommand())
+	cmd.AddCommand(newStarCommand())
+	cmd.AddCommand(newUnstarCommand())
 
 	return cmd
 }

--- a/internal/cmd/drive/list.go
+++ b/internal/cmd/drive/list.go
@@ -18,6 +18,7 @@ func newListCommand() *cobra.Command {
 		maxResults int64
 		fileType   string
 		jsonOutput bool
+		idsOutput  bool
 		myDrive    bool
 		driveFlag  string
 	)
@@ -44,6 +45,9 @@ File types: document, spreadsheet, presentation, folder, pdf, image, video, audi
 			// Validate mutually exclusive flags
 			if myDrive && driveFlag != "" {
 				return fmt.Errorf("--my-drive and --drive are mutually exclusive")
+			}
+			if idsOutput && jsonOutput {
+				return fmt.Errorf("--ids and --json are mutually exclusive")
 			}
 
 			client, err := newDriveClient(cmd.Context())
@@ -73,6 +77,13 @@ File types: document, spreadsheet, presentation, folder, pdf, image, video, audi
 				return fmt.Errorf("listing files: %w", err)
 			}
 
+			if idsOutput {
+				for _, f := range files {
+					fmt.Println(f.ID)
+				}
+				return nil
+			}
+
 			if len(files) == 0 {
 				if jsonOutput {
 					fmt.Println("[]")
@@ -94,6 +105,7 @@ File types: document, spreadsheet, presentation, folder, pdf, image, video, audi
 	cmd.Flags().Int64VarP(&maxResults, "max", "m", 25, "Maximum number of results to return")
 	cmd.Flags().StringVarP(&fileType, "type", "t", "", "Filter by file type")
 	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
+	cmd.Flags().BoolVar(&idsOutput, "ids", false, "Output only file IDs (one per line, for piping)")
 	cmd.Flags().BoolVar(&myDrive, "my-drive", false, "Limit to My Drive only")
 	cmd.Flags().StringVar(&driveFlag, "drive", "", "List files in specific shared drive (name or ID)")
 

--- a/internal/cmd/drive/mock_test.go
+++ b/internal/cmd/drive/mock_test.go
@@ -14,6 +14,9 @@ type MockDriveClient struct {
 	DownloadFileFunc       func(ctx context.Context, fileID string) ([]byte, error)
 	ExportFileFunc         func(ctx context.Context, fileID, mimeType string) ([]byte, error)
 	ListSharedDrivesFunc   func(ctx context.Context, pageSize int64) ([]*driveapi.SharedDrive, error)
+	StarFileFunc           func(ctx context.Context, fileID string) error
+	UnstarFileFunc         func(ctx context.Context, fileID string) error
+	SearchFileIDsFunc      func(ctx context.Context, query string, pageSize int64) ([]string, error)
 }
 
 // Verify MockDriveClient implements DriveClient
@@ -61,6 +64,27 @@ func (m *MockDriveClient) ExportFile(ctx context.Context, fileID, mimeType strin
 func (m *MockDriveClient) ListSharedDrives(ctx context.Context, pageSize int64) ([]*driveapi.SharedDrive, error) {
 	if m.ListSharedDrivesFunc != nil {
 		return m.ListSharedDrivesFunc(ctx, pageSize)
+	}
+	return nil, nil
+}
+
+func (m *MockDriveClient) StarFile(ctx context.Context, fileID string) error {
+	if m.StarFileFunc != nil {
+		return m.StarFileFunc(ctx, fileID)
+	}
+	return nil
+}
+
+func (m *MockDriveClient) UnstarFile(ctx context.Context, fileID string) error {
+	if m.UnstarFileFunc != nil {
+		return m.UnstarFileFunc(ctx, fileID)
+	}
+	return nil
+}
+
+func (m *MockDriveClient) SearchFileIDs(ctx context.Context, query string, pageSize int64) ([]string, error) {
+	if m.SearchFileIDsFunc != nil {
+		return m.SearchFileIDsFunc(ctx, query, pageSize)
 	}
 	return nil, nil
 }

--- a/internal/cmd/drive/output.go
+++ b/internal/cmd/drive/output.go
@@ -15,6 +15,9 @@ type DriveClient interface {
 	DownloadFile(ctx context.Context, fileID string) ([]byte, error)
 	ExportFile(ctx context.Context, fileID string, mimeType string) ([]byte, error)
 	ListSharedDrives(ctx context.Context, pageSize int64) ([]*drive.SharedDrive, error)
+	StarFile(ctx context.Context, fileID string) error
+	UnstarFile(ctx context.Context, fileID string) error
+	SearchFileIDs(ctx context.Context, query string, pageSize int64) ([]string, error)
 }
 
 // ClientFactory is the function used to create Drive clients.

--- a/internal/cmd/drive/search.go
+++ b/internal/cmd/drive/search.go
@@ -17,6 +17,7 @@ func newSearchCommand() *cobra.Command {
 		modBefore  string
 		inFolder   string
 		jsonOutput bool
+		idsOutput  bool
 		myDrive    bool
 		driveFlag  string
 	)
@@ -49,6 +50,9 @@ File types: document, spreadsheet, presentation, folder, pdf, image, video, audi
 			if myDrive && driveFlag != "" {
 				return fmt.Errorf("--my-drive and --drive are mutually exclusive")
 			}
+			if idsOutput && jsonOutput {
+				return fmt.Errorf("--ids and --json are mutually exclusive")
+			}
 
 			client, err := newDriveClient(cmd.Context())
 			if err != nil {
@@ -75,6 +79,13 @@ File types: document, spreadsheet, presentation, folder, pdf, image, video, audi
 			files, err := client.ListFilesWithScope(ctx, searchQuery, maxResults, scope)
 			if err != nil {
 				return fmt.Errorf("searching files: %w", err)
+			}
+
+			if idsOutput {
+				for _, f := range files {
+					fmt.Println(f.ID)
+				}
+				return nil
 			}
 
 			if len(files) == 0 {
@@ -112,6 +123,7 @@ File types: document, spreadsheet, presentation, folder, pdf, image, video, audi
 	cmd.Flags().StringVar(&modBefore, "modified-before", "", "Modified before date (YYYY-MM-DD)")
 	cmd.Flags().StringVar(&inFolder, "in-folder", "", "Search within specific folder")
 	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
+	cmd.Flags().BoolVar(&idsOutput, "ids", false, "Output only file IDs (one per line, for piping)")
 	cmd.Flags().BoolVar(&myDrive, "my-drive", false, "Limit search to My Drive only")
 	cmd.Flags().StringVar(&driveFlag, "drive", "", "Search in specific shared drive (name or ID)")
 

--- a/internal/cmd/drive/star.go
+++ b/internal/cmd/drive/star.go
@@ -1,0 +1,150 @@
+package drive
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/bulk"
+)
+
+func newStarCommand() *cobra.Command {
+	var (
+		jsonOutput bool
+		dryRun     bool
+		stdin      bool
+		query      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "star [file-ids...]",
+		Short: "Star files",
+		Long: `Star files in Google Drive.
+
+Supports three input modes (mutually exclusive):
+  1. Positional arguments: gro drive star file1 file2
+  2. Stdin (--stdin):      gro drive search "report" --ids | gro drive star --stdin
+  3. Query (--query):      gro drive star --query "name contains 'report'"
+
+Examples:
+  gro drive star abc123
+  gro drive search "budget" --ids | gro drive star --stdin
+  gro drive star --query "name contains 'report'" --dry-run`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newDriveClient(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("creating Drive client: %w", err)
+			}
+
+			ctx := cmd.Context()
+			ids, err := bulk.ResolveIDs(bulk.Config{
+				Args:  args,
+				Stdin: stdin,
+				Query: query,
+			}, func(q string) ([]string, error) {
+				return client.SearchFileIDs(ctx, q, 0)
+			})
+			if err != nil {
+				return err
+			}
+
+			result := &bulk.Result{
+				Action:   "starred",
+				IDs:      ids,
+				Count:    len(ids),
+				DryRun:   dryRun,
+				ItemNoun: "file",
+			}
+
+			if dryRun {
+				result.Action = "star"
+				return result.Print(jsonOutput)
+			}
+
+			for _, id := range ids {
+				if err := client.StarFile(ctx, id); err != nil {
+					return fmt.Errorf("starring files: %w", err)
+				}
+			}
+
+			return result.Print(jsonOutput)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
+	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read file IDs from stdin")
+	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve file IDs")
+
+	return cmd
+}
+
+func newUnstarCommand() *cobra.Command {
+	var (
+		jsonOutput bool
+		dryRun     bool
+		stdin      bool
+		query      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "unstar [file-ids...]",
+		Short: "Unstar files",
+		Long: `Remove stars from files in Google Drive.
+
+Supports three input modes (mutually exclusive):
+  1. Positional arguments: gro drive unstar file1 file2
+  2. Stdin (--stdin):      echo "file1" | gro drive unstar --stdin
+  3. Query (--query):      gro drive unstar --query "starred = true"
+
+Examples:
+  gro drive unstar abc123
+  gro drive unstar --query "starred = true" --dry-run`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newDriveClient(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("creating Drive client: %w", err)
+			}
+
+			ctx := cmd.Context()
+			ids, err := bulk.ResolveIDs(bulk.Config{
+				Args:  args,
+				Stdin: stdin,
+				Query: query,
+			}, func(q string) ([]string, error) {
+				return client.SearchFileIDs(ctx, q, 0)
+			})
+			if err != nil {
+				return err
+			}
+
+			result := &bulk.Result{
+				Action:   "unstarred",
+				IDs:      ids,
+				Count:    len(ids),
+				DryRun:   dryRun,
+				ItemNoun: "file",
+			}
+
+			if dryRun {
+				result.Action = "unstar"
+				return result.Print(jsonOutput)
+			}
+
+			for _, id := range ids {
+				if err := client.UnstarFile(ctx, id); err != nil {
+					return fmt.Errorf("unstarring files: %w", err)
+				}
+			}
+
+			return result.Print(jsonOutput)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
+	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read file IDs from stdin")
+	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve file IDs")
+
+	return cmd
+}

--- a/internal/cmd/drive/star.go
+++ b/internal/cmd/drive/star.go
@@ -63,7 +63,7 @@ Examples:
 
 			for _, id := range ids {
 				if err := client.StarFile(ctx, id); err != nil {
-					return fmt.Errorf("starring files: %w", err)
+					return fmt.Errorf("starring file %s: %w", id, err)
 				}
 			}
 
@@ -133,7 +133,7 @@ Examples:
 
 			for _, id := range ids {
 				if err := client.UnstarFile(ctx, id); err != nil {
-					return fmt.Errorf("unstarring files: %w", err)
+					return fmt.Errorf("unstarring file %s: %w", id, err)
 				}
 			}
 

--- a/internal/cmd/drive/star_test.go
+++ b/internal/cmd/drive/star_test.go
@@ -1,0 +1,216 @@
+package drive
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/open-cli-collective/google-readonly/internal/bulk"
+	"github.com/open-cli-collective/google-readonly/internal/testutil"
+)
+
+func TestStarCommand(t *testing.T) {
+	cmd := newStarCommand()
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		testutil.NotNil(t, flag)
+		testutil.Equal(t, flag.Shorthand, "j")
+	})
+
+	t.Run("has dry-run flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("dry-run")
+		testutil.NotNil(t, flag)
+		testutil.Equal(t, flag.Shorthand, "n")
+	})
+
+	t.Run("has stdin flag", func(t *testing.T) {
+		testutil.NotNil(t, cmd.Flags().Lookup("stdin"))
+	})
+
+	t.Run("has query flag", func(t *testing.T) {
+		testutil.NotNil(t, cmd.Flags().Lookup("query"))
+	})
+}
+
+func TestStarCommand_Success(t *testing.T) {
+	var starredIDs []string
+	mock := &MockDriveClient{
+		StarFileFunc: func(_ context.Context, fileID string) error {
+			starredIDs = append(starredIDs, fileID)
+			return nil
+		},
+	}
+
+	cmd := newStarCommand()
+	cmd.SetArgs([]string{"file1", "file2"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Contains(t, output, "Starred 2 file(s).")
+		testutil.Len(t, starredIDs, 2)
+	})
+}
+
+func TestStarCommand_DryRun(t *testing.T) {
+	mock := &MockDriveClient{
+		StarFileFunc: func(_ context.Context, _ string) error {
+			t.Fatal("StarFile should not be called in dry-run")
+			return nil
+		},
+	}
+
+	cmd := newStarCommand()
+	cmd.SetArgs([]string{"file1", "--dry-run"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Contains(t, output, "[dry-run] Would star 1 file(s).")
+	})
+}
+
+func TestStarCommand_JSON(t *testing.T) {
+	mock := &MockDriveClient{
+		StarFileFunc: func(_ context.Context, _ string) error {
+			return nil
+		},
+	}
+
+	cmd := newStarCommand()
+	cmd.SetArgs([]string{"file1", "--json"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		var result bulk.Result
+		err := json.Unmarshal([]byte(output), &result)
+		testutil.NoError(t, err)
+		testutil.Equal(t, result.Action, "starred")
+		testutil.Equal(t, result.Count, 1)
+	})
+}
+
+func TestStarCommand_Query(t *testing.T) {
+	mock := &MockDriveClient{
+		SearchFileIDsFunc: func(_ context.Context, q string, _ int64) ([]string, error) {
+			testutil.Equal(t, q, "name contains 'report'")
+			return []string{"file1", "file2", "file3"}, nil
+		},
+		StarFileFunc: func(_ context.Context, _ string) error {
+			return nil
+		},
+	}
+
+	cmd := newStarCommand()
+	cmd.SetArgs([]string{"--query", "name contains 'report'"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Contains(t, output, "Starred 3 file(s).")
+	})
+}
+
+func TestStarCommand_APIError(t *testing.T) {
+	mock := &MockDriveClient{
+		StarFileFunc: func(_ context.Context, _ string) error {
+			return errors.New("permission denied")
+		},
+	}
+
+	cmd := newStarCommand()
+	cmd.SetArgs([]string{"file1"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "starring files")
+	})
+}
+
+func TestStarCommand_ClientCreationError(t *testing.T) {
+	cmd := newStarCommand()
+	cmd.SetArgs([]string{"file1"})
+
+	withFailingClientFactory(func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "creating Drive client")
+	})
+}
+
+func TestUnstarCommand_Success(t *testing.T) {
+	var unstarredIDs []string
+	mock := &MockDriveClient{
+		UnstarFileFunc: func(_ context.Context, fileID string) error {
+			unstarredIDs = append(unstarredIDs, fileID)
+			return nil
+		},
+	}
+
+	cmd := newUnstarCommand()
+	cmd.SetArgs([]string{"file1"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Contains(t, output, "Unstarred 1 file(s).")
+		testutil.Len(t, unstarredIDs, 1)
+	})
+}
+
+func TestUnstarCommand_DryRun(t *testing.T) {
+	mock := &MockDriveClient{
+		UnstarFileFunc: func(_ context.Context, _ string) error {
+			t.Fatal("UnstarFile should not be called in dry-run")
+			return nil
+		},
+	}
+
+	cmd := newUnstarCommand()
+	cmd.SetArgs([]string{"file1", "--dry-run"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Contains(t, output, "[dry-run] Would unstar 1 file(s).")
+	})
+}
+
+func TestUnstarCommand_APIError(t *testing.T) {
+	mock := &MockDriveClient{
+		UnstarFileFunc: func(_ context.Context, _ string) error {
+			return errors.New("permission denied")
+		},
+	}
+
+	cmd := newUnstarCommand()
+	cmd.SetArgs([]string{"file1"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "unstarring files")
+	})
+}

--- a/internal/cmd/drive/star_test.go
+++ b/internal/cmd/drive/star_test.go
@@ -139,7 +139,7 @@ func TestStarCommand_APIError(t *testing.T) {
 	withMockClient(mock, func() {
 		err := cmd.Execute()
 		testutil.Error(t, err)
-		testutil.Contains(t, err.Error(), "starring files")
+		testutil.Contains(t, err.Error(), "starring file file1")
 	})
 }
 
@@ -211,6 +211,6 @@ func TestUnstarCommand_APIError(t *testing.T) {
 	withMockClient(mock, func() {
 		err := cmd.Execute()
 		testutil.Error(t, err)
-		testutil.Contains(t, err.Error(), "unstarring files")
+		testutil.Contains(t, err.Error(), "unstarring file file1")
 	})
 }

--- a/internal/cmd/drive/tree_test.go
+++ b/internal/cmd/drive/tree_test.go
@@ -250,6 +250,18 @@ func (m *mockDriveClient) ListSharedDrives(_ context.Context, _ int64) ([]*drive
 	return nil, fmt.Errorf("not implemented")
 }
 
+func (m *mockDriveClient) StarFile(_ context.Context, _ string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (m *mockDriveClient) UnstarFile(_ context.Context, _ string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (m *mockDriveClient) SearchFileIDs(_ context.Context, _ string, _ int64) ([]string, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 func TestBuildTree(t *testing.T) {
 	t.Run("builds tree for root folder", func(t *testing.T) {
 		mock := newMockDriveClient()

--- a/internal/drive/client.go
+++ b/internal/drive/client.go
@@ -148,6 +148,58 @@ func (c *Client) ExportFile(ctx context.Context, fileID string, mimeType string)
 	return data, nil
 }
 
+// StarFile stars a file in Drive
+func (c *Client) StarFile(ctx context.Context, fileID string) error {
+	_, err := c.service.Files.Update(fileID, &drive.File{
+		Starred:         true,
+		ForceSendFields: []string{"Starred"},
+	}).SupportsAllDrives(true).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("starring file: %w", err)
+	}
+	return nil
+}
+
+// UnstarFile removes the star from a file in Drive
+func (c *Client) UnstarFile(ctx context.Context, fileID string) error {
+	_, err := c.service.Files.Update(fileID, &drive.File{
+		Starred:         false,
+		ForceSendFields: []string{"Starred"},
+	}).SupportsAllDrives(true).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("unstarring file: %w", err)
+	}
+	return nil
+}
+
+// SearchFileIDs returns only file IDs matching the query (no metadata fetch).
+// This is more efficient than ListFiles when only IDs are needed.
+func (c *Client) SearchFileIDs(ctx context.Context, query string, pageSize int64) ([]string, error) {
+	call := c.service.Files.List().
+		Fields("files(id)").
+		SupportsAllDrives(true).
+		IncludeItemsFromAllDrives(true).
+		Corpora("allDrives")
+
+	if query != "" {
+		call = call.Q(query)
+	}
+	if pageSize > 0 {
+		call = call.PageSize(pageSize)
+	}
+
+	resp, err := call.Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("searching file IDs: %w", err)
+	}
+
+	ids := make([]string, 0, len(resp.Files))
+	for _, f := range resp.Files {
+		ids = append(ids, f.Id)
+	}
+	return ids, nil
+}
+
 // ListSharedDrives returns all shared drives accessible to the user
 func (c *Client) ListSharedDrives(ctx context.Context, pageSize int64) ([]*SharedDrive, error) {
 	var allDrives []*SharedDrive


### PR DESCRIPTION
## Summary

- Add `gro drive star [file-ids...]` and `gro drive unstar [file-ids...]` commands
- Add `--ids` flag to `gro drive search` and `gro drive list` for piping
- Add `drive.DriveMetadataScope` for metadata write access (star/unstar)
- Add `SearchFileIDs` method and `ItemNoun` field to `bulk.Result`

## Details

**Scope change:** Adds `drive.metadata` alongside existing `drive.readonly`. The metadata scope enables star/unstar operations but doesn't allow file content writes. The readonly scope is still needed for download/export commands.

**Star/Unstar commands:** Support 3 input modes (positional args, `--stdin`, `--query`), `--json`, and `--dry-run`. Each file is starred/unstarred individually via `Files.Update()` with `ForceSendFields` to ensure the boolean `Starred` field is sent even when false (for unstar).

**--ids flag:** Added to both `search` and `list` commands. Mutually exclusive with `--json`. Outputs one file ID per line for piping to star/unstar/other commands.

**bulk.Result.ItemNoun:** New field to customize the item noun in text output (e.g., "file" instead of "message"). Defaults to "message" for backwards compatibility with mail commands.

## Test plan

- [x] All existing tests pass (`make test` — 23 packages)
- [x] Lint clean (`make lint` — 0 issues)
- [x] Architecture tests pass (scope allowlist, JSON flag, etc.)
- [x] Star tests: success, dry-run, JSON, query, API error, client error
- [x] Unstar tests: success, dry-run, API error
- [x] Tree test mock updated with new interface methods

Closes #100