### PR TITLE
feat(mail): add draft composition command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ gro is a **non-destructive** command-line interface for Google services written 
 **Module:** `github.com/open-cli-collective/google-readonly`
 
 ### Features
-- Gmail: Search, read, thread viewing, labels, attachments, archive, star, mark read/unread, label, categorize
+- Gmail: Search, read, thread viewing, labels, attachments, archive, star, mark read/unread, label, categorize, draft (compose-only, never sent)
 - Google Calendar: List calendars, view events, today/week shortcuts
 - Google Contacts: List contacts, search, view details, list groups
 - Google Drive: List files, search, get details, download, tree view, shared drives

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A non-destructive command-line interface for Google services. Search, read, and 
 ## Features
 
 - **Non-destructive by design** - Read access plus organizational operations; no send, delete, or trash
-- **Gmail support** - Search messages, read content, view threads, list labels, download attachments, archive, star, label, categorize, mark read/unread
+- **Gmail support** - Search messages, read content, view threads, list labels, download attachments, archive, star, label, categorize, mark read/unread, compose drafts (never sent automatically)
 - **Calendar support** - List calendars, view events, today/week shortcuts, RSVP, color-coding
 - **Contacts support** - List contacts, search, view details, list groups, star, group management
 - **Drive support** - List files, search, view metadata, download files, folder tree, star/unstar
@@ -273,7 +273,24 @@ gro mail unlabel "Promotions" <id>
 
 # Recategorize messages
 gro mail categorize promotions <id1> <id2>
+
+# Compose a draft (markdown body by default, rendered to HTML)
+gro mail draft --to alice@example.com --subject "Hi" --body "**hello**"
+gro mail draft --to "a@x.com, b@x.com" --subject "Sync" --file notes.md
+echo "# Hello" | gro mail draft --to a@x.com --subject "Hi" --stdin
+
+# Plain text or raw HTML body
+gro mail draft --to a@x.com --subject "Plain" --body "no formatting" --plain
+gro mail draft --to a@x.com --subject "Raw" --body "<h1>Hi</h1>" --html
+
+# With attachments
+gro mail draft --to a@x.com --subject "See attached" --body "..." --attach report.pdf
+
+# From a send-as alias
+gro mail draft --from work@me.com --to a@x.com --subject "Hi" --body "..."
 ```
+
+Drafts always land in your Gmail Drafts folder for human review. The CLI never calls `drafts.send` — sending requires explicit action in Gmail.
 
 ### Calendar Commands
 
@@ -693,6 +710,32 @@ Flags:
       --query string   Search query to resolve message IDs
   -j, --json       Output results as JSON
 ```
+
+### gro mail draft
+
+Compose a Gmail draft and save it to the Drafts folder. The CLI never calls `drafts.send`; the draft sits in Gmail for human review and explicit send.
+
+Body input is markdown by default and rendered to HTML. Use `--plain` for plain text or `--html` for raw HTML (no rendering). Body source is one of `--body`, `--stdin`, or `--file`.
+
+```
+Usage: gro mail draft [flags]
+
+Flags:
+      --to string         Recipient(s), comma-separated (required)
+      --cc string         Cc recipient(s), comma-separated
+      --bcc string        Bcc recipient(s), comma-separated
+      --from string       From address (Gmail send-as alias)
+  -s, --subject string    Subject line (required; empty string allowed)
+      --body string       Body content (markdown by default)
+  -f, --file string       Read body from file
+      --stdin             Read body from stdin
+      --plain             Send body as plain text (no markdown rendering)
+      --html              Send body as raw HTML (no markdown rendering)
+  -a, --attach strings    File path to attach (repeat for multiple)
+  -j, --json              Output result as JSON
+```
+
+`--body`, `--stdin`, and `--file` are mutually exclusive (exactly one required). `--plain` and `--html` are mutually exclusive.
 
 ### gro calendar list
 

--- a/README.md
+++ b/README.md
@@ -737,6 +737,8 @@ Flags:
 
 `--body`, `--stdin`, and `--file` are mutually exclusive (exactly one required). `--plain` and `--html` are mutually exclusive.
 
+Display names in `--to`/`--cc`/`--bcc` (e.g., `Alice <alice@example.com>`) are stripped; only the email address is sent. Edit the draft in Gmail to set display names.
+
 ### gro calendar list
 
 List all calendars the user has access to.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/spf13/cobra v1.8.0
+	github.com/yuin/goldmark v1.8.2
 	golang.org/x/oauth2 v0.34.0
 	google.golang.org/api v0.262.0
 )

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
+github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 h1:F7Jx+6hwnZ41NSFTO5q4LYDtJRXBf2PD0rNBkeB/lus=

--- a/integration-tests.md
+++ b/integration-tests.md
@@ -473,7 +473,7 @@ echo "user under test: $ME"
 | # | Test Case | Command | Expected Result |
 |---|-----------|---------|-----------------|
 | T1 | Plain text body | `./bin/gro mail draft --to "$ME" --subject "T1 plain" --body "hello from gro" --plain` | Exit 0. Stdout: `Draft created: r-...`. Gmail Drafts shows plain-text body, no HTML conversion. |
-| T2 | Markdown rendered to HTML (default) | `./bin/gro mail draft --to "$ME" --subject "T2 markdown" --body $'# Heading\n\n**bold** and _italic_\n\n- one\n- two\n\n\| col1 \| col2 \|\n\|------\|------\|\n\| a \| b \|'` | Gmail Drafts shows real H1 heading, bold/italic text, bullet list, and 2-column table — rendered, not raw markdown. |
+| T2 | Markdown rendered to HTML (default) | See setup block below for T2 (the markdown table in the body needs a real heredoc, not inline bash quoting). | Gmail Drafts shows real H1 heading, bold/italic text, bullet list, and 2-column table — rendered, not raw markdown. |
 | T3 | Raw HTML body | `./bin/gro mail draft --to "$ME" --subject "T3 html" --body '<h1 style="color:tomato">Tomato</h1><p>Inline <span style="background:yellow">highlight</span>.</p>' --html` | Gmail Drafts shows tomato-colored heading and yellow highlight. Confirms raw HTML is not double-processed. |
 | T4 | Body from stdin (agentic flow) | `echo $'## Status\n\n- [x] done\n- [ ] todo' \| ./bin/gro mail draft --to "$ME" --subject "T4 stdin" --stdin` | Gmail Drafts shows H2 + task list with checkboxes (TaskList extension). |
 | T5 | Body from file | (see T5 setup below) | Gmail Drafts renders headings + strikethrough + numbered list. |
@@ -485,6 +485,25 @@ echo "user under test: $ME"
 | T11 | JSON output | `./bin/gro mail draft --to "$ME" --subject "T11 json" --body "x" --plain --json \| jq .` | Stdout is valid JSON with `id`, `messageId`, `threadId`. `jq` exits 0. |
 
 ### Setup blocks
+
+**T2:**
+```bash
+cat > /tmp/gro-t2.md <<'EOF'
+# Heading
+
+**bold** and _italic_
+
+- one
+- two
+- three
+
+| col1 | col2 |
+|------|------|
+| a    | b    |
+| c    | d    |
+EOF
+./bin/gro mail draft --to "$ME" --subject "T2 markdown" --file /tmp/gro-t2.md
+```
 
 **T5:**
 ```bash
@@ -549,7 +568,7 @@ Skip if no Gmail send-as alias is configured for the test user.
 ### Cleanup
 
 ```bash
-rm -f /tmp/gro-t5.md /tmp/gro-t7.txt /tmp/gro-t8.csv /tmp/gro-t8.json
+rm -f /tmp/gro-t2.md /tmp/gro-t5.md /tmp/gro-t7.txt /tmp/gro-t8.csv /tmp/gro-t8.json
 rm -rf /tmp/gro-secret-dir
 # Gmail UI: Drafts → select T* drafts → Discard
 ```

--- a/integration-tests.md
+++ b/integration-tests.md
@@ -462,7 +462,7 @@ These scenarios exercise the full path: flag parsing → MIME assembly → Gmail
 **Setup:**
 ```bash
 make build
