### PR TITLE
feat(contacts): add group management and starring operations

### DIFF
--- a/internal/architecture/architecture_test.go
+++ b/internal/architecture/architecture_test.go
@@ -312,6 +312,7 @@ var allowedScopes = map[string]bool{
 	"https://www.googleapis.com/auth/gmail.modify":      true, // label, archive, star, read/unread (NOT send/delete)
 	"https://www.googleapis.com/auth/calendar.readonly": true,
 	"https://www.googleapis.com/auth/contacts.readonly": true,
+	"https://www.googleapis.com/auth/contacts":          true, // group membership, starring (NOT create/delete contacts)
 	"https://www.googleapis.com/auth/drive.readonly":    true,
 }
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -21,10 +21,12 @@ import (
 // AllScopes contains all OAuth scopes used by the application.
 // Gmail uses the modify scope for organizational operations (label, archive, star, mark read/unread).
 // The modify scope is a superset of readonly — it includes all read access.
+// Contacts uses the full contacts scope for group management and starring.
+// The contacts scope is a superset of contacts.readonly — it includes all read access.
 var AllScopes = []string{
 	gmail.GmailModifyScope,
 	calendar.CalendarReadonlyScope,
-	people.ContactsReadonlyScope,
+	people.ContactsScope,
 	drive.DriveReadonlyScope,
 }
 
@@ -33,6 +35,7 @@ var ScopeDescriptions = map[string]string{
 	gmail.GmailModifyScope:         "Gmail Modify — read messages, plus label, archive, star, and mark read/unread. No send or delete access.",
 	gmail.GmailReadonlyScope:       "Gmail Read-Only — read messages and metadata.",
 	calendar.CalendarReadonlyScope: "Calendar Read-Only — read calendars and events.",
+	people.ContactsScope:           "Contacts — read contacts and groups, plus manage group membership and starring.",
 	people.ContactsReadonlyScope:   "Contacts Read-Only — read contacts and groups.",
 	drive.DriveReadonlyScope:       "Drive Read-Only — read files and metadata.",
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -111,8 +111,8 @@ func TestAllScopes(t *testing.T) {
 	if !strings.Contains(scopeSet, "https://www.googleapis.com/auth/calendar.readonly") {
 		t.Errorf("expected AllScopes to contain %q", "https://www.googleapis.com/auth/calendar.readonly")
 	}
-	if !strings.Contains(scopeSet, "https://www.googleapis.com/auth/contacts.readonly") {
-		t.Errorf("expected AllScopes to contain %q", "https://www.googleapis.com/auth/contacts.readonly")
+	if !strings.Contains(scopeSet, "https://www.googleapis.com/auth/contacts") {
+		t.Errorf("expected AllScopes to contain %q", "https://www.googleapis.com/auth/contacts")
 	}
 	if !strings.Contains(scopeSet, "https://www.googleapis.com/auth/drive.readonly") {
 		t.Errorf("expected AllScopes to contain %q", "https://www.googleapis.com/auth/drive.readonly")
@@ -152,6 +152,9 @@ func TestCheckScopesMigration_MissingScope(t *testing.T) {
 	}
 	if !strings.Contains(msg, "Gmail Modify") {
 		t.Errorf("expected message to mention 'Gmail Modify', got %q", msg)
+	}
+	if !strings.Contains(msg, "Contacts") {
+		t.Errorf("expected message to mention 'Contacts', got %q", msg)
 	}
 }
 

--- a/internal/bulk/result.go
+++ b/internal/bulk/result.go
@@ -9,11 +9,12 @@ import (
 
 // Result represents the outcome of a bulk operation.
 type Result struct {
-	Action  string   `json:"action"`
-	IDs     []string `json:"ids"`
-	Count   int      `json:"count"`
-	DryRun  bool     `json:"dryRun"`
-	Details any      `json:"details,omitempty"`
+	Action   string   `json:"action"`
+	IDs      []string `json:"ids"`
+	Count    int      `json:"count"`
+	DryRun   bool     `json:"dryRun"`
+	Details  any      `json:"details,omitempty"`
+	ItemNoun string   `json:"-"` // e.g. "message", "file", "contact"; defaults to "message"
 }
 
 // Print outputs the result as text or JSON.
@@ -21,10 +22,14 @@ func (r *Result) Print(jsonOutput bool) error {
 	if jsonOutput {
 		return output.JSONStdout(r)
 	}
+	noun := r.ItemNoun
+	if noun == "" {
+		noun = "message"
+	}
 	if r.DryRun {
-		fmt.Printf("[dry-run] Would %s %d message(s).\n", r.Action, r.Count)
+		fmt.Printf("[dry-run] Would %s %d %s(s).\n", r.Action, r.Count, noun)
 	} else {
-		fmt.Printf("%s %d message(s).\n", capitalize(r.Action), r.Count)
+		fmt.Printf("%s %d %s(s).\n", capitalize(r.Action), r.Count, noun)
 	}
 	return nil
 }

--- a/internal/cmd/contacts/contacts.go
+++ b/internal/cmd/contacts/contacts.go
@@ -11,21 +11,28 @@ func NewCommand() *cobra.Command {
 		Use:     "contacts",
 		Aliases: []string{"ppl"},
 		Short:   "Google Contacts commands",
-		Long: `Commands for reading Google Contacts.
+		Long: `Commands for reading and organizing Google Contacts.
 
-All commands are read-only - no modifications are possible.
+Supports read operations plus non-destructive organizational operations:
+group membership management and starring.
 
 The short alias 'ppl' can be used instead of 'contacts':
   gro ppl list
   gro ppl search "John"
   gro ppl get <resource-name>
-  gro ppl groups`,
+  gro ppl groups
+  gro ppl star <contact-id>
+  gro ppl add-to-group "Friends" <contact-id>`,
 	}
 
 	cmd.AddCommand(newListCommand())
 	cmd.AddCommand(newSearchCommand())
 	cmd.AddCommand(newGetCommand())
 	cmd.AddCommand(newGroupsCommand())
+	cmd.AddCommand(newAddToGroupCommand())
+	cmd.AddCommand(newRemoveFromGroupCommand())
+	cmd.AddCommand(newStarCommand())
+	cmd.AddCommand(newUnstarCommand())
 
 	return cmd
 }

--- a/internal/cmd/contacts/contacts_test.go
+++ b/internal/cmd/contacts/contacts_test.go
@@ -23,12 +23,12 @@ func TestContactsCommand(t *testing.T) {
 
 	t.Run("has long description", func(t *testing.T) {
 		testutil.NotEmpty(t, cmd.Long)
-		testutil.Contains(t, cmd.Long, "read-only")
+		testutil.Contains(t, cmd.Long, "organizing")
 	})
 
 	t.Run("has subcommands", func(t *testing.T) {
 		subcommands := cmd.Commands()
-		testutil.GreaterOrEqual(t, len(subcommands), 4)
+		testutil.GreaterOrEqual(t, len(subcommands), 8)
 
 		var names []string
 		for _, sub := range subcommands {
@@ -38,6 +38,10 @@ func TestContactsCommand(t *testing.T) {
 		testutil.SliceContains(t, names, "search")
 		testutil.SliceContains(t, names, "get")
 		testutil.SliceContains(t, names, "groups")
+		testutil.SliceContains(t, names, "add-to-group")
+		testutil.SliceContains(t, names, "remove-from-group")
+		testutil.SliceContains(t, names, "star")
+		testutil.SliceContains(t, names, "unstar")
 	})
 }
 
@@ -73,6 +77,12 @@ func TestListCommand(t *testing.T) {
 		flag := cmd.Flags().Lookup("json")
 		testutil.NotNil(t, flag)
 		testutil.Equal(t, flag.Shorthand, "j")
+		testutil.Equal(t, flag.DefValue, "false")
+	})
+
+	t.Run("has ids flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("ids")
+		testutil.NotNil(t, flag)
 		testutil.Equal(t, flag.DefValue, "false")
 	})
 }
@@ -114,6 +124,12 @@ func TestSearchCommand(t *testing.T) {
 		testutil.NotNil(t, flag)
 		testutil.Equal(t, flag.Shorthand, "j")
 	})
+
+	t.Run("has ids flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("ids")
+		testutil.NotNil(t, flag)
+		testutil.Equal(t, flag.DefValue, "false")
+	})
 }
 
 func TestGetCommand(t *testing.T) {
@@ -141,6 +157,121 @@ func TestGetCommand(t *testing.T) {
 		flag := cmd.Flags().Lookup("json")
 		testutil.NotNil(t, flag)
 		testutil.Equal(t, flag.Shorthand, "j")
+	})
+}
+
+func TestAddToGroupCommand(t *testing.T) {
+	cmd := newAddToGroupCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		testutil.Contains(t, cmd.Use, "add-to-group")
+	})
+
+	t.Run("requires at least one argument", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{"Friends"})
+		testutil.NoError(t, err)
+
+		err = cmd.Args(cmd, []string{"Friends", "people/c123"})
+		testutil.NoError(t, err)
+	})
+
+	t.Run("rejects no arguments", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{})
+		testutil.Error(t, err)
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		testutil.NotNil(t, flag)
+		testutil.Equal(t, flag.Shorthand, "j")
+	})
+
+	t.Run("has dry-run flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("dry-run")
+		testutil.NotNil(t, flag)
+		testutil.Equal(t, flag.Shorthand, "n")
+	})
+
+	t.Run("has stdin flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("stdin")
+		testutil.NotNil(t, flag)
+	})
+
+	t.Run("has query flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("query")
+		testutil.NotNil(t, flag)
+	})
+}
+
+func TestRemoveFromGroupCommand(t *testing.T) {
+	cmd := newRemoveFromGroupCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		testutil.Contains(t, cmd.Use, "remove-from-group")
+	})
+
+	t.Run("requires at least one argument", func(t *testing.T) {
+		err := cmd.Args(cmd, []string{"Friends"})
+		testutil.NoError(t, err)
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		testutil.NotNil(t, flag)
+		testutil.Equal(t, flag.Shorthand, "j")
+	})
+
+	t.Run("has dry-run flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("dry-run")
+		testutil.NotNil(t, flag)
+	})
+}
+
+func TestStarCommand(t *testing.T) {
+	cmd := newStarCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		testutil.Contains(t, cmd.Use, "star")
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		testutil.NotNil(t, flag)
+		testutil.Equal(t, flag.Shorthand, "j")
+	})
+
+	t.Run("has dry-run flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("dry-run")
+		testutil.NotNil(t, flag)
+	})
+
+	t.Run("has stdin flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("stdin")
+		testutil.NotNil(t, flag)
+	})
+
+	t.Run("has query flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("query")
+		testutil.NotNil(t, flag)
+	})
+}
+
+func TestUnstarCommand(t *testing.T) {
+	cmd := newUnstarCommand()
+
+	t.Run("has correct use", func(t *testing.T) {
+		testutil.Contains(t, cmd.Use, "unstar")
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		testutil.NotNil(t, flag)
+		testutil.Equal(t, flag.Shorthand, "j")
+	})
+
+	t.Run("has dry-run flag", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("dry-run")
+		testutil.NotNil(t, flag)
 	})
 }
 