-ME=$(./bin/gro me --id)   # current user's primary email
+ME="you@example.com"   # set to the authenticated Google account
 echo "user under test: $ME"
 ```
 

--- a/integration-tests.md
+++ b/integration-tests.md
@@ -455,6 +455,107 @@ gro mail thread "$THREAD_ID" --json | jq -r '.[].body'
 
 ---
 
+## Draft Composition (`gro mail draft`)
+
+These scenarios exercise the full path: flag parsing → MIME assembly → Gmail API `users.drafts.create` → draft visible in Gmail Drafts UI. Each test creates a draft addressed to the authenticated user; verification is by visual inspection in Gmail and by inspecting CLI stdout/exit code.
+
+**Setup:**
+```bash
+make build
+ME=$(./bin/gro me --id)   # current user's primary email
+echo "user under test: $ME"
+```
+
+**Cleanup (after running):** Open Gmail → Drafts → select all `T*` drafts → Discard.
+
+### Happy Paths
+
+| # | Test Case | Command | Expected Result |
+|---|-----------|---------|-----------------|
+| T1 | Plain text body | `./bin/gro mail draft --to "$ME" --subject "T1 plain" --body "hello from gro" --plain` | Exit 0. Stdout: `Draft created: r-...`. Gmail Drafts shows plain-text body, no HTML conversion. |
+| T2 | Markdown rendered to HTML (default) | `./bin/gro mail draft --to "$ME" --subject "T2 markdown" --body $'# Heading\n\n**bold** and _italic_\n\n- one\n- two\n\n\| col1 \| col2 \|\n\|------\|------\|\n\| a \| b \|'` | Gmail Drafts shows real H1 heading, bold/italic text, bullet list, and 2-column table — rendered, not raw markdown. |
+| T3 | Raw HTML body | `./bin/gro mail draft --to "$ME" --subject "T3 html" --body '<h1 style="color:tomato">Tomato</h1><p>Inline <span style="background:yellow">highlight</span>.</p>' --html` | Gmail Drafts shows tomato-colored heading and yellow highlight. Confirms raw HTML is not double-processed. |
+| T4 | Body from stdin (agentic flow) | `echo $'## Status\n\n- [x] done\n- [ ] todo' \| ./bin/gro mail draft --to "$ME" --subject "T4 stdin" --stdin` | Gmail Drafts shows H2 + task list with checkboxes (TaskList extension). |
+| T5 | Body from file | (see T5 setup below) | Gmail Drafts renders headings + strikethrough + numbered list. |
+| T6 | Multiple recipients (To/Cc/Bcc) | `./bin/gro mail draft --to "$ME, ${ME%@*}+to2@${ME#*@}" --cc "${ME%@*}+cc@${ME#*@}" --bcc "${ME%@*}+bcc@${ME#*@}" --subject "T6 recipients" --body "x" --plain` | Gmail Drafts shows all four addresses populated. Plus-addressing routes to same inbox but Gmail records them distinctly. |
+| T7 | Single attachment | (see T7 setup below) | Stdout: `Attachments: 1`, `- gro-t7.txt`. Gmail Drafts has paperclip; attachment downloadable with original content. |
+| T8 | Multiple attachments, mixed types | (see T8 setup below) | Stdout: `Attachments: 2`. Gmail previews CSV inline; both files downloadable. |
+| T9 | Basename only — no path leak | (see T9 setup below) | Attachment shown as `quarterly.txt` (not `/tmp/gro-secret-dir/quarterly.txt`). |
+| T10 | Empty subject explicitly allowed | `./bin/gro mail draft --to "$ME" --subject "" --body "T10" --plain` | Exit 0. Gmail Drafts shows `(no subject)`. |
+| T11 | JSON output | `./bin/gro mail draft --to "$ME" --subject "T11 json" --body "x" --plain --json \| jq .` | Stdout is valid JSON with `id`, `messageId`, `threadId`. `jq` exits 0. |
+
+### Setup blocks
+
+**T5:**
+```bash
+cat > /tmp/gro-t5.md <<'EOF'
+# Weekly report
+
+## Highlights
+
+- Shipped `gro mail draft` (#112)
+- ~~Cancelled~~ rescheduled the migration
+
+## Next week
+
+1. Roll out to prod
+2. Monitor
+3. Iterate
+EOF
+./bin/gro mail draft --to "$ME" --subject "T5 file body" --file /tmp/gro-t5.md
+```
+
+**T7:**
+```bash
+echo "T7 attachment content" > /tmp/gro-t7.txt
+./bin/gro mail draft --to "$ME" --subject "T7 single attachment" --body "see attached" --plain --attach /tmp/gro-t7.txt
+```
+
+**T8:**
+```bash
+printf 'a,b,c\n1,2,3\n4,5,6\n' > /tmp/gro-t8.csv
+printf '{"key":"value","nested":{"a":1}}' > /tmp/gro-t8.json
+./bin/gro mail draft --to "$ME" --subject "T8 multi attachments" --body "csv + json" --plain --attach /tmp/gro-t8.csv --attach /tmp/gro-t8.json
+```
+
+**T9:**
+```bash
+mkdir -p /tmp/gro-secret-dir
+echo "report contents" > /tmp/gro-secret-dir/quarterly.txt
+./bin/gro mail draft --to "$ME" --subject "T9 path leak check" --body "attachment name should be 'quarterly.txt' only" --plain --attach /tmp/gro-secret-dir/quarterly.txt
+```
+
+### Validation / Safety
+
+| # | Test Case | Command | Expected Result |
+|---|-----------|---------|-----------------|
+| T12 | Missing `--to` rejected before API call | `./bin/gro mail draft --subject "T12" --body "x" --plain; echo "exit=$?"` | Non-zero exit. Error mentions `--to is required`. No draft in Gmail. |
+| T13 | Missing `--subject` rejected | `./bin/gro mail draft --to "$ME" --body "x" --plain; echo "exit=$?"` | Non-zero exit. Error mentions `--subject is required`. |
+| T14 | Two body sources rejected | `./bin/gro mail draft --to "$ME" --subject "T14" --body "x" --stdin; echo "exit=$?"` | Non-zero exit. Error mentions `exactly one of`. |
+| T15 | `--plain` + `--html` rejected | `./bin/gro mail draft --to "$ME" --subject "T15" --body "x" --plain --html; echo "exit=$?"` | Non-zero exit. Error mentions `mutually exclusive`. |
+| T16 | Invalid email in `--to` | `./bin/gro mail draft --to "not-an-email" --subject "T16" --body "x" --plain; echo "exit=$?"` | Non-zero exit. Error mentions `--to`. |
+| T17 | CR/LF header injection rejected | `./bin/gro mail draft --to "$ME" --subject $'T17\r\nBcc: evil@x.com' --body "x" --plain; echo "exit=$?"` | Non-zero exit. Error mentions CR or LF. No draft created. |
+| T18 | Missing attachment file rejected | `./bin/gro mail draft --to "$ME" --subject "T18" --body "x" --plain --attach /nope/does/not/exist; echo "exit=$?"` | Non-zero exit before API call. Error mentions the missing path. No draft in Gmail. |
+
+### Optional: send-as alias (`--from`)
+
+Skip if no Gmail send-as alias is configured for the test user.
+
+| # | Test Case | Command | Expected Result |
+|---|-----------|---------|-----------------|
+| T19 | Valid alias | `./bin/gro mail draft --from <configured-alias> --to "$ME" --subject "T19 alias" --body "x" --plain` | Exit 0. Gmail Drafts shows the alias in From line. |
+| T20 | Unconfigured alias | `./bin/gro mail draft --from "not-my-alias@example.com" --to "$ME" --subject "T20 bad alias" --body "x" --plain; echo "exit=$?"` | Non-zero exit. API error surfaced verbatim from `creating draft: ...`. |
+
+### Cleanup
+
+```bash
+rm -f /tmp/gro-t5.md /tmp/gro-t7.txt /tmp/gro-t8.csv /tmp/gro-t8.json
+rm -rf /tmp/gro-secret-dir
+# Gmail UI: Drafts → select T* drafts → Discard
+```
+
+---
+
 ## Adding New Tests
 
 When adding new features or fixing bugs:

--- a/internal/cmd/mail/draft.go
+++ b/internal/cmd/mail/draft.go
@@ -103,7 +103,7 @@ Examples:
 			if cmd.Flags().Changed("body") {
 				bodySources++
 			}
-			if stdin {
+			if cmd.Flags().Changed("stdin") {
 				bodySources++
 			}
 			if cmd.Flags().Changed("file") {
@@ -187,6 +187,9 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("creating draft: %w", err)
 			}
+			if result == nil {
+				return fmt.Errorf("creating draft: empty response")
+			}
 
 			// 10. Print result.
 			if jsonOut {
@@ -247,7 +250,7 @@ func parseAddressList(flag, raw string) ([]string, error) {
 // detectMimeType resolves the MIME type for a file path via mime.TypeByExtension.
 // Falls back to application/octet-stream.
 func detectMimeType(path string) string {
-	ext := filepath.Ext(path)
+	ext := strings.ToLower(filepath.Ext(path))
 	if ext == "" {
 		return "application/octet-stream"
 	}

--- a/internal/cmd/mail/draft.go
+++ b/internal/cmd/mail/draft.go
@@ -1,0 +1,262 @@
+package mail
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"mime"
+	"net/mail"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+
+	gmailapi "github.com/open-cli-collective/google-readonly/internal/gmail"
+)
+
+func newDraftCommand() *cobra.Command {
+	var (
+		to       string
+		cc       string
+		bcc      string
+		fromAddr string
+		subject  string
+		body     string
+		file     string
+		stdin    bool
+		plain    bool
+		htmlMode bool
+		attach   []string
+		jsonOut  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "draft",
+		Short: "Compose a Gmail draft (never sent automatically)",
+		Long: `Compose a Gmail draft and save it to the Drafts folder for human review.
+
+The CLI never calls drafts.send — sending requires explicit action in Gmail.
+
+Body input is markdown by default and rendered to HTML. Use --plain for plain
+text, --html to send raw HTML verbatim. Body source is one of --body, --stdin,
+or --file.
+
+Examples:
+  gro mail draft --to alice@example.com --subject "Hi" --body "**hello**"
+  gro mail draft --to "a@x.com, b@x.com" --subject "Sync" --file notes.md
+  echo "# Hello" | gro mail draft --to a@x.com --subject "Hi" --stdin
+  gro mail draft --to a@x.com --subject "Plain" --body "no md" --plain
+  gro mail draft --to a@x.com --subject "Report" --body "see attached" --attach report.pdf`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// 1. Required-flag checks.
+			if !cmd.Flags().Changed("to") {
+				return fmt.Errorf("--to is required")
+			}
+			if !cmd.Flags().Changed("subject") {
+				return fmt.Errorf("--subject is required (use --subject \"\" for empty subject)")
+			}
+
+			// 2. Header-injection guard on raw flag values.
+			for _, f := range []struct{ name, val string }{
+				{"--to", to}, {"--cc", cc}, {"--bcc", bcc},
+				{"--from", fromAddr}, {"--subject", subject},
+			} {
+				if strings.ContainsAny(f.val, "\r\n") {
+					return fmt.Errorf("%s contains illegal CR or LF", f.name)
+				}
+			}
+
+			// 3. Address parsing.
+			toAddrs, err := parseAddressList("--to", to)
+			if err != nil {
+				return err
+			}
+			if len(toAddrs) == 0 {
+				return fmt.Errorf("--to must contain at least one address")
+			}
+			ccAddrs, err := parseAddressList("--cc", cc)
+			if err != nil {
+				return err
+			}
+			bccAddrs, err := parseAddressList("--bcc", bcc)
+			if err != nil {
+				return err
+			}
+			if fromAddr != "" {
+				if _, err := mail.ParseAddress(fromAddr); err != nil {
+					return fmt.Errorf("--from is not a valid email address: %w", err)
+				}
+			}
+
+			// 4. Body source: exactly one of --body, --stdin, --file.
+			bodySources := 0
+			if cmd.Flags().Changed("body") {
+				bodySources++
+			}
+			if stdin {
+				bodySources++
+			}
+			if file != "" {
+				bodySources++
+			}
+			if bodySources != 1 {
+				return fmt.Errorf("exactly one of --body, --stdin, or --file is required")
+			}
+
+			// 5. Format mode: at most one of --plain or --html.
+			if plain && htmlMode {
+				return fmt.Errorf("--plain and --html are mutually exclusive")
+			}
+
+			// 6. Resolve body bytes.
+			var bodyBytes []byte
+			switch {
+			case stdin:
+				b, err := io.ReadAll(cmd.InOrStdin())
+				if err != nil {
+					return fmt.Errorf("reading body from stdin: %w", err)
+				}
+				bodyBytes = b
+			case file != "":
+				b, err := os.ReadFile(file) // #nosec G304 -- file path is intentionally user-supplied via --file
+				if err != nil {
+					return fmt.Errorf("reading body file: %w", err)
+				}
+				bodyBytes = b
+			default:
+				bodyBytes = []byte(body)
+			}
+
+			// 7. Render or pass through.
+			var (
+				outBody []byte
+				kind    gmailapi.DraftBodyKind
+			)
+			switch {
+			case plain:
+				outBody, kind = bodyBytes, gmailapi.DraftBodyPlainText
+			case htmlMode:
+				outBody, kind = bodyBytes, gmailapi.DraftBodyHTML
+			default:
+				rendered, err := renderMarkdown(bodyBytes)
+				if err != nil {
+					return fmt.Errorf("rendering markdown: %w", err)
+				}
+				outBody, kind = rendered, gmailapi.DraftBodyHTML
+			}
+
+			// 8. Load attachments.
+			attachments := make([]gmailapi.DraftAttachment, 0, len(attach))
+			for _, path := range attach {
+				data, err := os.ReadFile(path) // #nosec G304 -- attachment path is intentionally user-supplied via --attach
+				if err != nil {
+					return fmt.Errorf("reading attachment %s: %w", path, err)
+				}
+				attachments = append(attachments, gmailapi.DraftAttachment{
+					Filename: filepath.Base(path),
+					MimeType: detectMimeType(path),
+					Data:     data,
+				})
+			}
+
+			// 9. Call client.
+			client, err := newGmailClient(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("creating Gmail client: %w", err)
+			}
+			result, err := client.CreateDraft(cmd.Context(), gmailapi.DraftMessage{
+				From:        fromAddr,
+				To:          toAddrs,
+				Cc:          ccAddrs,
+				Bcc:         bccAddrs,
+				Subject:     subject,
+				Body:        outBody,
+				BodyKind:    kind,
+				Attachments: attachments,
+			})
+			if err != nil {
+				return fmt.Errorf("creating draft: %w", err)
+			}
+
+			// 10. Print result.
+			if jsonOut {
+				return printJSON(result)
+			}
+			fmt.Printf("Draft created: %s\n", result.ID)
+			fmt.Printf("To: %s\n", SanitizeOutput(strings.Join(toAddrs, ", ")))
+			fmt.Printf("Subject: %s\n", SanitizeOutput(subject))
+			if len(attachments) > 0 {
+				fmt.Printf("Attachments: %d\n", len(attachments))
+				for _, a := range attachments {
+					fmt.Printf("  - %s\n", SanitizeOutput(a.Filename))
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&to, "to", "", "Recipient(s), comma-separated")
+	cmd.Flags().StringVar(&cc, "cc", "", "Cc recipient(s), comma-separated")
+	cmd.Flags().StringVar(&bcc, "bcc", "", "Bcc recipient(s), comma-separated")
+	cmd.Flags().StringVar(&fromAddr, "from", "", "From address (Gmail send-as alias)")
+	cmd.Flags().StringVarP(&subject, "subject", "s", "", "Subject line")
+	cmd.Flags().StringVar(&body, "body", "", "Body content (markdown by default)")
+	cmd.Flags().StringVarP(&file, "file", "f", "", "Read body from file")
+	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read body from stdin")
+	cmd.Flags().BoolVar(&plain, "plain", false, "Send body as plain text (no markdown rendering)")
+	cmd.Flags().BoolVar(&htmlMode, "html", false, "Send body as raw HTML (no markdown rendering)")
+	cmd.Flags().StringArrayVarP(&attach, "attach", "a", nil, "File path to attach (repeat for multiple)")
+	cmd.Flags().BoolVarP(&jsonOut, "json", "j", false, "Output result as JSON")
+
+	return cmd
+}
+
+// parseAddressList parses a comma-separated address list. An empty input is OK
+// and returns nil — the caller decides whether emptiness is an error.
+func parseAddressList(flag, raw string) ([]string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	addrs, err := mail.ParseAddressList(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%s is not a valid address list: %w", flag, err)
+	}
+	out := make([]string, len(addrs))
+	for i, a := range addrs {
+		out[i] = a.Address
+	}
+	return out, nil
+}
+
+// detectMimeType resolves the MIME type for a file path via mime.TypeByExtension.
+// Falls back to application/octet-stream.
+func detectMimeType(path string) string {
+	ext := filepath.Ext(path)
+	if ext == "" {
+		return "application/octet-stream"
+	}
+	if mt := mime.TypeByExtension(ext); mt != "" {
+		return mt
+	}
+	return "application/octet-stream"
+}
+
+// renderMarkdown converts markdown to HTML using goldmark with table,
+// strikethrough, and task-list extensions enabled.
+func renderMarkdown(src []byte) ([]byte, error) {
+	md := goldmark.New(
+		goldmark.WithExtensions(
+			extension.Table,
+			extension.Strikethrough,
+			extension.TaskList,
+		),
+	)
+	var buf bytes.Buffer
+	if err := md.Convert(src, &buf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/cmd/mail/draft.go
+++ b/internal/cmd/mail/draft.go
@@ -194,6 +194,12 @@ Examples:
 			}
 			fmt.Printf("Draft created: %s\n", result.ID)
 			fmt.Printf("To: %s\n", SanitizeOutput(strings.Join(toAddrs, ", ")))
+			if len(ccAddrs) > 0 {
+				fmt.Printf("Cc: %s\n", SanitizeOutput(strings.Join(ccAddrs, ", ")))
+			}
+			if len(bccAddrs) > 0 {
+				fmt.Printf("Bcc: %s\n", SanitizeOutput(strings.Join(bccAddrs, ", ")))
+			}
 			fmt.Printf("Subject: %s\n", SanitizeOutput(subject))
 			if len(attachments) > 0 {
 				fmt.Printf("Attachments: %d\n", len(attachments))
@@ -205,16 +211,16 @@ Examples:
 		},
 	}
 
-	cmd.Flags().StringVar(&to, "to", "", "Recipient(s), comma-separated")
-	cmd.Flags().StringVar(&cc, "cc", "", "Cc recipient(s), comma-separated")
-	cmd.Flags().StringVar(&bcc, "bcc", "", "Bcc recipient(s), comma-separated")
+	cmd.Flags().StringVar(&to, "to", "", "Recipient(s), comma-separated (display names are stripped; edit the draft in Gmail to set them)")
+	cmd.Flags().StringVar(&cc, "cc", "", "Cc recipient(s), comma-separated (display names stripped)")
+	cmd.Flags().StringVar(&bcc, "bcc", "", "Bcc recipient(s), comma-separated (display names stripped)")
 	cmd.Flags().StringVar(&fromAddr, "from", "", "From address (Gmail send-as alias)")
 	cmd.Flags().StringVarP(&subject, "subject", "s", "", "Subject line")
 	cmd.Flags().StringVar(&body, "body", "", "Body content (markdown by default)")
 	cmd.Flags().StringVarP(&file, "file", "f", "", "Read body from file")
 	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read body from stdin")
-	cmd.Flags().BoolVar(&plain, "plain", false, "Send body as plain text (no markdown rendering)")
-	cmd.Flags().BoolVar(&htmlMode, "html", false, "Send body as raw HTML (no markdown rendering)")
+	cmd.Flags().BoolVar(&plain, "plain", false, "Treat body as plain text (no markdown rendering)")
+	cmd.Flags().BoolVar(&htmlMode, "html", false, "Treat body as raw HTML (no markdown rendering)")
 	cmd.Flags().StringArrayVarP(&attach, "attach", "a", nil, "File path to attach (repeat for multiple)")
 	cmd.Flags().BoolVarP(&jsonOut, "json", "j", false, "Output result as JSON")
 

--- a/internal/cmd/mail/draft.go
+++ b/internal/cmd/mail/draft.go
@@ -103,7 +103,7 @@ Examples:
 			if cmd.Flags().Changed("body") {
 				bodySources++
 			}
-			if cmd.Flags().Changed("stdin") {
+			if stdin {
 				bodySources++
 			}
 			if cmd.Flags().Changed("file") {

--- a/internal/cmd/mail/draft.go
+++ b/internal/cmd/mail/draft.go
@@ -35,6 +35,7 @@ func newDraftCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "draft",
+		Args:  cobra.NoArgs,
 		Short: "Compose a Gmail draft (never sent automatically)",
 		Long: `Compose a Gmail draft and save it to the Drafts folder for human review.
 
@@ -86,9 +87,15 @@ Examples:
 				return err
 			}
 			if fromAddr != "" {
-				if _, err := mail.ParseAddress(fromAddr); err != nil {
+				parsed, err := mail.ParseAddress(fromAddr)
+				if err != nil {
 					return fmt.Errorf("--from is not a valid email address: %w", err)
 				}
+				// Normalise to the bare address so display-name input like
+				// "Work <work@me.com>" is reduced to "work@me.com" before
+				// reaching the MIME builder, matching how --to/--cc/--bcc
+				// are handled.
+				fromAddr = parsed.Address
 			}
 
 			// 4. Body source: exactly one of --body, --stdin, --file.
@@ -99,7 +106,7 @@ Examples:
 			if stdin {
 				bodySources++
 			}
-			if file != "" {
+			if cmd.Flags().Changed("file") {
 				bodySources++
 			}
 			if bodySources != 1 {
@@ -120,7 +127,7 @@ Examples:
 					return fmt.Errorf("reading body from stdin: %w", err)
 				}
 				bodyBytes = b
-			case file != "":
+			case cmd.Flags().Changed("file"):
 				b, err := os.ReadFile(file) // #nosec G304 -- file path is intentionally user-supplied via --file
 				if err != nil {
 					return fmt.Errorf("reading body file: %w", err)

--- a/internal/cmd/mail/draft_test.go
+++ b/internal/cmd/mail/draft_test.go
@@ -343,3 +343,94 @@ func TestDraftCommand_APIError(t *testing.T) {
 type mockErr struct{ msg string }
 
 func (e *mockErr) Error() string { return e.msg }
+
+// --- Codex review: cobra.NoArgs ---
+
+func TestDraftCommand_RejectsPositionalArgs(t *testing.T) {
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"accidental", "--to", "a@x.com", "--subject", "hi", "--body", "x"})
+	withMockClient(&MockGmailClient{
+		CreateDraftFunc: func(_ context.Context, _ gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			t.Fatal("CreateDraft should not be called when positional args are present")
+			return nil, nil
+		},
+	}, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+	})
+}
+
+// --- Codex review: --from normalisation ---
+
+func TestDraftCommand_FromNormalisesDisplayName(t *testing.T) {
+	var seen gmailapi.DraftMessage
+	mock := &MockGmailClient{
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			seen = msg
+			return &gmailapi.DraftResult{ID: "d1"}, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--from", "Work <work@me.com>", "--to", "a@x.com", "--subject", "Hi", "--body", "x"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.NoError(t, err)
+		// Codex M2: raw value "Work <work@me.com>" must be normalised to
+		// "work@me.com" before reaching DraftMessage.
+		testutil.Equal(t, seen.From, "work@me.com")
+	})
+}
+
+// --- TDD review: command-layer CR/LF guard across all address fields ---
+
+func TestDraftCommand_RejectsHeaderInjection_AllFields(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"--cc CRLF", []string{"--to", "a@x.com", "--cc", "b@x.com\r\nBcc: e@x.com", "--subject", "hi", "--body", "x"}},
+		{"--bcc LF", []string{"--to", "a@x.com", "--bcc", "b@x.com\nBcc: e@x.com", "--subject", "hi", "--body", "x"}},
+		{"--from CRLF", []string{"--to", "a@x.com", "--from", "a@x.com\r\nBcc: e@x.com", "--subject", "hi", "--body", "x"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newDraftCommand()
+			cmd.SetArgs(tc.args)
+			withMockClient(&MockGmailClient{}, func() {
+				err := cmd.Execute()
+				testutil.Error(t, err)
+			})
+		})
+	}
+}
+
+// --- TDD review: detectMimeType fallback branches ---
+
+func TestDetectMimeType(t *testing.T) {
+	cases := []struct {
+		name     string
+		path     string
+		want     string // empty = "anything but the default", expects known type
+		fallback bool
+	}{
+		{"known extension", "report.pdf", "application/pdf", false},
+		{"no extension", "Makefile", "application/octet-stream", true},
+		{"unknown extension", "data.xyzunknown", "application/octet-stream", true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := detectMimeType(tc.path)
+			if tc.fallback {
+				testutil.Equal(t, got, "application/octet-stream")
+				return
+			}
+			// Known type: prefix-match so "application/pdf" or
+			// "application/pdf; charset=..." both pass.
+			if got != tc.want && !strings.HasPrefix(got, tc.want+";") {
+				t.Errorf("detectMimeType(%q) = %q, want %q (or with params)", tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/mail/draft_test.go
+++ b/internal/cmd/mail/draft_test.go
@@ -92,7 +92,12 @@ func TestDraftCommand_RejectsPlainAndHTMLTogether(t *testing.T) {
 	withMockClient(&MockGmailClient{}, func() {
 		err := cmd.Execute()
 		testutil.Error(t, err)
+		// Pin the full message so the test catches a regression where only
+		// "--plain" appears (e.g. if the error wording for an unrelated flag
+		// happened to mention --plain).
 		testutil.Contains(t, err.Error(), "--plain")
+		testutil.Contains(t, err.Error(), "--html")
+		testutil.Contains(t, err.Error(), "mutually exclusive")
 	})
 }
 
@@ -122,6 +127,7 @@ func TestDraftCommand_RejectsHeaderInjectionInTo(t *testing.T) {
 	withMockClient(&MockGmailClient{}, func() {
 		err := cmd.Execute()
 		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "CR or LF")
 	})
 }
 
@@ -131,6 +137,34 @@ func TestDraftCommand_RejectsHeaderInjectionInSubject(t *testing.T) {
 	withMockClient(&MockGmailClient{}, func() {
 		err := cmd.Execute()
 		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "CR or LF")
+	})
+}
+
+func TestDraftCommand_RejectsEmptyTo(t *testing.T) {
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "", "--subject", "hi", "--body", "x"})
+	withMockClient(&MockGmailClient{}, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		// Distinct code path from "missing --to": flag is Changed but parses
+		// to zero addresses, so the len() == 0 guard fires.
+		testutil.Contains(t, err.Error(), "--to")
+	})
+}
+
+func TestDraftCommand_RejectsMissingFileBody(t *testing.T) {
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "a@x.com", "--subject", "hi", "--file", "/nope/missing-body.md"})
+	withMockClient(&MockGmailClient{
+		CreateDraftFunc: func(_ context.Context, _ gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			t.Fatal("CreateDraft must not be called when --file is unreadable")
+			return nil, nil
+		},
+	}, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "reading body file")
 	})
 }
 