--- a/internal/cmd/contacts/group_manage.go
+++ b/internal/cmd/contacts/group_manage.go
@@ -1,0 +1,172 @@
+package contacts
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/bulk"
+)
+
+func newAddToGroupCommand() *cobra.Command {
+	var (
+		jsonOutput bool
+		dryRun     bool
+		stdin      bool
+		query      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "add-to-group <group-name> [contact-ids...]",
+		Short: "Add contacts to a group",
+		Long: `Add contacts to a contact group.
+
+The first argument is the group name (e.g., "Friends", "Work").
+Contact IDs are resource names in the form "people/c1234567890".
+
+Supports three input modes for contact IDs (mutually exclusive):
+  1. Positional arguments: gro contacts add-to-group "Friends" people/c123 people/c456
+  2. Stdin (--stdin):      gro ppl search "John" --ids | gro contacts add-to-group "Friends" --stdin
+  3. Query (--query):      gro contacts add-to-group "Friends" --query "John"
+
+Examples:
+  gro contacts add-to-group "Friends" people/c1234567890
+  gro ppl search "John" --ids | gro contacts add-to-group "Work" --stdin
+  gro contacts add-to-group "Friends" --query "John" --dry-run`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			groupName := args[0]
+			contactArgs := args[1:]
+
+			client, err := newContactsClient(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("creating Contacts client: %w", err)
+			}
+
+			ctx := cmd.Context()
+
+			groupResourceName, err := client.ResolveGroupName(ctx, groupName)
+			if err != nil {
+				return fmt.Errorf("resolving group: %w", err)
+			}
+
+			ids, err := bulk.ResolveIDs(bulk.Config{
+				Args:  contactArgs,
+				Stdin: stdin,
+				Query: query,
+			}, func(q string) ([]string, error) {
+				return client.SearchContactIDs(ctx, q, 0)
+			})
+			if err != nil {
+				return err
+			}
+
+			result := &bulk.Result{
+				Action:   fmt.Sprintf("added to group '%s'", groupName),
+				IDs:      ids,
+				Count:    len(ids),
+				DryRun:   dryRun,
+				ItemNoun: "contact",
+			}
+
+			if dryRun {
+				result.Action = fmt.Sprintf("add to group '%s'", groupName)
+				return result.Print(jsonOutput)
+			}
+
+			if err := client.AddToGroup(ctx, groupResourceName, ids); err != nil {
+				return fmt.Errorf("adding contacts to group: %w", err)
+			}
+
+			return result.Print(jsonOutput)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
+	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read contact IDs from stdin")
+	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve contact IDs")
+
+	return cmd
+}
+
+func newRemoveFromGroupCommand() *cobra.Command {
+	var (
+		jsonOutput bool
+		dryRun     bool
+		stdin      bool
+		query      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "remove-from-group <group-name> [contact-ids...]",
+		Short: "Remove contacts from a group",
+		Long: `Remove contacts from a contact group.
+
+The first argument is the group name (e.g., "Friends", "Work").
+Contact IDs are resource names in the form "people/c1234567890".
+
+Supports three input modes for contact IDs (mutually exclusive):
+  1. Positional arguments: gro contacts remove-from-group "Friends" people/c123 people/c456
+  2. Stdin (--stdin):      echo "people/c123" | gro contacts remove-from-group "Friends" --stdin
+  3. Query (--query):      gro contacts remove-from-group "Friends" --query "John"
+
+Examples:
+  gro contacts remove-from-group "Friends" people/c1234567890
+  gro contacts remove-from-group "Work" --query "John" --dry-run`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			groupName := args[0]
+			contactArgs := args[1:]
+
+			client, err := newContactsClient(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("creating Contacts client: %w", err)
+			}
+
+			ctx := cmd.Context()
+
+			groupResourceName, err := client.ResolveGroupName(ctx, groupName)
+			if err != nil {
+				return fmt.Errorf("resolving group: %w", err)
+			}
+
+			ids, err := bulk.ResolveIDs(bulk.Config{
+				Args:  contactArgs,
+				Stdin: stdin,
+				Query: query,
+			}, func(q string) ([]string, error) {
+				return client.SearchContactIDs(ctx, q, 0)
+			})
+			if err != nil {
+				return err
+			}
+
+			result := &bulk.Result{
+				Action:   fmt.Sprintf("removed from group '%s'", groupName),
+				IDs:      ids,
+				Count:    len(ids),
+				DryRun:   dryRun,
+				ItemNoun: "contact",
+			}
+
+			if dryRun {
+				result.Action = fmt.Sprintf("remove from group '%s'", groupName)
+				return result.Print(jsonOutput)
+			}
+
+			if err := client.RemoveFromGroup(ctx, groupResourceName, ids); err != nil {
+				return fmt.Errorf("removing contacts from group: %w", err)
+			}
+
+			return result.Print(jsonOutput)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
+	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read contact IDs from stdin")
+	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve contact IDs")
+
+	return cmd
+}

--- a/internal/cmd/contacts/group_manage_test.go
+++ b/internal/cmd/contacts/group_manage_test.go
@@ -1,0 +1,259 @@
+package contacts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/open-cli-collective/google-readonly/internal/testutil"
+)
+
+func TestAddToGroupCommand_Success(t *testing.T) {
+	var addedGroup string
+	var addedContacts []string
+
+	mock := &MockContactsClient{
+		ResolveGroupNameFunc: func(_ context.Context, name string) (string, error) {
+			testutil.Equal(t, name, "Friends")
+			return "contactGroups/abc123", nil
+		},
+		AddToGroupFunc: func(_ context.Context, groupResourceName string, contactResourceNames []string) error {
+			addedGroup = groupResourceName
+			addedContacts = contactResourceNames
+			return nil
+		},
+	}
+
+	cmd := newAddToGroupCommand()
+	cmd.SetArgs([]string{"Friends", "people/c111", "people/c222"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Equal(t, addedGroup, "contactGroups/abc123")
+		testutil.Len(t, addedContacts, 2)
+		testutil.Contains(t, output, "Added to group 'Friends' 2 contact(s)")
+	})
+}
+
+func TestAddToGroupCommand_DryRun(t *testing.T) {
+	mock := &MockContactsClient{
+		ResolveGroupNameFunc: func(_ context.Context, _ string) (string, error) {
+			return "contactGroups/abc123", nil
+		},
+	}
+
+	cmd := newAddToGroupCommand()
+	cmd.SetArgs([]string{"Friends", "people/c111", "--dry-run"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Contains(t, output, "[dry-run]")
+		testutil.Contains(t, output, "add to group 'Friends'")
+		testutil.Contains(t, output, "1 contact(s)")
+	})
+}
+
+func TestAddToGroupCommand_DryRunJSON(t *testing.T) {
+	mock := &MockContactsClient{
+		ResolveGroupNameFunc: func(_ context.Context, _ string) (string, error) {
+			return "contactGroups/abc123", nil
+		},
+	}
+
+	cmd := newAddToGroupCommand()
+	cmd.SetArgs([]string{"Friends", "people/c111", "--dry-run", "--json"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		var result map[string]any
+		err := json.Unmarshal([]byte(output), &result)
+		testutil.NoError(t, err)
+		testutil.Equal(t, result["dryRun"].(bool), true)
+	})
+}
+
+func TestAddToGroupCommand_JSON(t *testing.T) {
+	mock := &MockContactsClient{
+		ResolveGroupNameFunc: func(_ context.Context, _ string) (string, error) {
+			return "contactGroups/abc123", nil
+		},
+		AddToGroupFunc: func(_ context.Context, _ string, _ []string) error {
+			return nil
+		},
+	}
+
+	cmd := newAddToGroupCommand()
+	cmd.SetArgs([]string{"Friends", "people/c111", "--json"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		var result map[string]any
+		err := json.Unmarshal([]byte(output), &result)
+		testutil.NoError(t, err)
+		testutil.Equal(t, result["count"].(float64), float64(1))
+	})
+}
+
+func TestAddToGroupCommand_GroupNotFound(t *testing.T) {
+	mock := &MockContactsClient{
+		ResolveGroupNameFunc: func(_ context.Context, _ string) (string, error) {
+			return "", errors.New("group not found: Nonexistent")
+		},
+	}
+
+	cmd := newAddToGroupCommand()
+	cmd.SetArgs([]string{"Nonexistent", "people/c111"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "resolving group")
+	})
+}
+
+func TestAddToGroupCommand_APIError(t *testing.T) {
+	mock := &MockContactsClient{
+		ResolveGroupNameFunc: func(_ context.Context, _ string) (string, error) {
+			return "contactGroups/abc123", nil
+		},
+		AddToGroupFunc: func(_ context.Context, _ string, _ []string) error {
+			return errors.New("API error")
+		},
+	}
+
+	cmd := newAddToGroupCommand()
+	cmd.SetArgs([]string{"Friends", "people/c111"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "adding contacts to group")
+	})
+}
+
+func TestAddToGroupCommand_ClientError(t *testing.T) {
+	cmd := newAddToGroupCommand()
+	cmd.SetArgs([]string{"Friends", "people/c111"})
+
+	withFailingClientFactory(func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "creating Contacts client")
+	})
+}
+
+func TestAddToGroupCommand_Query(t *testing.T) {
+	mock := &MockContactsClient{
+		ResolveGroupNameFunc: func(_ context.Context, _ string) (string, error) {
+			return "contactGroups/abc123", nil
+		},
+		SearchContactIDsFunc: func(_ context.Context, query string, _ int64) ([]string, error) {
+			testutil.Equal(t, query, "John")
+			return []string{"people/c111", "people/c222"}, nil
+		},
+		AddToGroupFunc: func(_ context.Context, _ string, contacts []string) error {
+			testutil.Len(t, contacts, 2)
+			return nil
+		},
+	}
+
+	cmd := newAddToGroupCommand()
+	cmd.SetArgs([]string{"Friends", "--query", "John"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Contains(t, output, "2 contact(s)")
+	})
+}
+
+func TestRemoveFromGroupCommand_Success(t *testing.T) {
+	var removedGroup string
+	var removedContacts []string
+
+	mock := &MockContactsClient{
+		ResolveGroupNameFunc: func(_ context.Context, _ string) (string, error) {
+			return "contactGroups/abc123", nil
+		},
+		RemoveFromGroupFunc: func(_ context.Context, groupResourceName string, contactResourceNames []string) error {
+			removedGroup = groupResourceName
+			removedContacts = contactResourceNames
+			return nil
+		},
+	}
+
+	cmd := newRemoveFromGroupCommand()
+	cmd.SetArgs([]string{"Friends", "people/c111"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Equal(t, removedGroup, "contactGroups/abc123")
+		testutil.Len(t, removedContacts, 1)
+		testutil.Contains(t, output, "Removed from group 'Friends' 1 contact(s)")
+	})
+}
+
+func TestRemoveFromGroupCommand_DryRun(t *testing.T) {
+	mock := &MockContactsClient{
+		ResolveGroupNameFunc: func(_ context.Context, _ string) (string, error) {
+			return "contactGroups/abc123", nil
+		},
+	}
+
+	cmd := newRemoveFromGroupCommand()
+	cmd.SetArgs([]string{"Friends", "people/c111", "--dry-run"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Contains(t, output, "[dry-run]")
+		testutil.Contains(t, output, "remove from group 'Friends'")
+	})
+}
+
+func TestRemoveFromGroupCommand_APIError(t *testing.T) {
+	mock := &MockContactsClient{
+		ResolveGroupNameFunc: func(_ context.Context, _ string) (string, error) {
+			return "contactGroups/abc123", nil
+		},
+		RemoveFromGroupFunc: func(_ context.Context, _ string, _ []string) error {
+			return errors.New("API error")
+		},
+	}
+
+	cmd := newRemoveFromGroupCommand()
+	cmd.SetArgs([]string{"Friends", "people/c111"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "removing contacts from group")
+	})
+}