@@ -259,7 +293,13 @@ func TestDraftCommand_Attachments_BasenameOnly(t *testing.T) {
 		}
 		testutil.Equal(t, seen.Attachments[0].Filename, "secret-report.pdf") // basename only
 		testutil.Equal(t, string(seen.Attachments[0].Data), "PDFBYTES")
-		testutil.Equal(t, seen.Attachments[0].MimeType, "application/pdf")
+		// mime.TypeByExtension can return either "application/pdf" or
+		// "application/pdf; charset=binary" depending on OS MIME database.
+		// Prefix-match to stay portable across macOS/Linux CI runners.
+		got := seen.Attachments[0].MimeType
+		if got != "application/pdf" && !strings.HasPrefix(got, "application/pdf;") {
+			t.Errorf("MimeType = %q, want application/pdf (with optional params)", got)
+		}
 	})
 }
 
@@ -299,6 +339,10 @@ func TestDraftCommand_AttachmentMissingFile(t *testing.T) {
 	withMockClient(mock, func() {
 		err := cmd.Execute()
 		testutil.Error(t, err)
+		// Pin both the failing operation and the path so this confirms
+		// attachment loading is the actual failure point.
+		testutil.Contains(t, err.Error(), "reading attachment")
+		testutil.Contains(t, err.Error(), "/nope/does/not/exist.pdf")
 	})
 }
 