--- a/internal/cmd/contacts/handlers_test.go
+++ b/internal/cmd/contacts/handlers_test.go
@@ -461,3 +461,79 @@ func TestGroupsCommand_APIError(t *testing.T) {
 		testutil.Contains(t, err.Error(), "listing contact groups")
 	})
 }
+
+func TestListCommand_IDsOutput(t *testing.T) {
+	mock := &MockContactsClient{
+		ListContactsFunc: func(_ context.Context, _ string, _ int64) (*people.ListConnectionsResponse, error) {
+			return &people.ListConnectionsResponse{
+				Connections: []*people.Person{
+					testutil.SamplePerson("people/c123"),
+					testutil.SamplePerson("people/c456"),
+				},
+			}, nil
+		},
+	}
+
+	cmd := newListCommand()
+	cmd.SetArgs([]string{"--ids"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Contains(t, output, "people/c123")
+		testutil.Contains(t, output, "people/c456")
+		testutil.NotContains(t, output, "John Doe")
+	})
+}
+
+func TestListCommand_IDsAndJSONMutuallyExclusive(t *testing.T) {
+	cmd := newListCommand()
+	cmd.SetArgs([]string{"--ids", "--json"})
+
+	withMockClient(&MockContactsClient{}, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "mutually exclusive")
+	})
+}
+
+func TestSearchCommand_IDsOutput(t *testing.T) {
+	mock := &MockContactsClient{
+		SearchContactsFunc: func(_ context.Context, _ string, _ int64) (*people.SearchResponse, error) {
+			return &people.SearchResponse{
+				Results: []*people.SearchResult{
+					{Person: testutil.SamplePerson("people/c123")},
+					{Person: testutil.SamplePerson("people/c456")},
+				},
+			}, nil
+		},
+	}
+
+	cmd := newSearchCommand()
+	cmd.SetArgs([]string{"John", "--ids"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Contains(t, output, "people/c123")
+		testutil.Contains(t, output, "people/c456")
+		testutil.NotContains(t, output, "John Doe")
+	})
+}
+
+func TestSearchCommand_IDsAndJSONMutuallyExclusive(t *testing.T) {
+	cmd := newSearchCommand()
+	cmd.SetArgs([]string{"John", "--ids", "--json"})
+
+	withMockClient(&MockContactsClient{}, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "mutually exclusive")
+	})
+}