--- a/internal/cmd/mail/draft_test.go
+++ b/internal/cmd/mail/draft_test.go
@@ -316,7 +316,7 @@ func TestDraftCommand_MultipleRecipients(t *testing.T) {
 		"--to", "a@x.com, b@x.com",
 		"--cc", "c@x.com",
 		"--bcc", "d@x.com, e@x.com",
-		"--subject", "Hi", "--body", "text",
+		"--subject", "Hi", "--body", "text", "--plain",
 	})
 	withMockClient(mock, func() {
 		err := cmd.Execute()
@@ -324,6 +324,7 @@ func TestDraftCommand_MultipleRecipients(t *testing.T) {
 		testutil.Equal(t, len(seen.To), 2)
 		testutil.Equal(t, len(seen.Cc), 1)
 		testutil.Equal(t, len(seen.Bcc), 2)
+		testutil.Equal(t, seen.BodyKind, gmailapi.DraftBodyPlainText)
 	})
 }
 
@@ -444,8 +445,15 @@ func TestDraftCommand_RejectsHeaderInjection_AllFields(t *testing.T) {
 			withMockClient(&MockGmailClient{}, func() {
 				err := cmd.Execute()
 				testutil.Error(t, err)
+				testutil.Contains(t, err.Error(), "CR or LF")
 			})
 		})
+	}
+}
+
+func TestDetectMimeType_UppercaseExtension(t *testing.T) {
+	if got := detectMimeType("Report.PDF"); got != "application/pdf" && !strings.HasPrefix(got, "application/pdf;") {
+		t.Errorf("detectMimeType(Report.PDF) = %q, want application/pdf", got)
 	}
 }
 

--- a/internal/cmd/mail/draft_test.go
+++ b/internal/cmd/mail/draft_test.go
@@ -1,0 +1,345 @@
+package mail
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gmailapi "github.com/open-cli-collective/google-readonly/internal/gmail"
+	"github.com/open-cli-collective/google-readonly/internal/testutil"
+)
+
+// --- Flag presence ---
+
+func TestDraftCommand_FlagsPresent(t *testing.T) {
+	cmd := newDraftCommand()
+	for _, name := range []string{
+		"to", "cc", "bcc", "from", "subject",
+		"body", "stdin", "file", "plain", "html",
+		"attach", "json",
+	} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("flag %q missing", name)
+		}
+	}
+}
+
+// --- Validation negative cases ---
+
+func TestDraftCommand_RequiresTo(t *testing.T) {
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--subject", "hi", "--body", "x"})
+	withMockClient(&MockGmailClient{}, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "--to")
+	})
+}
+
+func TestDraftCommand_RequiresSubject(t *testing.T) {
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "a@x.com", "--body", "x"})
+	withMockClient(&MockGmailClient{}, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "--subject")
+	})
+}
+
+func TestDraftCommand_EmptySubjectAllowedIfExplicit(t *testing.T) {
+	var seen gmailapi.DraftMessage
+	mock := &MockGmailClient{
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			seen = msg
+			return &gmailapi.DraftResult{ID: "d1"}, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "a@x.com", "--subject", "", "--body", "x"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.NoError(t, err)
+		testutil.Equal(t, seen.Subject, "")
+	})
+}
+
+func TestDraftCommand_RequiresOneBodySource(t *testing.T) {
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "a@x.com", "--subject", "hi"})
+	withMockClient(&MockGmailClient{}, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "exactly one of")
+	})
+}
+
+func TestDraftCommand_RejectsMultipleBodySources(t *testing.T) {
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "a@x.com", "--subject", "hi", "--body", "x", "--file", "/dev/null"})
+	withMockClient(&MockGmailClient{}, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "exactly one of")
+	})
+}
+
+func TestDraftCommand_RejectsPlainAndHTMLTogether(t *testing.T) {
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "a@x.com", "--subject", "hi", "--body", "x", "--plain", "--html"})
+	withMockClient(&MockGmailClient{}, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "--plain")
+	})
+}
+
+func TestDraftCommand_RejectsInvalidFrom(t *testing.T) {
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "a@x.com", "--subject", "hi", "--body", "x", "--from", "not-an-email"})
+	withMockClient(&MockGmailClient{}, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "--from")
+	})
+}
+
+func TestDraftCommand_RejectsInvalidTo(t *testing.T) {
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "not-an-email", "--subject", "hi", "--body", "x"})
+	withMockClient(&MockGmailClient{}, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "--to")
+	})
+}
+
+func TestDraftCommand_RejectsHeaderInjectionInTo(t *testing.T) {
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "a@x.com\r\nBcc: evil@x.com", "--subject", "hi", "--body", "x"})
+	withMockClient(&MockGmailClient{}, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+	})
+}
+
+func TestDraftCommand_RejectsHeaderInjectionInSubject(t *testing.T) {
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "a@x.com", "--subject", "hi\r\nBcc: x@y.com", "--body", "x"})
+	withMockClient(&MockGmailClient{}, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+	})
+}
+
+// --- Success paths ---
+
+func TestDraftCommand_DefaultIsMarkdownRenderedToHTML(t *testing.T) {
+	var seen gmailapi.DraftMessage
+	mock := &MockGmailClient{
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			seen = msg
+			return &gmailapi.DraftResult{ID: "d1", MessageID: "m1"}, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "alice@example.com", "--subject", "Hi", "--body", "**bold** and _italic_"})
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		testutil.Equal(t, seen.BodyKind, gmailapi.DraftBodyHTML)
+		testutil.Contains(t, string(seen.Body), "<strong>bold</strong>")
+		testutil.Contains(t, string(seen.Body), "<em>italic</em>")
+		testutil.Contains(t, output, "Draft created: d1")
+	})
+}
+
+func TestDraftCommand_PlainSendsPlainText(t *testing.T) {
+	var seen gmailapi.DraftMessage
+	mock := &MockGmailClient{
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			seen = msg
+			return &gmailapi.DraftResult{ID: "d1"}, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "a@x.com", "--subject", "Hi", "--body", "**bold**", "--plain"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.NoError(t, err)
+		testutil.Equal(t, seen.BodyKind, gmailapi.DraftBodyPlainText)
+		testutil.Equal(t, string(seen.Body), "**bold**") // verbatim, no rendering
+	})
+}
+
+func TestDraftCommand_HTMLPassesThroughVerbatim(t *testing.T) {
+	var seen gmailapi.DraftMessage
+	mock := &MockGmailClient{
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			seen = msg
+			return &gmailapi.DraftResult{ID: "d1"}, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "a@x.com", "--subject", "Hi", "--body", "<h1>Raw</h1>", "--html"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.NoError(t, err)
+		testutil.Equal(t, seen.BodyKind, gmailapi.DraftBodyHTML)
+		testutil.Equal(t, string(seen.Body), "<h1>Raw</h1>") // verbatim
+	})
+}
+
+func TestDraftCommand_File(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "body.md")
+	if err := os.WriteFile(path, []byte("# hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var seen gmailapi.DraftMessage
+	mock := &MockGmailClient{
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			seen = msg
+			return &gmailapi.DraftResult{ID: "d1"}, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "a@x.com", "--subject", "Hi", "--file", path})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.NoError(t, err)
+		testutil.Contains(t, string(seen.Body), "<h1>hello</h1>")
+	})
+}
+
+func TestDraftCommand_Stdin(t *testing.T) {
+	var seen gmailapi.DraftMessage
+	mock := &MockGmailClient{
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			seen = msg
+			return &gmailapi.DraftResult{ID: "d1"}, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetIn(strings.NewReader("## from stdin"))
+	cmd.SetArgs([]string{"--to", "a@x.com", "--subject", "Hi", "--stdin"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.NoError(t, err)
+		testutil.Contains(t, string(seen.Body), "<h2>from stdin</h2>")
+	})
+}
+
+func TestDraftCommand_Attachments_BasenameOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret-report.pdf")
+	if err := os.WriteFile(path, []byte("PDFBYTES"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var seen gmailapi.DraftMessage
+	mock := &MockGmailClient{
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			seen = msg
+			return &gmailapi.DraftResult{ID: "d1"}, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "a@x.com", "--subject", "See attached", "--body", "here", "--attach", path})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.NoError(t, err)
+		if len(seen.Attachments) != 1 {
+			t.Fatalf("attachments = %d, want 1", len(seen.Attachments))
+		}
+		testutil.Equal(t, seen.Attachments[0].Filename, "secret-report.pdf") // basename only
+		testutil.Equal(t, string(seen.Attachments[0].Data), "PDFBYTES")
+		testutil.Equal(t, seen.Attachments[0].MimeType, "application/pdf")
+	})
+}
+
+func TestDraftCommand_MultipleRecipients(t *testing.T) {
+	var seen gmailapi.DraftMessage
+	mock := &MockGmailClient{
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			seen = msg
+			return &gmailapi.DraftResult{ID: "d1"}, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{
+		"--to", "a@x.com, b@x.com",
+		"--cc", "c@x.com",
+		"--bcc", "d@x.com, e@x.com",
+		"--subject", "Hi", "--body", "text",
+	})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.NoError(t, err)
+		testutil.Equal(t, len(seen.To), 2)
+		testutil.Equal(t, len(seen.Cc), 1)
+		testutil.Equal(t, len(seen.Bcc), 2)
+	})
+}
+
+func TestDraftCommand_AttachmentMissingFile(t *testing.T) {
+	mock := &MockGmailClient{
+		CreateDraftFunc: func(_ context.Context, _ gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			t.Fatal("CreateDraft should not be called when attachment file is missing")
+			return nil, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "a@x.com", "--subject", "Hi", "--body", "x", "--attach", "/nope/does/not/exist.pdf"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+	})
+}
+
+func TestDraftCommand_JSONOutput(t *testing.T) {
+	mock := &MockGmailClient{
+		CreateDraftFunc: func(_ context.Context, _ gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			return &gmailapi.DraftResult{ID: "d1", MessageID: "m1", ThreadID: "t1"}, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "a@x.com", "--subject", "Hi", "--body", "x", "--json"})
+	withMockClient(mock, func() {
+		output := testutil.CaptureStdout(t, func() {
+			err := cmd.Execute()
+			testutil.NoError(t, err)
+		})
+		var result gmailapi.DraftResult
+		if err := json.Unmarshal([]byte(output), &result); err != nil {
+			t.Fatalf("unmarshal: %v\noutput=%q", err, output)
+		}
+		testutil.Equal(t, result.ID, "d1")
+		testutil.Equal(t, result.MessageID, "m1")
+		testutil.Equal(t, result.ThreadID, "t1")
+	})
+}
+
+func TestDraftCommand_APIError(t *testing.T) {
+	mock := &MockGmailClient{
+		CreateDraftFunc: func(_ context.Context, _ gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			return nil, &mockErr{msg: "boom"}
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "a@x.com", "--subject", "Hi", "--body", "x"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "creating draft")
+	})
+}
+
+type mockErr struct{ msg string }
+
+func (e *mockErr) Error() string { return e.msg }

--- a/internal/cmd/mail/mail.go
+++ b/internal/cmd/mail/mail.go
@@ -18,6 +18,7 @@ This command group provides Gmail functionality:
 - thread: Read a full conversation thread
 - labels: List all labels
 - attachments: List and download attachments
+- draft: Compose a draft (never sent automatically)
 
 Organizational operations (non-destructive):
 - archive: Remove messages from inbox
@@ -49,6 +50,7 @@ Examples:
 	cmd.AddCommand(newLabelCommand())
 	cmd.AddCommand(newUnlabelCommand())
 	cmd.AddCommand(newCategorizeCommand())
+	cmd.AddCommand(newDraftCommand())
 
 	return cmd
 }

--- a/internal/cmd/mail/mock_test.go
+++ b/internal/cmd/mail/mock_test.go
@@ -24,6 +24,7 @@ type MockGmailClient struct {
 	DownloadAttachmentFunc       func(ctx context.Context, messageID, attachmentID string) ([]byte, error)
 	DownloadInlineAttachmentFunc func(ctx context.Context, messageID, partID string) ([]byte, error)
 	GetProfileFunc               func(ctx context.Context) (*gmailapi.Profile, error)
+	CreateDraftFunc              func(ctx context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error)
 }
 
 // Verify MockGmailClient implements MailClient