--- a/internal/cmd/contacts/list.go
+++ b/internal/cmd/contacts/list.go
@@ -12,6 +12,7 @@ func newListCommand() *cobra.Command {
 	var (
 		maxResults int64
 		jsonOutput bool
+		idsOutput  bool
 	)
 
 	cmd := &cobra.Command{
@@ -24,9 +25,14 @@ Contacts are sorted by last name.
 Examples:
   gro contacts list
   gro contacts list --max 50
-  gro ppl list --json`,
+  gro ppl list --json
+  gro ppl list --ids | gro contacts star --stdin`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if idsOutput && jsonOutput {
+				return fmt.Errorf("--ids and --json are mutually exclusive")
+			}
+
 			client, err := newContactsClient(cmd.Context())
 			if err != nil {
 				return fmt.Errorf("creating Contacts client: %w", err)
@@ -42,7 +48,16 @@ Examples:
 					fmt.Println("[]")
 					return nil
 				}
-				fmt.Println("No contacts found.")
+				if !idsOutput {
+					fmt.Println("No contacts found.")
+				}
+				return nil
+			}
+
+			if idsOutput {
+				for _, p := range resp.Connections {
+					fmt.Println(p.ResourceName)
+				}
 				return nil
 			}
 
@@ -67,6 +82,7 @@ Examples:
 
 	cmd.Flags().Int64VarP(&maxResults, "max", "m", 10, "Maximum number of contacts to return")
 	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output as JSON")
+	cmd.Flags().BoolVar(&idsOutput, "ids", false, "Output only resource names, one per line")
 
 	return cmd
 }

--- a/internal/cmd/contacts/mock_test.go
+++ b/internal/cmd/contacts/mock_test.go
@@ -12,6 +12,10 @@ type MockContactsClient struct {
 	SearchContactsFunc    func(ctx context.Context, query string, pageSize int64) (*people.SearchResponse, error)
 	GetContactFunc        func(ctx context.Context, resourceName string) (*people.Person, error)
 	ListContactGroupsFunc func(ctx context.Context, pageToken string, pageSize int64) (*people.ListContactGroupsResponse, error)
+	AddToGroupFunc        func(ctx context.Context, groupResourceName string, contactResourceNames []string) error
+	RemoveFromGroupFunc   func(ctx context.Context, groupResourceName string, contactResourceNames []string) error
+	ResolveGroupNameFunc  func(ctx context.Context, name string) (string, error)
+	SearchContactIDsFunc  func(ctx context.Context, query string, pageSize int64) ([]string, error)
 }
 
 // Verify MockContactsClient implements ContactsClient
@@ -41,6 +45,34 @@ func (m *MockContactsClient) GetContact(ctx context.Context, resourceName string
 func (m *MockContactsClient) ListContactGroups(ctx context.Context, pageToken string, pageSize int64) (*people.ListContactGroupsResponse, error) {
 	if m.ListContactGroupsFunc != nil {
 		return m.ListContactGroupsFunc(ctx, pageToken, pageSize)
+	}
+	return nil, nil
+}
+
+func (m *MockContactsClient) AddToGroup(ctx context.Context, groupResourceName string, contactResourceNames []string) error {
+	if m.AddToGroupFunc != nil {
+		return m.AddToGroupFunc(ctx, groupResourceName, contactResourceNames)
+	}
+	return nil
+}
+
+func (m *MockContactsClient) RemoveFromGroup(ctx context.Context, groupResourceName string, contactResourceNames []string) error {
+	if m.RemoveFromGroupFunc != nil {
+		return m.RemoveFromGroupFunc(ctx, groupResourceName, contactResourceNames)
+	}
+	return nil
+}
+
+func (m *MockContactsClient) ResolveGroupName(ctx context.Context, name string) (string, error) {
+	if m.ResolveGroupNameFunc != nil {
+		return m.ResolveGroupNameFunc(ctx, name)
+	}
+	return "", nil
+}
+
+func (m *MockContactsClient) SearchContactIDs(ctx context.Context, query string, pageSize int64) ([]string, error) {
+	if m.SearchContactIDsFunc != nil {
+		return m.SearchContactIDsFunc(ctx, query, pageSize)
 	}
 	return nil, nil
 }

--- a/internal/cmd/contacts/output.go
+++ b/internal/cmd/contacts/output.go
@@ -16,6 +16,10 @@ type ContactsClient interface {
 	SearchContacts(ctx context.Context, query string, pageSize int64) (*people.SearchResponse, error)
 	GetContact(ctx context.Context, resourceName string) (*people.Person, error)
 	ListContactGroups(ctx context.Context, pageToken string, pageSize int64) (*people.ListContactGroupsResponse, error)
+	AddToGroup(ctx context.Context, groupResourceName string, contactResourceNames []string) error
+	RemoveFromGroup(ctx context.Context, groupResourceName string, contactResourceNames []string) error
+	ResolveGroupName(ctx context.Context, name string) (string, error)
+	SearchContactIDs(ctx context.Context, query string, pageSize int64) ([]string, error)
 }
 
 // ClientFactory is the function used to create Contacts clients.

--- a/internal/cmd/contacts/search.go
+++ b/internal/cmd/contacts/search.go
@@ -12,6 +12,7 @@ func newSearchCommand() *cobra.Command {
 	var (
 		maxResults int64
 		jsonOutput bool
+		idsOutput  bool
 	)
 
 	cmd := &cobra.Command{
@@ -30,9 +31,14 @@ Examples:
   gro contacts search "John"
   gro contacts search "example.com"
   gro contacts search "+1-555" --max 20
-  gro ppl search "Acme" --json`,
+  gro ppl search "Acme" --json
+  gro ppl search "John" --ids | gro contacts add-to-group "Friends" --stdin`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if idsOutput && jsonOutput {
+				return fmt.Errorf("--ids and --json are mutually exclusive")
+			}
+
 			query := args[0]
 
 			client, err := newContactsClient(cmd.Context())
@@ -50,7 +56,18 @@ Examples:
 					fmt.Println("[]")
 					return nil
 				}
-				fmt.Printf("No contacts found matching \"%s\".\n", query)
+				if !idsOutput {
+					fmt.Printf("No contacts found matching \"%s\".\n", query)
+				}
+				return nil
+			}
+
+			if idsOutput {
+				for _, r := range resp.Results {
+					if r.Person != nil {
+						fmt.Println(r.Person.ResourceName)
+					}
+				}
 				return nil
 			}
 
@@ -75,6 +92,7 @@ Examples:
 
 	cmd.Flags().Int64VarP(&maxResults, "max", "m", 10, "Maximum number of results")
 	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output as JSON")
+	cmd.Flags().BoolVar(&idsOutput, "ids", false, "Output only resource names, one per line")
 
 	return cmd
 }