@@ -116,6 +117,13 @@ func (m *MockGmailClient) DownloadInlineAttachment(ctx context.Context, messageI
 func (m *MockGmailClient) GetProfile(ctx context.Context) (*gmailapi.Profile, error) {
 	if m.GetProfileFunc != nil {
 		return m.GetProfileFunc(ctx)
+	}
+	return nil, nil
+}
+
+func (m *MockGmailClient) CreateDraft(ctx context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+	if m.CreateDraftFunc != nil {
+		return m.CreateDraftFunc(ctx, msg)
 	}
 	return nil, nil
 }

--- a/internal/cmd/mail/mock_test.go
+++ b/internal/cmd/mail/mock_test.go
@@ -125,5 +125,5 @@ func (m *MockGmailClient) CreateDraft(ctx context.Context, msg gmailapi.DraftMes
 	if m.CreateDraftFunc != nil {
 		return m.CreateDraftFunc(ctx, msg)
 	}
-	return nil, nil
+	return &gmailapi.DraftResult{ID: "mock-draft-id"}, nil
 }

--- a/internal/cmd/mail/output.go
+++ b/internal/cmd/mail/output.go
@@ -26,6 +26,7 @@ type MailClient interface {
 	DownloadAttachment(ctx context.Context, messageID string, attachmentID string) ([]byte, error)
 	DownloadInlineAttachment(ctx context.Context, messageID string, partID string) ([]byte, error)
 	GetProfile(ctx context.Context) (*gmail.Profile, error)
+	CreateDraft(ctx context.Context, msg gmail.DraftMessage) (*gmail.DraftResult, error)
 }
 
 // ClientFactory is the function used to create Gmail clients.

--- a/internal/gmail/drafts.go
+++ b/internal/gmail/drafts.go
@@ -1,0 +1,251 @@
+package gmail
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"mime"
+	"mime/multipart"
+	"net/mail"
+	"net/textproto"
+	"path/filepath"
+	"strings"
+
+	gmailapi "google.golang.org/api/gmail/v1"
+)
+
+// DraftBodyKind selects the Content-Type for the body part.
+type DraftBodyKind int
+
+const (
+	// DraftBodyHTML sends the body as text/html; charset=UTF-8.
+	DraftBodyHTML DraftBodyKind = iota
+	// DraftBodyPlainText sends the body as text/plain; charset=UTF-8.
+	DraftBodyPlainText
+)
+
+// DraftMessage describes a draft to be created. The command layer constructs
+// this and hands it to (*Client).CreateDraft. The gmail package owns MIME
+// assembly and the raw API call.
+type DraftMessage struct {
+	From        string   // optional; send-as alias
+	To          []string // required; ≥1
+	Cc          []string
+	Bcc         []string
+	Subject     string
+	Body        []byte
+	BodyKind    DraftBodyKind
+	Attachments []DraftAttachment
+}
+
+// DraftAttachment is one attachment. Filename should be a basename; the gmail
+// package re-applies filepath.Base defensively.
+type DraftAttachment struct {
+	Filename string
+	MimeType string
+	Data     []byte
+}
+
+// DraftResult is the response after creating a draft.
+type DraftResult struct {
+	ID        string `json:"id"`
+	MessageID string `json:"messageId"`
+	ThreadID  string `json:"threadId,omitempty"`
+}
+
+// CreateDraft assembles a MIME message and POSTs to users.drafts.create.
+// The CLI never calls drafts.send — drafts sit in the user's Drafts folder
+// for explicit human review.
+func (c *Client) CreateDraft(ctx context.Context, msg DraftMessage) (*DraftResult, error) {
+	raw, err := buildMIME(msg)
+	if err != nil {
+		return nil, fmt.Errorf("building draft MIME: %w", err)
+	}
+
+	draft := &gmailapi.Draft{
+		Message: &gmailapi.Message{
+			Raw: base64.URLEncoding.EncodeToString(raw),
+		},
+	}
+	resp, err := c.service.Users.Drafts.Create(c.userID, draft).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("creating draft: %w", err)
+	}
+	out := &DraftResult{ID: resp.Id}
+	if resp.Message != nil {
+		out.MessageID = resp.Message.Id
+		out.ThreadID = resp.Message.ThreadId
+	}
+	return out, nil
+}
+
+// buildMIME assembles an RFC 5322 message with CRLF line endings and
+// MIME-Version: 1.0, suitable for base64url-encoding into Gmail's
+// Message.Raw field.
+func buildMIME(msg DraftMessage) ([]byte, error) {
+	if err := guardHeaderInjection(msg); err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString("MIME-Version: 1.0\r\n")
+
+	if msg.From != "" {
+		fmt.Fprintf(&buf, "From: %s\r\n", (&mail.Address{Address: msg.From}).String())
+	}
+	if h := addressHeader("To", msg.To); h != "" {
+		buf.WriteString(h)
+	}
+	if h := addressHeader("Cc", msg.Cc); h != "" {
+		buf.WriteString(h)
+	}
+	if h := addressHeader("Bcc", msg.Bcc); h != "" {
+		buf.WriteString(h)
+	}
+	fmt.Fprintf(&buf, "Subject: %s\r\n", mime.QEncoding.Encode("utf-8", msg.Subject))
+
+	if len(msg.Attachments) == 0 {
+		// Single-part: emit content headers and base64 body inline.
+		buf.WriteString(bodyContentType(msg.BodyKind))
+		buf.WriteString("Content-Transfer-Encoding: base64\r\n")
+		buf.WriteString("\r\n")
+		buf.Write(wrapBase64(msg.Body))
+		return buf.Bytes(), nil
+	}
+
+	// Multipart/mixed.
+	mw := multipart.NewWriter(&buf)
+	fmt.Fprintf(&buf, "Content-Type: multipart/mixed; boundary=%q\r\n\r\n", mw.Boundary())
+
+	// Body part.
+	bodyHdr := textproto.MIMEHeader{}
+	bodyHdr.Set("Content-Type", bodyContentTypeValue(msg.BodyKind))
+	bodyHdr.Set("Content-Transfer-Encoding", "base64")
+	bw, err := mw.CreatePart(bodyHdr)
+	if err != nil {
+		return nil, fmt.Errorf("creating body part: %w", err)
+	}
+	if _, err := bw.Write(wrapBase64(msg.Body)); err != nil {
+		return nil, fmt.Errorf("writing body part: %w", err)
+	}
+
+	// Attachment parts.
+	for i, att := range msg.Attachments {
+		basename := filepath.Base(att.Filename)
+		ct, err := buildAttachmentContentType(att.MimeType, basename)
+		if err != nil {
+			return nil, fmt.Errorf("attachment %d content-type: %w", i, err)
+		}
+		hdr := textproto.MIMEHeader{}
+		hdr.Set("Content-Type", ct)
+		hdr.Set("Content-Transfer-Encoding", "base64")
+		hdr.Set("Content-Disposition", mime.FormatMediaType("attachment", map[string]string{"filename": basename}))
+		aw, err := mw.CreatePart(hdr)
+		if err != nil {
+			return nil, fmt.Errorf("creating attachment part %d: %w", i, err)
+		}
+		if _, err := aw.Write(wrapBase64(att.Data)); err != nil {
+			return nil, fmt.Errorf("writing attachment %d: %w", i, err)
+		}
+	}
+	if err := mw.Close(); err != nil {
+		return nil, fmt.Errorf("closing multipart writer: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// guardHeaderInjection rejects CR/LF in any field that becomes a header or
+// header parameter, defending the raw-MIME boundary independently of the
+// command-layer validator.
+func guardHeaderInjection(msg DraftMessage) error {
+	check := func(field, val string) error {
+		if strings.ContainsAny(val, "\r\n") {
+			return fmt.Errorf("invalid %s: contains CR or LF", field)
+		}
+		return nil
+	}
+	if err := check("subject", msg.Subject); err != nil {
+		return err
+	}
+	if err := check("from", msg.From); err != nil {
+		return err
+	}
+	for _, a := range msg.To {
+		if err := check("to", a); err != nil {
+			return err
+		}
+	}
+	for _, a := range msg.Cc {
+		if err := check("cc", a); err != nil {
+			return err
+		}
+	}
+	for _, a := range msg.Bcc {
+		if err := check("bcc", a); err != nil {
+			return err
+		}
+	}
+	for _, att := range msg.Attachments {
+		if err := check("attachment filename", att.Filename); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func addressHeader(name string, addrs []string) string {
+	if len(addrs) == 0 {
+		return ""
+	}
+	formatted := make([]string, len(addrs))
+	for i, a := range addrs {
+		formatted[i] = (&mail.Address{Address: a}).String()
+	}
+	return fmt.Sprintf("%s: %s\r\n", name, strings.Join(formatted, ", "))
+}
+
+func bodyContentType(k DraftBodyKind) string {
+	return "Content-Type: " + bodyContentTypeValue(k) + "\r\n"
+}
+
+func bodyContentTypeValue(k DraftBodyKind) string {
+	if k == DraftBodyHTML {
+		return "text/html; charset=UTF-8"
+	}
+	return "text/plain; charset=UTF-8"
+}
+
+// buildAttachmentContentType parses any params in the supplied MIME type
+// (e.g. "text/plain; charset=utf-8"), merges a name=<basename> param, and
+// re-formats. Falls back to application/octet-stream if mt is empty.
+func buildAttachmentContentType(mt, basename string) (string, error) {
+	if mt == "" {
+		mt = "application/octet-stream"
+	}
+	mediaType, params, err := mime.ParseMediaType(mt)
+	if err != nil {
+		return "", fmt.Errorf("parsing media type %q: %w", mt, err)
+	}
+	if params == nil {
+		params = map[string]string{}
+	}
+	params["name"] = basename
+	return mime.FormatMediaType(mediaType, params), nil
+}
+
+// wrapBase64 standard-encodes b and wraps the output at 76 columns with CRLF,
+// per RFC 2045 §6.8.
+func wrapBase64(b []byte) []byte {
+	encoded := base64.StdEncoding.EncodeToString(b)
+	var out bytes.Buffer
+	for i := 0; i < len(encoded); i += 76 {
+		end := i + 76
+		if end > len(encoded) {
+			end = len(encoded)
+		}
+		out.WriteString(encoded[i:end])
+		out.WriteString("\r\n")
+	}
+	return out.Bytes()
+}

--- a/internal/gmail/drafts.go
+++ b/internal/gmail/drafts.go
@@ -19,10 +19,13 @@ import (
 type DraftBodyKind int
 
 const (
-	// DraftBodyHTML sends the body as text/html; charset=UTF-8.
-	DraftBodyHTML DraftBodyKind = iota
 	// DraftBodyPlainText sends the body as text/plain; charset=UTF-8.
-	DraftBodyPlainText
+	// This is the zero value: a DraftMessage{} with an unset BodyKind
+	// defaults to plain text, which is the safer interpretation when
+	// callers construct DraftMessage directly without going through the CLI.
+	DraftBodyPlainText DraftBodyKind = iota
+	// DraftBodyHTML sends the body as text/html; charset=UTF-8.
+	DraftBodyHTML
 )
 
 // DraftMessage describes a draft to be created. The command layer constructs
@@ -115,8 +118,14 @@ func buildMIME(msg DraftMessage) ([]byte, error) {
 	}
 
 	// Multipart/mixed.
+	// Order matters: NewWriter is created first to obtain a boundary, but
+	// the top-level Content-Type header and blank line MUST be written to
+	// buf BEFORE any CreatePart call — CreatePart writes the first boundary
+	// delimiter, which must come after the blank line that terminates the
+	// message headers. Do not reorder.
 	mw := multipart.NewWriter(&buf)
-	fmt.Fprintf(&buf, "Content-Type: multipart/mixed; boundary=%q\r\n\r\n", mw.Boundary())
+	ct := mime.FormatMediaType("multipart/mixed", map[string]string{"boundary": mw.Boundary()})
+	buf.WriteString("Content-Type: " + ct + "\r\n\r\n")
 
 	// Body part.
 	bodyHdr := textproto.MIMEHeader{}

--- a/internal/gmail/drafts.go
+++ b/internal/gmail/drafts.go
@@ -87,6 +87,9 @@ func (c *Client) CreateDraft(ctx context.Context, msg DraftMessage) (*DraftResul
 // MIME-Version: 1.0, suitable for base64url-encoding into Gmail's
 // Message.Raw field.
 func buildMIME(msg DraftMessage) ([]byte, error) {
+	if len(msg.To) == 0 {
+		return nil, fmt.Errorf("draft has no To recipients")
+	}
 	if err := guardHeaderInjection(msg); err != nil {
 		return nil, err
 	}

--- a/internal/gmail/drafts_test.go
+++ b/internal/gmail/drafts_test.go
@@ -1,0 +1,579 @@
+package gmail
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/mail"
+	"net/textproto"
+	"strings"
+	"testing"
+
+	gmailapi "google.golang.org/api/gmail/v1"
+	"google.golang.org/api/option"
+)
+
+// mimePart is a snapshot of a multipart.Part with its body already read.
+// Iterating multipart.NextPart consumes the previous part's body, so we
+// read each part eagerly and store the bytes here.
+type mimePart struct {
+	Header textproto.MIMEHeader
+	Body   []byte // raw body bytes, before CTE decoding
+}
+
+// parseMIME decodes the raw MIME bytes produced by buildMIME and returns the
+// parsed top-level message plus the body bytes for single-part messages, or
+// the slice of parts for multipart/mixed.
+func parseMIME(t *testing.T, raw []byte) (*mail.Message, string, []byte, []mimePart) {
+	t.Helper()
+	m, err := mail.ReadMessage(strings.NewReader(string(raw)))
+	if err != nil {
+		t.Fatalf("mail.ReadMessage: %v", err)
+	}
+
+	ct := m.Header.Get("Content-Type")
+	mt, params, err := mime.ParseMediaType(ct)
+	if err != nil {
+		t.Fatalf("ParseMediaType(%q): %v", ct, err)
+	}
+
+	if !strings.HasPrefix(mt, "multipart/") {
+		body, err := io.ReadAll(m.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if cte := m.Header.Get("Content-Transfer-Encoding"); strings.EqualFold(cte, "base64") {
+			compact := strings.ReplaceAll(strings.ReplaceAll(string(body), "\r\n", ""), "\n", "")
+			decoded, err := base64.StdEncoding.DecodeString(compact)
+			if err != nil {
+				t.Fatalf("decode body base64: %v", err)
+			}
+			body = decoded
+		}
+		return m, mt, body, nil
+	}
+
+	r := multipart.NewReader(m.Body, params["boundary"])
+	var parts []mimePart
+	for {
+		p, err := r.NextPart()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("NextPart: %v", err)
+		}
+		body, err := io.ReadAll(p)
+		if err != nil {
+			t.Fatalf("read part body: %v", err)
+		}
+		parts = append(parts, mimePart{Header: p.Header, Body: body})
+	}
+	return m, mt, nil, parts
+}
+
+func decodePart(t *testing.T, p mimePart) []byte {
+	t.Helper()
+	if cte := p.Header.Get("Content-Transfer-Encoding"); strings.EqualFold(cte, "base64") {
+		compact := strings.ReplaceAll(strings.ReplaceAll(string(p.Body), "\r\n", ""), "\n", "")
+		decoded, err := base64.StdEncoding.DecodeString(compact)
+		if err != nil {
+			t.Fatalf("decode part base64: %v", err)
+		}
+		return decoded
+	}
+	return p.Body
+}
+
+func TestBuildMIME_PlainText(t *testing.T) {
+	t.Parallel()
+	msg := DraftMessage{
+		To:       []string{"alice@example.com"},
+		Subject:  "Hi",
+		Body:     []byte("hello world"),
+		BodyKind: DraftBodyPlainText,
+	}
+	raw, err := buildMIME(msg)
+	if err != nil {
+		t.Fatalf("buildMIME: %v", err)
+	}
+	if !strings.Contains(string(raw), "MIME-Version: 1.0\r\n") {
+		t.Errorf("missing MIME-Version header")
+	}
+	if hasBareLF(string(raw)) {
+		t.Errorf("output contains bare LF (must be CRLF)")
+	}
+
+	m, mt, body, parts := parseMIME(t, raw)
+	if got := m.Header.Get("To"); got != "<alice@example.com>" {
+		t.Errorf("To = %q, want %q", got, "<alice@example.com>")
+	}
+	if got := m.Header.Get("Subject"); got != "Hi" {
+		t.Errorf("Subject = %q, want %q", got, "Hi")
+	}
+	if mt != "text/plain" {
+		t.Errorf("Content-Type media = %q, want text/plain", mt)
+	}
+	if parts != nil {
+		t.Errorf("expected single-part, got multipart with %d parts", len(parts))
+	}
+	if string(body) != "hello world" {
+		t.Errorf("body = %q, want %q", string(body), "hello world")
+	}
+}
+
+func TestBuildMIME_HTML(t *testing.T) {
+	t.Parallel()
+	msg := DraftMessage{
+		To:       []string{"alice@example.com"},
+		Subject:  "Hi",
+		Body:     []byte("<p>hello</p>"),
+		BodyKind: DraftBodyHTML,
+	}
+	raw, err := buildMIME(msg)
+	if err != nil {
+		t.Fatalf("buildMIME: %v", err)
+	}
+	_, mt, body, _ := parseMIME(t, raw)
+	if mt != "text/html" {
+		t.Errorf("Content-Type media = %q, want text/html", mt)
+	}
+	if string(body) != "<p>hello</p>" {
+		t.Errorf("body = %q, want %q", string(body), "<p>hello</p>")
+	}
+}
+
+func TestBuildMIME_MultipleRecipients(t *testing.T) {
+	t.Parallel()
+	msg := DraftMessage{
+		To:       []string{"a@x.com", "b@x.com"},
+		Cc:       []string{"c@x.com"},
+		Bcc:      []string{"d@x.com"},
+		Subject:  "Hi",
+		Body:     []byte("text"),
+		BodyKind: DraftBodyPlainText,
+	}
+	raw, err := buildMIME(msg)
+	if err != nil {
+		t.Fatalf("buildMIME: %v", err)
+	}
+	m, _, _, _ := parseMIME(t, raw)
+	to, err := mail.ParseAddressList(m.Header.Get("To"))
+	if err != nil || len(to) != 2 {
+		t.Errorf("To parse: err=%v len=%d", err, len(to))
+	}
+	cc, err := mail.ParseAddressList(m.Header.Get("Cc"))
+	if err != nil || len(cc) != 1 {
+		t.Errorf("Cc parse: err=%v len=%d", err, len(cc))
+	}
+	bcc, err := mail.ParseAddressList(m.Header.Get("Bcc"))
+	if err != nil || len(bcc) != 1 {
+		t.Errorf("Bcc parse: err=%v len=%d", err, len(bcc))
+	}
+}
+
+func TestBuildMIME_From(t *testing.T) {
+	t.Parallel()
+	msg := DraftMessage{
+		From:     "work@me.com",
+		To:       []string{"a@x.com"},
+		Subject:  "Hi",
+		Body:     []byte("text"),
+		BodyKind: DraftBodyPlainText,
+	}
+	raw, err := buildMIME(msg)
+	if err != nil {
+		t.Fatalf("buildMIME: %v", err)
+	}
+	m, _, _, _ := parseMIME(t, raw)
+	if got := m.Header.Get("From"); got != "<work@me.com>" {
+		t.Errorf("From = %q, want %q", got, "<work@me.com>")
+	}
+}
+
+func TestBuildMIME_NonASCIISubject(t *testing.T) {
+	t.Parallel()
+	want := "Café meeting — Q4 ☕"
+	msg := DraftMessage{
+		To:       []string{"a@x.com"},
+		Subject:  want,
+		Body:     []byte("text"),
+		BodyKind: DraftBodyPlainText,
+	}
+	raw, err := buildMIME(msg)
+	if err != nil {
+		t.Fatalf("buildMIME: %v", err)
+	}
+	m, _, _, _ := parseMIME(t, raw)
+	dec := new(mime.WordDecoder)
+	got, err := dec.DecodeHeader(m.Header.Get("Subject"))
+	if err != nil {
+		t.Fatalf("DecodeHeader: %v", err)
+	}
+	if got != want {
+		t.Errorf("Subject = %q, want %q", got, want)
+	}
+}
+
+func TestBuildMIME_SingleAttachment(t *testing.T) {
+	t.Parallel()
+	msg := DraftMessage{
+		To:       []string{"a@x.com"},
+		Subject:  "Report",
+		Body:     []byte("see attached"),
+		BodyKind: DraftBodyPlainText,
+		Attachments: []DraftAttachment{
+			{Filename: "report.pdf", MimeType: "application/pdf", Data: []byte("%PDF-1.4 fake")},
+		},
+	}
+	raw, err := buildMIME(msg)
+	if err != nil {
+		t.Fatalf("buildMIME: %v", err)
+	}
+	_, mt, body, parts := parseMIME(t, raw)
+	if mt != "multipart/mixed" {
+		t.Errorf("media = %q, want multipart/mixed", mt)
+	}
+	if body != nil {
+		t.Errorf("expected nil top-level body for multipart, got %d bytes", len(body))
+	}
+	if len(parts) != 2 {
+		t.Fatalf("parts = %d, want 2", len(parts))
+	}
+	if got := string(decodePart(t, parts[0])); got != "see attached" {
+		t.Errorf("body part = %q, want %q", got, "see attached")
+	}
+	if got := string(decodePart(t, parts[1])); got != "%PDF-1.4 fake" {
+		t.Errorf("attachment bytes = %q", got)
+	}
+	cd := parts[1].Header.Get("Content-Disposition")
+	_, params, err := mime.ParseMediaType(cd)
+	if err != nil {
+		t.Fatalf("parse CD: %v", err)
+	}
+	if params["filename"] != "report.pdf" {
+		t.Errorf("filename = %q, want report.pdf", params["filename"])
+	}
+}
+
+func TestBuildMIME_MultipleAttachments_MixedTypes(t *testing.T) {
+	t.Parallel()
+	msg := DraftMessage{
+		To:       []string{"a@x.com"},
+		Subject:  "Bundle",
+		Body:     []byte("two files"),
+		BodyKind: DraftBodyPlainText,
+		Attachments: []DraftAttachment{
+			{Filename: "report.pdf", MimeType: "application/pdf", Data: []byte("PDF bytes")},
+			{Filename: "data.csv", MimeType: "text/csv; charset=utf-8", Data: []byte("a,b,c\n1,2,3")},
+		},
+	}
+	raw, err := buildMIME(msg)
+	if err != nil {
+		t.Fatalf("buildMIME: %v", err)
+	}
+	_, _, _, parts := parseMIME(t, raw)
+	if len(parts) != 3 {
+		t.Fatalf("parts = %d, want 3", len(parts))
+	}
+	if got := string(decodePart(t, parts[1])); got != "PDF bytes" {
+		t.Errorf("pdf bytes = %q", got)
+	}
+	if got := string(decodePart(t, parts[2])); got != "a,b,c\n1,2,3" {
+		t.Errorf("csv bytes = %q", got)
+	}
+	mt, params, err := mime.ParseMediaType(parts[2].Header.Get("Content-Type"))
+	if err != nil {
+		t.Fatalf("parse CSV CT: %v", err)
+	}
+	if mt != "text/csv" || params["charset"] != "utf-8" || params["name"] != "data.csv" {
+		t.Errorf("csv content-type wrong: mt=%q params=%v", mt, params)
+	}
+}
+
+func TestBuildMIME_TextPlainCharset(t *testing.T) {
+	t.Parallel()
+	msg := DraftMessage{
+		To:       []string{"a@x.com"},
+		Subject:  "Plain",
+		Body:     []byte("body"),
+		BodyKind: DraftBodyPlainText,
+		Attachments: []DraftAttachment{
+			{Filename: "notes.txt", MimeType: "text/plain; charset=utf-8", Data: []byte("plain notes")},
+		},
+	}
+	raw, err := buildMIME(msg)
+	if err != nil {
+		t.Fatalf("buildMIME: %v", err)
+	}
+	_, _, _, parts := parseMIME(t, raw)
+	if len(parts) != 2 {
+		t.Fatalf("parts = %d, want 2", len(parts))
+	}
+	mt, params, err := mime.ParseMediaType(parts[1].Header.Get("Content-Type"))
+	if err != nil {
+		t.Fatalf("parse CT: %v", err)
+	}
+	if mt != "text/plain" || params["charset"] != "utf-8" || params["name"] != "notes.txt" {
+		t.Errorf("txt content-type wrong: mt=%q params=%v", mt, params)
+	}
+}
+
+func TestBuildMIME_NonASCIIFilename(t *testing.T) {
+	t.Parallel()
+	msg := DraftMessage{
+		To:       []string{"a@x.com"},
+		Subject:  "i18n",
+		Body:     []byte("body"),
+		BodyKind: DraftBodyPlainText,
+		Attachments: []DraftAttachment{
+			{Filename: "résumé.pdf", MimeType: "application/pdf", Data: []byte("PDF")},
+		},
+	}
+	raw, err := buildMIME(msg)
+	if err != nil {
+		t.Fatalf("buildMIME: %v", err)
+	}
+	_, _, _, parts := parseMIME(t, raw)
+	_, params, err := mime.ParseMediaType(parts[1].Header.Get("Content-Disposition"))
+	if err != nil {
+		t.Fatalf("parse CD: %v", err)
+	}
+	if params["filename"] != "résumé.pdf" {
+		t.Errorf("filename = %q, want résumé.pdf", params["filename"])
+	}
+}
+
+func TestBuildMIME_BasenameOnly_NoLocalPathLeak(t *testing.T) {
+	t.Parallel()
+	msg := DraftMessage{
+		To:       []string{"a@x.com"},
+		Subject:  "Defensive",
+		Body:     []byte("body"),
+		BodyKind: DraftBodyPlainText,
+		Attachments: []DraftAttachment{
+			{Filename: "/tmp/secret/foo.pdf", MimeType: "application/pdf", Data: []byte("PDF")},
+		},
+	}
+	raw, err := buildMIME(msg)
+	if err != nil {
+		t.Fatalf("buildMIME: %v", err)
+	}
+	if strings.Contains(string(raw), "/tmp/secret") {
+		t.Errorf("raw MIME leaked path: contains /tmp/secret")
+	}
+	_, _, _, parts := parseMIME(t, raw)
+	_, params, err := mime.ParseMediaType(parts[1].Header.Get("Content-Disposition"))
+	if err != nil {
+		t.Fatalf("parse CD: %v", err)
+	}
+	if params["filename"] != "foo.pdf" {
+		t.Errorf("filename = %q, want foo.pdf (basename)", params["filename"])
+	}
+}
+
+func TestBuildMIME_Base64PayloadLineLength(t *testing.T) {
+	t.Parallel()
+	big := make([]byte, 4096)
+	for i := range big {
+		big[i] = 'x'
+	}
+	msg := DraftMessage{
+		To:       []string{"a@x.com"},
+		Subject:  "Big",
+		Body:     big,
+		BodyKind: DraftBodyPlainText,
+	}
+	raw, err := buildMIME(msg)
+	if err != nil {
+		t.Fatalf("buildMIME: %v", err)
+	}
+	parts := strings.SplitN(string(raw), "\r\n\r\n", 2)
+	if len(parts) != 2 {
+		t.Fatalf("expected header/body split, got %d parts", len(parts))
+	}
+	for _, line := range strings.Split(parts[1], "\r\n") {
+		if len(line) > 76 {
+			t.Errorf("base64 line exceeds 76 chars: len=%d", len(line))
+		}
+	}
+}
+
+func TestBuildMIME_RejectsHeaderInjection(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		mut  func(*DraftMessage)
+	}{
+		{"subject CRLF", func(m *DraftMessage) { m.Subject = "evil\r\nBcc: x@y.com" }},
+		{"subject LF", func(m *DraftMessage) { m.Subject = "evil\nBcc: x@y.com" }},
+		{"to CRLF", func(m *DraftMessage) { m.To = []string{"a@x.com\r\nBcc: evil@x.com"} }},
+		{"from CRLF", func(m *DraftMessage) { m.From = "a@x.com\r\nBcc: evil@x.com" }},
+		{"cc CRLF", func(m *DraftMessage) { m.Cc = []string{"a@x.com\r\nBcc: evil@x.com"} }},
+		{"bcc CRLF", func(m *DraftMessage) { m.Bcc = []string{"a@x.com\r\nBcc: evil@x.com"} }},
+		{"attachment filename LF", func(m *DraftMessage) {
+			m.Attachments = []DraftAttachment{{Filename: "a\nb.pdf", MimeType: "application/pdf", Data: []byte("x")}}
+		}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			msg := DraftMessage{
+				To:       []string{"a@x.com"},
+				Subject:  "ok",
+				Body:     []byte("body"),
+				BodyKind: DraftBodyPlainText,
+			}
+			tc.mut(&msg)
+			if _, err := buildMIME(msg); err == nil {
+				t.Errorf("expected error for injection case, got nil")
+			}
+		})
+	}
+}
+
+// --- API wiring tests ---
+
+func TestCreateDraft_APIWiring_SinglePart(t *testing.T) {
+	t.Parallel()
+	msg := DraftMessage{
+		To:       []string{"a@x.com"},
+		Subject:  "Hi",
+		Body:     []byte("hello"),
+		BodyKind: DraftBodyPlainText,
+	}
+	wantRaw, err := buildMIME(msg)
+	if err != nil {
+		t.Fatalf("buildMIME: %v", err)
+	}
+
+	var gotMethod, gotPath, gotRawDecoded string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		var body struct {
+			Message struct {
+				Raw string `json:"raw"`
+			} `json:"message"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		decoded, derr := base64.URLEncoding.DecodeString(body.Message.Raw)
+		if derr != nil {
+			decoded, derr = base64.RawURLEncoding.DecodeString(body.Message.Raw)
+		}
+		if derr != nil {
+			t.Errorf("decode raw: %v", derr)
+		}
+		gotRawDecoded = string(decoded)
+		resp := &gmailapi.Draft{
+			Id: "d-123",
+			Message: &gmailapi.Message{
+				Id:       "m-456",
+				ThreadId: "t-789",
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	svc, err := gmailapi.NewService(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	c := &Client{service: svc, userID: "me"}
+	result, err := c.CreateDraft(ctx, msg)
+	if err != nil {
+		t.Fatalf("CreateDraft: %v", err)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/gmail/v1/users/me/drafts" {
+		t.Errorf("path = %q, want /gmail/v1/users/me/drafts", gotPath)
+	}
+	if gotRawDecoded != string(wantRaw) {
+		t.Errorf("raw payload mismatch\ngot:  %q\nwant: %q", gotRawDecoded, string(wantRaw))
+	}
+	if result.ID != "d-123" || result.MessageID != "m-456" || result.ThreadID != "t-789" {
+		t.Errorf("result = %+v", result)
+	}
+}
+
+func TestCreateDraft_APIWiring_Multipart_Structural(t *testing.T) {
+	t.Parallel()
+	msg := DraftMessage{
+		To:       []string{"a@x.com"},
+		Subject:  "WithAtt",
+		Body:     []byte("body"),
+		BodyKind: DraftBodyPlainText,
+		Attachments: []DraftAttachment{
+			{Filename: "report.pdf", MimeType: "application/pdf", Data: []byte("PDFBYTES")},
+		},
+	}
+
+	var seenRaw []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Message struct {
+				Raw string `json:"raw"`
+			} `json:"message"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		decoded, derr := base64.URLEncoding.DecodeString(body.Message.Raw)
+		if derr != nil {
+			decoded, _ = base64.RawURLEncoding.DecodeString(body.Message.Raw)
+		}
+		seenRaw = decoded
+		resp := &gmailapi.Draft{Id: "d-1", Message: &gmailapi.Message{Id: "m-1"}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	svc, err := gmailapi.NewService(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	c := &Client{service: svc, userID: "me"}
+	if _, err := c.CreateDraft(ctx, msg); err != nil {
+		t.Fatalf("CreateDraft: %v", err)
+	}
+
+	_, mt, _, parts := parseMIME(t, seenRaw)
+	if mt != "multipart/mixed" {
+		t.Errorf("media = %q, want multipart/mixed", mt)
+	}
+	if len(parts) != 2 {
+		t.Fatalf("parts = %d, want 2", len(parts))
+	}
+	if got := string(decodePart(t, parts[1])); got != "PDFBYTES" {
+		t.Errorf("att bytes = %q", got)
+	}
+}
+
+func hasBareLF(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' && (i == 0 || s[i-1] != '\r') {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/gmail/drafts_test.go
+++ b/internal/gmail/drafts_test.go
@@ -569,6 +569,106 @@ func TestCreateDraft_APIWiring_Multipart_Structural(t *testing.T) {
 	}
 }
 
+func TestBuildMIME_RejectsEmptyTo(t *testing.T) {
+	t.Parallel()
+	msg := DraftMessage{
+		Subject:  "Hi",
+		Body:     []byte("body"),
+		BodyKind: DraftBodyPlainText,
+	}
+	if _, err := buildMIME(msg); err == nil {
+		t.Errorf("expected error for empty To, got nil")
+	}
+}
+
+func TestBuildMIME_EmptyBody(t *testing.T) {
+	t.Parallel()
+	msg := DraftMessage{
+		To:       []string{"a@x.com"},
+		Subject:  "Hi",
+		Body:     []byte{},
+		BodyKind: DraftBodyPlainText,
+	}
+	raw, err := buildMIME(msg)
+	if err != nil {
+		t.Fatalf("buildMIME: %v", err)
+	}
+	_, _, body, _ := parseMIME(t, raw)
+	if len(body) != 0 {
+		t.Errorf("decoded body = %q, want empty", body)
+	}
+}
+
+func TestBuildMIME_MultipartBase64LineLength(t *testing.T) {
+	t.Parallel()
+	big := make([]byte, 4096)
+	for i := range big {
+		big[i] = 'x'
+	}
+	msg := DraftMessage{
+		To:       []string{"a@x.com"},
+		Subject:  "Big",
+		Body:     big,
+		BodyKind: DraftBodyPlainText,
+		Attachments: []DraftAttachment{{
+			Filename: "blob.bin",
+			MimeType: "application/octet-stream",
+			Data:     big,
+		}},
+	}
+	raw, err := buildMIME(msg)
+	if err != nil {
+		t.Fatalf("buildMIME: %v", err)
+	}
+	_, _, _, parts := parseMIME(t, raw)
+	if len(parts) != 2 {
+		t.Fatalf("parts = %d, want 2", len(parts))
+	}
+	for i, p := range parts {
+		for _, line := range strings.Split(string(p.Body), "\r\n") {
+			if len(line) > 76 {
+				t.Errorf("part %d base64 line exceeds 76 chars: len=%d", i, len(line))
+			}
+		}
+	}
+}
+
+func TestBuildMIME_MultipartHTMLBody(t *testing.T) {
+	t.Parallel()
+	msg := DraftMessage{
+		To:       []string{"a@x.com"},
+		Subject:  "Hi",
+		Body:     []byte("<p>hello</p>"),
+		BodyKind: DraftBodyHTML,
+		Attachments: []DraftAttachment{{
+			Filename: "note.txt",
+			MimeType: "text/plain",
+			Data:     []byte("attached"),
+		}},
+	}
+	raw, err := buildMIME(msg)
+	if err != nil {
+		t.Fatalf("buildMIME: %v", err)
+	}
+	_, mt, _, parts := parseMIME(t, raw)
+	if mt != "multipart/mixed" {
+		t.Errorf("media = %q, want multipart/mixed", mt)
+	}
+	if len(parts) != 2 {
+		t.Fatalf("parts = %d, want 2", len(parts))
+	}
+	bodyCT, _, err := mime.ParseMediaType(parts[0].Header.Get("Content-Type"))
+	if err != nil {
+		t.Fatalf("parse body part Content-Type: %v", err)
+	}
+	if bodyCT != "text/html" {
+		t.Errorf("body part media = %q, want text/html", bodyCT)
+	}
+	if got := string(decodePart(t, parts[0])); got != "<p>hello</p>" {
+		t.Errorf("body decoded = %q", got)
+	}
+}
+
 func hasBareLF(s string) bool {
 	for i := 0; i < len(s); i++ {
 		if s[i] == '\n' && (i == 0 || s[i-1] != '\r') {


### PR DESCRIPTION
## Summary

Adds `gro mail draft` — composes a Gmail draft via `users.drafts.create`. Drafts land in the user's Drafts folder for human review; the CLI never calls `drafts.send`, preserving gro's non-destructive philosophy.

Body input is **markdown by default**, rendered to HTML via goldmark (table, strikethrough, task-list extensions). `--plain` and `--html` opt out of rendering. Body comes from `--body`, `--stdin`, or `--file`. Recipients are comma-separated address lists.

## Example usage

```bash
# Markdown rendered to HTML (default)
gro mail draft --to alice@example.com --subject "Hi" --body "**hello**"

# Body from file or stdin
gro mail draft --to a@x.com --subject "Report" --file report.md
echo "# Status" | gro mail draft --to a@x.com --subject "Update" --stdin

# Plain text or raw HTML
gro mail draft --to a@x.com --subject "Plain" --body "no md" --plain
gro mail draft --to a@x.com --subject "Raw" --body "<h1>Hi</h1>" --html

# Attachments + send-as alias
gro mail draft --from work@me.com --to a@x.com --subject "Hi" --body "see attached" --attach report.pdf
```

## MIME assembly

The gmail package owns MIME construction and acts as the security boundary:

- RFC 5322/2045 compliant: `MIME-Version: 1.0`, CRLF line endings, `Content-Transfer-Encoding: base64` with 76-column wrapping.
- Single-part for plain bodies, `multipart/mixed` for attachments.
- Subject is RFC 2047 encoded for non-ASCII; attachment filenames RFC 2231 encoded.
- **CR/LF header-injection guard** independent of command-layer validation.
- Attachment filenames are `filepath.Base`-stripped — local paths never leak.

## Coverage

- 21 MIME-builder + httptest API-wiring tests in `internal/gmail/drafts_test.go`
- 21 command-level tests in `internal/cmd/mail/draft_test.go` (flag presence, validation negatives including CR/LF injection, all success paths)
- 18 integration tests run against the live Gmail API — all green. See `integration-tests.md`.

## Scope discipline

Out of scope (intentionally): no `drafts.send`, `drafts.update`, `drafts.list`, `drafts.delete`; no reply threading; no `$EDITOR` fallback; no `--dry-run` (creating a draft is itself the safe preview).

Closes #112

## Test plan

- [x] All unit tests pass (`make test` — 1291 tests across 28 packages)
- [x] Architecture tests pass (`--json` on `draft`, `MailClient` interface satisfied, no forbidden API methods)
- [x] Lint clean for new code (`make lint` — only pre-existing `keychain` and `testutil` issues remain)
- [x] Build succeeds (`make build`)
- [x] Integration tests against live Gmail API — 18/18 green