--- a/internal/cmd/contacts/star.go
+++ b/internal/cmd/contacts/star.go
@@ -1,0 +1,153 @@
+package contacts
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/bulk"
+)
+
+// starredGroupResourceName is the system contact group for starred contacts.
+const starredGroupResourceName = "contactGroups/starred"
+
+func newStarCommand() *cobra.Command {
+	var (
+		jsonOutput bool
+		dryRun     bool
+		stdin      bool
+		query      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "star [contact-ids...]",
+		Short: "Star contacts",
+		Long: `Star contacts by adding them to the system "Starred" group.
+
+Contact IDs are resource names in the form "people/c1234567890".
+
+Supports three input modes (mutually exclusive):
+  1. Positional arguments: gro contacts star people/c123 people/c456
+  2. Stdin (--stdin):      gro ppl search "John" --ids | gro contacts star --stdin
+  3. Query (--query):      gro contacts star --query "John"
+
+Examples:
+  gro contacts star people/c1234567890
+  gro ppl list --max 5 --ids | gro contacts star --stdin
+  gro contacts star --query "John" --dry-run`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newContactsClient(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("creating Contacts client: %w", err)
+			}
+
+			ctx := cmd.Context()
+			ids, err := bulk.ResolveIDs(bulk.Config{
+				Args:  args,
+				Stdin: stdin,
+				Query: query,
+			}, func(q string) ([]string, error) {
+				return client.SearchContactIDs(ctx, q, 0)
+			})
+			if err != nil {
+				return err
+			}
+
+			result := &bulk.Result{
+				Action:   "starred",
+				IDs:      ids,
+				Count:    len(ids),
+				DryRun:   dryRun,
+				ItemNoun: "contact",
+			}
+
+			if dryRun {
+				result.Action = "star"
+				return result.Print(jsonOutput)
+			}
+
+			if err := client.AddToGroup(ctx, starredGroupResourceName, ids); err != nil {
+				return fmt.Errorf("starring contacts: %w", err)
+			}
+
+			return result.Print(jsonOutput)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
+	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read contact IDs from stdin")
+	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve contact IDs")
+
+	return cmd
+}
+
+func newUnstarCommand() *cobra.Command {
+	var (
+		jsonOutput bool
+		dryRun     bool
+		stdin      bool
+		query      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "unstar [contact-ids...]",
+		Short: "Unstar contacts",
+		Long: `Remove stars from contacts by removing them from the system "Starred" group.
+
+Contact IDs are resource names in the form "people/c1234567890".
+
+Supports three input modes (mutually exclusive):
+  1. Positional arguments: gro contacts unstar people/c123 people/c456
+  2. Stdin (--stdin):      echo "people/c123" | gro contacts unstar --stdin
+  3. Query (--query):      gro contacts unstar --query "John"
+
+Examples:
+  gro contacts unstar people/c1234567890
+  gro contacts unstar --query "John" --dry-run`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newContactsClient(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("creating Contacts client: %w", err)
+			}
+
+			ctx := cmd.Context()
+			ids, err := bulk.ResolveIDs(bulk.Config{
+				Args:  args,
+				Stdin: stdin,
+				Query: query,
+			}, func(q string) ([]string, error) {
+				return client.SearchContactIDs(ctx, q, 0)
+			})
+			if err != nil {
+				return err
+			}
+
+			result := &bulk.Result{
+				Action:   "unstarred",
+				IDs:      ids,
+				Count:    len(ids),
+				DryRun:   dryRun,
+				ItemNoun: "contact",
+			}
+
+			if dryRun {
+				result.Action = "unstar"
+				return result.Print(jsonOutput)
+			}
+
+			if err := client.RemoveFromGroup(ctx, starredGroupResourceName, ids); err != nil {
+				return fmt.Errorf("unstarring contacts: %w", err)
+			}
+
+			return result.Print(jsonOutput)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
+	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read contact IDs from stdin")
+	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve contact IDs")
+
+	return cmd
+}

--- a/internal/cmd/contacts/star_test.go
+++ b/internal/cmd/contacts/star_test.go
@@ -1,0 +1,210 @@
+package contacts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/open-cli-collective/google-readonly/internal/testutil"
+)
+
+func TestStarCommand_Success(t *testing.T) {
+	var addedGroup string
+	var addedContacts []string
+
+	mock := &MockContactsClient{
+		AddToGroupFunc: func(_ context.Context, groupResourceName string, contactResourceNames []string) error {
+			addedGroup = groupResourceName
+			addedContacts = contactResourceNames
+			return nil
+		},
+	}
+
+	cmd := newStarCommand()
+	cmd.SetArgs([]string{"people/c111", "people/c222"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Equal(t, addedGroup, "contactGroups/starred")
+		testutil.Len(t, addedContacts, 2)
+		testutil.Contains(t, output, "Starred 2 contact(s)")
+	})
+}
+
+func TestStarCommand_DryRun(t *testing.T) {
+	mock := &MockContactsClient{}
+
+	cmd := newStarCommand()
+	cmd.SetArgs([]string{"people/c111", "--dry-run"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Contains(t, output, "[dry-run]")
+		testutil.Contains(t, output, "star")
+		testutil.Contains(t, output, "1 contact(s)")
+	})
+}
+
+func TestStarCommand_DryRunJSON(t *testing.T) {
+	mock := &MockContactsClient{}
+
+	cmd := newStarCommand()
+	cmd.SetArgs([]string{"people/c111", "--dry-run", "--json"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		var result map[string]any
+		err := json.Unmarshal([]byte(output), &result)
+		testutil.NoError(t, err)
+		testutil.Equal(t, result["dryRun"].(bool), true)
+		testutil.Equal(t, result["action"].(string), "star")
+	})
+}
+
+func TestStarCommand_JSON(t *testing.T) {
+	mock := &MockContactsClient{
+		AddToGroupFunc: func(_ context.Context, _ string, _ []string) error {
+			return nil
+		},
+	}
+
+	cmd := newStarCommand()
+	cmd.SetArgs([]string{"people/c111", "--json"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		var result map[string]any
+		err := json.Unmarshal([]byte(output), &result)
+		testutil.NoError(t, err)
+		testutil.Equal(t, result["action"].(string), "starred")
+		testutil.Equal(t, result["count"].(float64), float64(1))
+	})
+}
+
+func TestStarCommand_Query(t *testing.T) {
+	mock := &MockContactsClient{
+		SearchContactIDsFunc: func(_ context.Context, query string, _ int64) ([]string, error) {
+			testutil.Equal(t, query, "John")
+			return []string{"people/c111"}, nil
+		},
+		AddToGroupFunc: func(_ context.Context, group string, _ []string) error {
+			testutil.Equal(t, group, "contactGroups/starred")
+			return nil
+		},
+	}
+
+	cmd := newStarCommand()
+	cmd.SetArgs([]string{"--query", "John"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Contains(t, output, "Starred 1 contact(s)")
+	})
+}
+
+func TestStarCommand_APIError(t *testing.T) {
+	mock := &MockContactsClient{
+		AddToGroupFunc: func(_ context.Context, _ string, _ []string) error {
+			return errors.New("API error")
+		},
+	}
+
+	cmd := newStarCommand()
+	cmd.SetArgs([]string{"people/c111"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "starring contacts")
+	})
+}
+
+func TestStarCommand_ClientError(t *testing.T) {
+	cmd := newStarCommand()
+	cmd.SetArgs([]string{"people/c111"})
+
+	withFailingClientFactory(func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "creating Contacts client")
+	})
+}
+
+func TestUnstarCommand_Success(t *testing.T) {
+	var removedGroup string
+
+	mock := &MockContactsClient{
+		RemoveFromGroupFunc: func(_ context.Context, groupResourceName string, _ []string) error {
+			removedGroup = groupResourceName
+			return nil
+		},
+	}
+
+	cmd := newUnstarCommand()
+	cmd.SetArgs([]string{"people/c111"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Equal(t, removedGroup, "contactGroups/starred")
+		testutil.Contains(t, output, "Unstarred 1 contact(s)")
+	})
+}
+
+func TestUnstarCommand_DryRun(t *testing.T) {
+	mock := &MockContactsClient{}
+
+	cmd := newUnstarCommand()
+	cmd.SetArgs([]string{"people/c111", "--dry-run"})
+
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+
+		testutil.Contains(t, output, "[dry-run]")
+		testutil.Contains(t, output, "unstar")
+	})
+}
+
+func TestUnstarCommand_APIError(t *testing.T) {
+	mock := &MockContactsClient{
+		RemoveFromGroupFunc: func(_ context.Context, _ string, _ []string) error {
+			return errors.New("API error")
+		},
+	}
+
+	cmd := newUnstarCommand()
+	cmd.SetArgs([]string{"people/c111"})
+
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "unstarring contacts")
+	})
+}

--- a/internal/contacts/client.go
+++ b/internal/contacts/client.go
@@ -97,3 +97,59 @@ func (c *Client) ListContactGroups(ctx context.Context, pageToken string, pageSi
 
 	return resp, nil
 }
+
+// AddToGroup adds contacts to a contact group
+func (c *Client) AddToGroup(ctx context.Context, groupResourceName string, contactResourceNames []string) error {
+	_, err := c.service.ContactGroups.Members.Modify(groupResourceName, &people.ModifyContactGroupMembersRequest{
+		ResourceNamesToAdd: contactResourceNames,
+	}).Context(ctx).Do()
+	return err
+}
+
+// RemoveFromGroup removes contacts from a contact group
+func (c *Client) RemoveFromGroup(ctx context.Context, groupResourceName string, contactResourceNames []string) error {
+	_, err := c.service.ContactGroups.Members.Modify(groupResourceName, &people.ModifyContactGroupMembersRequest{
+		ResourceNamesToRemove: contactResourceNames,
+	}).Context(ctx).Do()
+	return err
+}
+
+// ResolveGroupName finds a contact group by name and returns its resource name
+func (c *Client) ResolveGroupName(ctx context.Context, name string) (string, error) {
+	resp, err := c.service.ContactGroups.List().
+		PageSize(100).
+		GroupFields("name,groupType").
+		Context(ctx).
+		Do()
+	if err != nil {
+		return "", fmt.Errorf("listing groups: %w", err)
+	}
+
+	for _, g := range resp.ContactGroups {
+		if g.Name == name {
+			return g.ResourceName, nil
+		}
+	}
+	return "", fmt.Errorf("group not found: %s", name)
+}
+
+// SearchContactIDs searches contacts and returns only resource names
+func (c *Client) SearchContactIDs(ctx context.Context, query string, pageSize int64) ([]string, error) {
+	resp, err := c.service.People.SearchContacts().
+		Query(query).
+		ReadMask("names").
+		PageSize(pageSize).
+		Context(ctx).
+		Do()
+	if err != nil {
+		return nil, fmt.Errorf("searching contacts: %w", err)
+	}
+
+	ids := make([]string, 0, len(resp.Results))
+	for _, r := range resp.Results {
+		if r.Person != nil {
+			ids = append(ids, r.Person.ResourceName)
+		}
+	}
+	return ids, nil
+}

--- a/internal/contacts/client.go
+++ b/internal/contacts/client.go
@@ -133,8 +133,12 @@ func (c *Client) ResolveGroupName(ctx context.Context, name string) (string, err
 	return "", fmt.Errorf("group not found: %s", name)
 }
 
-// SearchContactIDs searches contacts and returns only resource names
+// SearchContactIDs searches contacts and returns only resource names.
+// pageSize of 0 defaults to 100 (the People API maximum for search).
 func (c *Client) SearchContactIDs(ctx context.Context, query string, pageSize int64) ([]string, error) {
+	if pageSize <= 0 {
+		pageSize = 100
+	}
 	resp, err := c.service.People.SearchContacts().
 		Query(query).
 		ReadMask("names").


### PR DESCRIPTION
## Summary

- Add group management commands (`add-to-group`, `remove-from-group`) for managing contact group membership
- Add `star`/`unstar` commands using the system `contactGroups/starred` group
- Add `--ids` flag to `list` and `search` commands for piping resource names
- Replace `contacts.readonly` scope with full `contacts` scope for group/star write access
- Add `ItemNoun` field to `bulk.Result` for domain-appropriate output text ("contact" vs "message")
- All new commands support bulk input (`--stdin`, `--query`, positional args), `--json`, and `--dry-run`

## Test plan

- [x] All existing tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [x] Architecture tests pass (scope allowlist, --json flags, client interface)
- [ ] Integration: `gro ppl list --ids` outputs bare resource names
- [ ] Integration: `gro ppl search "name" --ids | gro contacts star --stdin`
- [ ] Integration: `gro contacts add-to-group "Friends" <contact-id>`
- [ ] Integration: `gro contacts star <contact-id> --dry-run`

Closes #101