### PR TITLE
feat(mail): reply-to-thread drafts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ gro is a **non-destructive** command-line interface for Google services written 
 **Module:** `github.com/open-cli-collective/google-readonly`
 
 ### Features
-- Gmail: Search, read, thread viewing, labels, attachments, archive, star, mark read/unread, label, categorize, draft (compose-only, never sent)
+- Gmail: Search, read, thread viewing, labels, attachments, archive, star, mark read/unread, label, categorize, draft (compose-only, never sent — supports reply-to-thread)
 - Google Calendar: List calendars, view events, today/week shortcuts
 - Google Contacts: List contacts, search, view details, list groups
 - Google Drive: List files, search, get details, download, tree view, shared drives

--- a/README.md
+++ b/README.md
@@ -288,9 +288,16 @@ gro mail draft --to a@x.com --subject "See attached" --body "..." --attach repor
 
 # From a send-as alias
 gro mail draft --from work@me.com --to a@x.com --subject "Hi" --body "..."
+
+# Reply to an existing message (preserves thread, adds In-Reply-To / References)
+gro mail draft --reply-to <message-id> --body "thanks, will review"
+gro mail draft --reply-to <message-id> --reply-all --body "looping everyone in"
+gro mail draft --reply-to <message-id> --subject "Re: customised" --body "..."
 ```
 
 Drafts always land in your Gmail Drafts folder for human review. The CLI never calls `drafts.send` — sending requires explicit action in Gmail.
+
+With `--reply-to`, `--to` and `--subject` are derived from the source message (To = original From; Subject = `Re: <original>`, no double prefix). Explicit `--to` / `--cc` / `--subject` flags override the derived values. `--reply-all` adds the original To and Cc as Cc on the reply, filtered to remove your own address (and any `--from` alias).
 
 ### Calendar Commands
 
@@ -733,11 +740,15 @@ Flags:
       --html              Send body as raw HTML (no markdown rendering)
   -a, --attach strings    File path to attach (repeat for multiple)
   -j, --json              Output result as JSON
+      --reply-to string   Source Gmail message ID to reply to (derives To/Subject/threading)
+      --reply-all         Include the source To/Cc as Cc on the reply (requires --reply-to)
 ```
 
 `--body`, `--stdin`, and `--file` are mutually exclusive (exactly one required). `--plain` and `--html` are mutually exclusive.
 
 Display names in `--to`/`--cc`/`--bcc` (e.g., `Alice <alice@example.com>`) are stripped; only the email address is sent. Edit the draft in Gmail to set display names.
+
+With `--reply-to`, the draft is threaded onto the source conversation (`In-Reply-To` and `References` headers are set; `Draft.Message.ThreadId` is set to the source thread). `--to` and `--subject` are derived from the source (To = original From; Subject = `Re: <original>` with no double prefix). Explicit `--to`/`--cc`/`--subject` flags override the derived values. `--reply-all` populates Cc with the source To+Cc minus your authenticated account and any `--from` alias.
 
 ### gro calendar list
 

--- a/integration-tests.md
+++ b/integration-tests.md
@@ -590,7 +590,7 @@ DRAFT_MSG_ID=$(./bin/gro mail draft --reply-to "$SRC_ID" --body "T21 reply" --pl
 | T22 | Reply-all | `./bin/gro mail draft --reply-to "$SRC_ID" --reply-all --body "T22 all" --plain --json` | Exit 0. Cc on the draft contains the source To+Cc minus `$ME`. Read-back JSON same threading checks as T21. |
 | T23 | Explicit subject override | `./bin/gro mail draft --reply-to "$SRC_ID" --subject "T23 custom" --body "x" --plain --json` | Exit 0. Draft subject is `T23 custom` (no `Re:` prefix). Threading headers still set. |
 | T24 | Explicit Cc override | `./bin/gro mail draft --reply-to "$SRC_ID" --cc "$ME" --body "T24 cc" --plain --json` | Exit 0. Draft Cc is exactly `$ME` (replaces, not merges with, derived Cc). |
-| T25 | No double Re: prefix | Reply to a message whose subject already starts with `Re:`. Read-back subject must be unchanged (no `Re: Re: `). | Exit 0. |
+| T25 | No double Re: prefix | First find a source message whose subject already starts with `Re:`: `RE_SRC=$(./bin/gro mail search "subject:Re:" --json \| jq -r '.[0].id')`. Then: `./bin/gro mail draft --reply-to "$RE_SRC" --body "T25" --plain --json` | Exit 0. Read-back subject is unchanged (no `Re: Re: ` doubling). |
 | T26 | Reply-all without reply-to | `./bin/gro mail draft --to "$ME" --subject "x" --body "y" --reply-all; echo "exit=$?"` | Non-zero exit. Error mentions `--reply-all requires --reply-to`. |
 
 ### Cleanup

--- a/integration-tests.md
+++ b/integration-tests.md
@@ -565,6 +565,34 @@ Skip if no Gmail send-as alias is configured for the test user.
 | T19 | Valid alias | `./bin/gro mail draft --from <configured-alias> --to "$ME" --subject "T19 alias" --body "x" --plain` | Exit 0. Gmail Drafts shows the alias in From line. |
 | T20 | Unconfigured alias | `./bin/gro mail draft --from "not-my-alias@example.com" --to "$ME" --subject "T20 bad alias" --body "x" --plain; echo "exit=$?"` | Non-zero exit. API error surfaced verbatim from `creating draft: ...`. |
 
+### Reply-to-thread (`--reply-to` / `--reply-all`)
+
+**Setup additions:**
+```bash
+# Pick any existing message in your inbox as the source. The query can be
+# anything that resolves to a single recent message.
+SRC_ID=$(./bin/gro mail search "in:inbox" --json | jq -r '.[0].id')
+SRC_RFC=$(./bin/gro mail read "$SRC_ID" --json | jq -r '.rfcMessageId')
+SRC_THREAD=$(./bin/gro mail read "$SRC_ID" --json | jq -r '.threadId')
+echo "source: $SRC_ID / thread: $SRC_THREAD / rfc-id: $SRC_RFC"
+```
+
+For each happy-path scenario, capture the created draft's message ID and read it back to verify the wire-format headers:
+
+```bash
+DRAFT_MSG_ID=$(./bin/gro mail draft --reply-to "$SRC_ID" --body "T21 reply" --plain --json | jq -r '.messageId')
+./bin/gro mail read "$DRAFT_MSG_ID" --json | jq '{inReplyTo, references, threadId}'
+```
+
+| # | Test Case | Command | Expected Result |
+|---|-----------|---------|-----------------|
+| T21 | Simple reply | `./bin/gro mail draft --reply-to "$SRC_ID" --body "T21 reply" --plain --json` | Exit 0. Read-back JSON shows `threadId == $SRC_THREAD`, `inReplyTo == $SRC_RFC`, `references` ends with `$SRC_RFC`, subject prefixed `Re: `. Gmail UI shows the draft grouped under the original conversation. |
+| T22 | Reply-all | `./bin/gro mail draft --reply-to "$SRC_ID" --reply-all --body "T22 all" --plain --json` | Exit 0. Cc on the draft contains the source To+Cc minus `$ME`. Read-back JSON same threading checks as T21. |
+| T23 | Explicit subject override | `./bin/gro mail draft --reply-to "$SRC_ID" --subject "T23 custom" --body "x" --plain --json` | Exit 0. Draft subject is `T23 custom` (no `Re:` prefix). Threading headers still set. |
+| T24 | Explicit Cc override | `./bin/gro mail draft --reply-to "$SRC_ID" --cc "$ME" --body "T24 cc" --plain --json` | Exit 0. Draft Cc is exactly `$ME` (replaces, not merges with, derived Cc). |
+| T25 | No double Re: prefix | Reply to a message whose subject already starts with `Re:`. Read-back subject must be unchanged (no `Re: Re: `). | Exit 0. |
+| T26 | Reply-all without reply-to | `./bin/gro mail draft --to "$ME" --subject "x" --body "y" --reply-all; echo "exit=$?"` | Non-zero exit. Error mentions `--reply-all requires --reply-to`. |
+
 ### Cleanup
 
 ```bash

--- a/internal/cmd/mail/draft.go
+++ b/internal/cmd/mail/draft.go
@@ -31,6 +31,8 @@ func newDraftCommand() *cobra.Command {
 		htmlMode bool
 		attach   []string
 		jsonOut  bool
+		replyTo  string
+		replyAll bool
 	)
 
 	cmd := &cobra.Command{
@@ -50,33 +52,41 @@ Examples:
   gro mail draft --to "a@x.com, b@x.com" --subject "Sync" --file notes.md
   echo "# Hello" | gro mail draft --to a@x.com --subject "Hi" --stdin
   gro mail draft --to a@x.com --subject "Plain" --body "no md" --plain
-  gro mail draft --to a@x.com --subject "Report" --body "see attached" --attach report.pdf`,
+  gro mail draft --to a@x.com --subject "Report" --body "see attached" --attach report.pdf
+  gro mail draft --reply-to <message-id> --body "thanks, will review"
+  gro mail draft --reply-to <message-id> --reply-all --body "..."`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			// 1. Required-flag checks.
-			if !cmd.Flags().Changed("to") {
-				return fmt.Errorf("--to is required")
+			isReply := cmd.Flags().Changed("reply-to")
+
+			// 1. Required-flag checks. In reply mode, --to and --subject are
+			//    derived from the source message and only required if not derivable.
+			if replyAll && !isReply {
+				return fmt.Errorf("--reply-all requires --reply-to")
 			}
-			if !cmd.Flags().Changed("subject") {
-				return fmt.Errorf("--subject is required (use --subject \"\" for empty subject)")
+			if !isReply {
+				if !cmd.Flags().Changed("to") {
+					return fmt.Errorf("--to is required")
+				}
+				if !cmd.Flags().Changed("subject") {
+					return fmt.Errorf("--subject is required (use --subject \"\" for empty subject)")
+				}
 			}
 
 			// 2. Header-injection guard on raw flag values.
 			for _, f := range []struct{ name, val string }{
 				{"--to", to}, {"--cc", cc}, {"--bcc", bcc},
 				{"--from", fromAddr}, {"--subject", subject},
+				{"--reply-to", replyTo},
 			} {
 				if strings.ContainsAny(f.val, "\r\n") {
 					return fmt.Errorf("%s contains illegal CR or LF", f.name)
 				}
 			}
 
-			// 3. Address parsing.
+			// 3. Address parsing on user-supplied flags.
 			toAddrs, err := parseAddressList("--to", to)
 			if err != nil {
 				return err
-			}
-			if len(toAddrs) == 0 {
-				return fmt.Errorf("--to must contain at least one address")
 			}
 			ccAddrs, err := parseAddressList("--cc", cc)
 			if err != nil {
@@ -169,11 +179,58 @@ Examples:
 				})
 			}
 
-			// 9. Call client.
+			// 9. Build client; in reply mode, fetch source + (optionally) profile and derive defaults.
 			client, err := newGmailClient(cmd.Context())
 			if err != nil {
 				return fmt.Errorf("creating Gmail client: %w", err)
 			}
+
+			var (
+				threadID   string
+				inReplyTo  string
+				references []string
+			)
+			if isReply {
+				src, err := client.GetMessage(cmd.Context(), replyTo, false)
+				if err != nil {
+					return fmt.Errorf("fetching reply source %s: %w", replyTo, err)
+				}
+				selfSet := map[string]bool{}
+				if replyAll {
+					profile, err := client.GetProfile(cmd.Context())
+					if err != nil {
+						return fmt.Errorf("fetching profile for --reply-all: %w", err)
+					}
+					if profile != nil && profile.EmailAddress != "" {
+						selfSet[strings.ToLower(profile.EmailAddress)] = true
+					}
+					if fromAddr != "" {
+						selfSet[strings.ToLower(fromAddr)] = true
+					}
+				}
+				derived, err := deriveReplyDefaults(src, replyAll, selfSet)
+				if err != nil {
+					return err
+				}
+				threadID = derived.ThreadID
+				inReplyTo = derived.InReplyTo
+				references = derived.References
+				if !cmd.Flags().Changed("to") {
+					toAddrs = derived.To
+				}
+				if !cmd.Flags().Changed("cc") {
+					ccAddrs = derived.Cc
+				}
+				if !cmd.Flags().Changed("subject") {
+					subject = derived.Subject
+				}
+			}
+
+			// 9b. Post-derivation resolved-recipient validation.
+			if len(toAddrs) == 0 {
+				return fmt.Errorf("--to must contain at least one address")
+			}
+
 			result, err := client.CreateDraft(cmd.Context(), gmailapi.DraftMessage{
 				From:        fromAddr,
 				To:          toAddrs,
@@ -183,6 +240,9 @@ Examples:
 				Body:        outBody,
 				BodyKind:    kind,
 				Attachments: attachments,
+				ThreadID:    threadID,
+				InReplyTo:   inReplyTo,
+				References:  references,
 			})
 			if err != nil {
 				return fmt.Errorf("creating draft: %w", err)
@@ -226,8 +286,113 @@ Examples:
 	cmd.Flags().BoolVar(&htmlMode, "html", false, "Treat body as raw HTML (no markdown rendering)")
 	cmd.Flags().StringArrayVarP(&attach, "attach", "a", nil, "File path to attach (repeat for multiple)")
 	cmd.Flags().BoolVarP(&jsonOut, "json", "j", false, "Output result as JSON")
+	cmd.Flags().StringVar(&replyTo, "reply-to", "", "Source Gmail message ID to reply to (derives To/Subject/threading)")
+	cmd.Flags().BoolVar(&replyAll, "reply-all", false, "Include the source To/Cc as Cc on the reply (requires --reply-to)")
 
 	return cmd
+}
+
+// replyDerivation is the result of analysing the source message for reply mode.
+type replyDerivation struct {
+	ThreadID   string
+	InReplyTo  string
+	References []string
+	To         []string
+	Cc         []string
+	Subject    string
+}
+
+func deriveReplyDefaults(src *gmailapi.Message, replyAll bool, selfSet map[string]bool) (replyDerivation, error) {
+	if src == nil {
+		return replyDerivation{}, fmt.Errorf("source message is nil")
+	}
+	if strings.TrimSpace(src.From) == "" {
+		return replyDerivation{}, fmt.Errorf("source message %s has no From header", src.ID)
+	}
+	if strings.TrimSpace(src.RFCMessageID) == "" {
+		return replyDerivation{}, fmt.Errorf("source message %s has no Message-Id header", src.ID)
+	}
+	fromAddr, err := mail.ParseAddress(src.From)
+	if err != nil {
+		return replyDerivation{}, fmt.Errorf("parsing source From header %q: %w", src.From, err)
+	}
+	out := replyDerivation{
+		ThreadID:   src.ThreadID,
+		InReplyTo:  src.RFCMessageID,
+		References: buildReferences(src.References, src.RFCMessageID),
+		To:         []string{fromAddr.Address},
+		Subject:    addRePrefix(src.Subject),
+	}
+	if replyAll {
+		ccAddrs, err := splitAddressHeaders(src.To, src.Cc)
+		if err != nil {
+			return replyDerivation{}, fmt.Errorf("parsing source To/Cc headers: %w", err)
+		}
+		out.Cc = filterSelf(ccAddrs, selfSet)
+	}
+	return out, nil
+}
+
+// buildReferences appends the source Message-Id to the existing References
+// chain, splitting the raw header on whitespace (RFC 5322 §3.6.4). Returns
+// the new chain with empty tokens dropped.
+func buildReferences(rawRefs, msgID string) []string {
+	out := make([]string, 0)
+	for _, f := range strings.Fields(rawRefs) {
+		if f != "" {
+			out = append(out, f)
+		}
+	}
+	out = append(out, msgID)
+	return out
+}
+
+// splitAddressHeaders parses each non-empty raw header value via
+// mail.ParseAddressList and concatenates the bare addresses. Returns an
+// error on the first malformed header rather than silently dropping content.
+func splitAddressHeaders(values ...string) ([]string, error) {
+	var out []string
+	for _, v := range values {
+		if strings.TrimSpace(v) == "" {
+			continue
+		}
+		addrs, err := mail.ParseAddressList(v)
+		if err != nil {
+			return nil, fmt.Errorf("%q: %w", v, err)
+		}
+		for _, a := range addrs {
+			out = append(out, a.Address)
+		}
+	}
+	return out, nil
+}
+
+// filterSelf removes addresses present in selfSet (case-insensitive lookup)
+// and de-duplicates while preserving first-seen order.
+func filterSelf(addrs []string, selfSet map[string]bool) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(addrs))
+	for _, a := range addrs {
+		k := strings.ToLower(a)
+		if selfSet[k] || seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, a)
+	}
+	return out
+}
+
+// addRePrefix prefixes "Re: " unless the subject already begins with a
+// case-insensitive "re:" (followed by space or end-of-string). Locale
+// variants (Aw, Sv, etc.) are intentionally not recognised — Gmail itself
+// doesn't normalise them.
+func addRePrefix(subject string) string {
+	trimmed := strings.TrimLeft(subject, " \t")
+	if len(trimmed) >= 3 && strings.EqualFold(trimmed[:3], "re:") {
+		return subject
+	}
+	return "Re: " + subject
 }
 
 // parseAddressList parses a comma-separated address list. An empty input is OK

--- a/internal/cmd/mail/draft.go
+++ b/internal/cmd/mail/draft.go
@@ -56,7 +56,10 @@ Examples:
   gro mail draft --reply-to <message-id> --body "thanks, will review"
   gro mail draft --reply-to <message-id> --reply-all --body "..."`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			isReply := cmd.Flags().Changed("reply-to")
+			// Reply mode is opt-in via a non-empty --reply-to. Empty string
+			// (e.g. --reply-to "") is treated the same as omitting the flag,
+			// since an empty message ID can't be fetched.
+			isReply := strings.TrimSpace(replyTo) != ""
 
 			// 1. Required-flag checks. In reply mode, --to and --subject are
 			//    derived from the source message and only required if not derivable.
@@ -106,6 +109,12 @@ Examples:
 				// reaching the MIME builder, matching how --to/--cc/--bcc
 				// are handled.
 				fromAddr = parsed.Address
+			}
+
+			// 3b. Non-reply mode: require at least one --to address now (no I/O yet).
+			//     Reply mode defers this check until after source derivation.
+			if !isReply && len(toAddrs) == 0 {
+				return fmt.Errorf("--to must contain at least one address")
 			}
 
 			// 4. Body source: exactly one of --body, --stdin, --file.
@@ -195,8 +204,13 @@ Examples:
 				if err != nil {
 					return fmt.Errorf("fetching reply source %s: %w", replyTo, err)
 				}
+				needs := replyNeeds{
+					To:      !cmd.Flags().Changed("to"),
+					Cc:      replyAll && !cmd.Flags().Changed("cc"),
+					Subject: !cmd.Flags().Changed("subject"),
+				}
 				selfSet := map[string]bool{}
-				if replyAll {
+				if needs.Cc {
 					profile, err := client.GetProfile(cmd.Context())
 					if err != nil {
 						return fmt.Errorf("fetching profile for --reply-all: %w", err)
@@ -208,20 +222,20 @@ Examples:
 						selfSet[strings.ToLower(fromAddr)] = true
 					}
 				}
-				derived, err := deriveReplyDefaults(src, replyAll, selfSet)
+				derived, err := deriveReplyDefaults(src, needs, selfSet)
 				if err != nil {
 					return err
 				}
 				threadID = derived.ThreadID
 				inReplyTo = derived.InReplyTo
 				references = derived.References
-				if !cmd.Flags().Changed("to") {
+				if needs.To {
 					toAddrs = derived.To
 				}
-				if !cmd.Flags().Changed("cc") {
+				if needs.Cc {
 					ccAddrs = derived.Cc
 				}
-				if !cmd.Flags().Changed("subject") {
+				if needs.Subject {
 					subject = derived.Subject
 				}
 			}
@@ -302,28 +316,44 @@ type replyDerivation struct {
 	Subject    string
 }
 
-func deriveReplyDefaults(src *gmailapi.Message, replyAll bool, selfSet map[string]bool) (replyDerivation, error) {
+// replyNeeds tells deriveReplyDefaults which slots the caller will actually
+// consume. Source headers are only parsed for needed slots, so an explicit
+// --to/--cc/--subject override is unaffected by a malformed/missing source
+// header for that slot.
+type replyNeeds struct {
+	To      bool
+	Cc      bool
+	Subject bool
+}
+
+func deriveReplyDefaults(src *gmailapi.Message, needs replyNeeds, selfSet map[string]bool) (replyDerivation, error) {
 	if src == nil {
 		return replyDerivation{}, fmt.Errorf("source message is nil")
 	}
-	if strings.TrimSpace(src.From) == "" {
-		return replyDerivation{}, fmt.Errorf("source message %s has no From header", src.ID)
-	}
+	// Message-Id is always required: it feeds In-Reply-To and References,
+	// which are emitted regardless of override flags.
 	if strings.TrimSpace(src.RFCMessageID) == "" {
 		return replyDerivation{}, fmt.Errorf("source message %s has no Message-Id header", src.ID)
-	}
-	fromAddr, err := mail.ParseAddress(src.From)
-	if err != nil {
-		return replyDerivation{}, fmt.Errorf("parsing source From header %q: %w", src.From, err)
 	}
 	out := replyDerivation{
 		ThreadID:   src.ThreadID,
 		InReplyTo:  src.RFCMessageID,
 		References: buildReferences(src.References, src.RFCMessageID),
-		To:         []string{fromAddr.Address},
-		Subject:    addRePrefix(src.Subject),
 	}
-	if replyAll {
+	if needs.To {
+		if strings.TrimSpace(src.From) == "" {
+			return replyDerivation{}, fmt.Errorf("source message %s has no From header", src.ID)
+		}
+		fromAddr, err := mail.ParseAddress(src.From)
+		if err != nil {
+			return replyDerivation{}, fmt.Errorf("parsing source From header %q: %w", src.From, err)
+		}
+		out.To = []string{fromAddr.Address}
+	}
+	if needs.Subject {
+		out.Subject = addRePrefix(src.Subject)
+	}
+	if needs.Cc {
 		ccAddrs, err := splitAddressHeaders(src.To, src.Cc)
 		if err != nil {
 			return replyDerivation{}, fmt.Errorf("parsing source To/Cc headers: %w", err)

--- a/internal/cmd/mail/draft.go
+++ b/internal/cmd/mail/draft.go
@@ -56,10 +56,13 @@ Examples:
   gro mail draft --reply-to <message-id> --body "thanks, will review"
   gro mail draft --reply-to <message-id> --reply-all --body "..."`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			// Reply mode is opt-in via a non-empty --reply-to. Empty string
-			// (e.g. --reply-to "") is treated the same as omitting the flag,
-			// since an empty message ID can't be fetched.
-			isReply := strings.TrimSpace(replyTo) != ""
+			// --reply-to with an empty value is a user error (often a shell
+			// variable that didn't expand). Reject it explicitly so we don't
+			// silently produce an unthreaded draft.
+			if cmd.Flags().Changed("reply-to") && strings.TrimSpace(replyTo) == "" {
+				return fmt.Errorf("--reply-to requires a non-empty message ID")
+			}
+			isReply := cmd.Flags().Changed("reply-to")
 
 			// 1. Required-flag checks. In reply mode, --to and --subject are
 			//    derived from the source message and only required if not derivable.
@@ -111,9 +114,14 @@ Examples:
 				fromAddr = parsed.Address
 			}
 
-			// 3b. Non-reply mode: require at least one --to address now (no I/O yet).
-			//     Reply mode defers this check until after source derivation.
+			// 3b. Local recipient validation (no I/O yet).
+			//     - Non-reply mode: --to is required and must parse to ≥1 address.
+			//     - Reply mode: an explicit --to override must still parse to ≥1
+			//       address; otherwise we defer the check until after derivation.
 			if !isReply && len(toAddrs) == 0 {
+				return fmt.Errorf("--to must contain at least one address")
+			}
+			if isReply && cmd.Flags().Changed("to") && len(toAddrs) == 0 {
 				return fmt.Errorf("--to must contain at least one address")
 			}
 

--- a/internal/cmd/mail/draft.go
+++ b/internal/cmd/mail/draft.go
@@ -372,17 +372,14 @@ func deriveReplyDefaults(src *gmailapi.Message, needs replyNeeds, selfSet map[st
 }
 
 // buildReferences appends the source Message-Id to the existing References
-// chain, splitting the raw header on whitespace (RFC 5322 §3.6.4). Returns
-// the new chain with empty tokens dropped.
+// chain, splitting the raw header on whitespace (RFC 5322 §3.6.4). If the
+// chain already ends with msgID, it is not duplicated.
 func buildReferences(rawRefs, msgID string) []string {
-	out := make([]string, 0)
-	for _, f := range strings.Fields(rawRefs) {
-		if f != "" {
-			out = append(out, f)
-		}
+	out := strings.Fields(rawRefs)
+	if len(out) > 0 && out[len(out)-1] == msgID {
+		return out
 	}
-	out = append(out, msgID)
-	return out
+	return append(out, msgID)
 }
 
 // splitAddressHeaders parses each non-empty raw header value via
@@ -422,8 +419,9 @@ func filterSelf(addrs []string, selfSet map[string]bool) []string {
 }
 
 // addRePrefix prefixes "Re: " unless the subject already begins with a
-// case-insensitive "re:" (followed by space or end-of-string). Locale
-// variants (Aw, Sv, etc.) are intentionally not recognised — Gmail itself
+// case-insensitive "re:" (the colon is the delimiter; "re:foo" without a
+// trailing space still counts as already-prefixed). Locale variants
+// (Aw, Sv, etc.) are intentionally not recognised — Gmail itself
 // doesn't normalise them.
 func addRePrefix(subject string) string {
 	trimmed := strings.TrimLeft(subject, " \t")

--- a/internal/cmd/mail/draft_test.go
+++ b/internal/cmd/mail/draft_test.go
@@ -661,32 +661,43 @@ func TestDraftCommand_ReplyAll_OverrideCcWithMalformedSourceToCc(t *testing.T) {
 	})
 }
 
-func TestDraftCommand_EmptyReplyToTreatedAsNonReply(t *testing.T) {
+func TestDraftCommand_EmptyReplyToIsAnError(t *testing.T) {
+	// --reply-to with an empty value (often an unexpanded shell variable)
+	// must fail explicitly rather than silently producing an unthreaded draft.
 	mock := &MockGmailClient{
 		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) {
 			t.Fatal("GetMessage must not be called with empty --reply-to")
 			return nil, nil
 		},
+		CreateDraftFunc: func(_ context.Context, _ gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			t.Fatal("CreateDraft must not be called with empty --reply-to")
+			return nil, nil
+		},
 	}
 	cmd := newDraftCommand()
-	cmd.SetArgs([]string{"--reply-to", "", "--body", "x", "--plain"})
+	cmd.SetArgs([]string{"--reply-to", "", "--to", "a@x.com", "--subject", "hi", "--body", "x", "--plain"})
 	withMockClient(mock, func() {
 		err := cmd.Execute()
 		testutil.Error(t, err)
-		// Empty --reply-to falls back to non-reply mode, so --to is required.
-		testutil.Contains(t, err.Error(), "--to")
+		testutil.Contains(t, err.Error(), "--reply-to requires a non-empty message ID")
 	})
 }
 
-func TestDraftCommand_EmptyReplyToWithReplyAll(t *testing.T) {
-	mock := &MockGmailClient{}
+func TestDraftCommand_ReplyTo_EmptyToOverrideRejectedLocally(t *testing.T) {
+	// In reply mode, an explicit --to "" override must fail before any
+	// GetMessage call — it's a local user error.
+	mock := &MockGmailClient{
+		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) {
+			t.Fatal("GetMessage must not be called when --to override is empty")
+			return nil, nil
+		},
+	}
 	cmd := newDraftCommand()
-	cmd.SetArgs([]string{"--reply-to", "", "--reply-all", "--body", "x", "--plain"})
+	cmd.SetArgs([]string{"--reply-to", "msg-src", "--to", "", "--body", "x", "--plain"})
 	withMockClient(mock, func() {
 		err := cmd.Execute()
 		testutil.Error(t, err)
-		testutil.Contains(t, err.Error(), "--reply-all")
-		testutil.Contains(t, err.Error(), "--reply-to")
+		testutil.Contains(t, err.Error(), "--to must contain at least one address")
 	})
 }
 

--- a/internal/cmd/mail/draft_test.go
+++ b/internal/cmd/mail/draft_test.go
@@ -606,12 +606,87 @@ func TestDraftCommand_ReplyAll_FiltersFromAlias(t *testing.T) {
 	withMockClient(mock, func() {
 		err := cmd.Execute()
 		testutil.NoError(t, err)
-		// alias@example.com filtered (via --from), me@example.com would have been (not present here), bob+carol remain.
-		for _, a := range seen.Cc {
-			if a == "alias@example.com" {
-				t.Errorf("alias not filtered from Cc: %v", seen.Cc)
-			}
-		}
+		// Source To = alias + bob; source Cc = carol. alias filtered via --from.
+		// Pin the exact list so the test fails if filtering accidentally drops bob/carol too.
+		testutil.LenSlice(t, len(seen.Cc), 2)
+		testutil.Equal(t, seen.Cc[0], "bob@example.com")
+		testutil.Equal(t, seen.Cc[1], "carol@example.com")
+	})
+}
+
+func TestDraftCommand_ReplyTo_OverrideToWithMalformedSourceFrom(t *testing.T) {
+	// --to override means the source From is never parsed, so a malformed
+	// source From header must not fail the command.
+	var seen gmailapi.DraftMessage
+	src := srcReply()
+	src.From = "not-an-email"
+	mock := &MockGmailClient{
+		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return src, nil },
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			seen = msg
+			return &gmailapi.DraftResult{ID: "d1"}, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--reply-to", "msg-src", "--to", "override@x.com", "--body", "x", "--plain"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.NoError(t, err)
+		testutil.LenSlice(t, len(seen.To), 1)
+		testutil.Equal(t, seen.To[0], "override@x.com")
+		// Threading headers still derive (Message-Id is unaffected).
+		testutil.Equal(t, seen.InReplyTo, "<orig@example.com>")
+	})
+}
+
+func TestDraftCommand_ReplyAll_OverrideCcWithMalformedSourceToCc(t *testing.T) {
+	// --cc override means source To/Cc are never parsed, so malformed values must not fail.
+	var seen gmailapi.DraftMessage
+	src := srcReply()
+	src.To = "garbage @@@ not parseable"
+	mock := &MockGmailClient{
+		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return src, nil },
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			seen = msg
+			return &gmailapi.DraftResult{ID: "d1"}, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--reply-to", "msg-src", "--reply-all", "--cc", "explicit@x.com", "--body", "x", "--plain"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.NoError(t, err)
+		testutil.LenSlice(t, len(seen.Cc), 1)
+		testutil.Equal(t, seen.Cc[0], "explicit@x.com")
+	})
+}
+
+func TestDraftCommand_EmptyReplyToTreatedAsNonReply(t *testing.T) {
+	mock := &MockGmailClient{
+		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) {
+			t.Fatal("GetMessage must not be called with empty --reply-to")
+			return nil, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--reply-to", "", "--body", "x", "--plain"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		// Empty --reply-to falls back to non-reply mode, so --to is required.
+		testutil.Contains(t, err.Error(), "--to")
+	})
+}
+
+func TestDraftCommand_EmptyReplyToWithReplyAll(t *testing.T) {
+	mock := &MockGmailClient{}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--reply-to", "", "--reply-all", "--body", "x", "--plain"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "--reply-all")
+		testutil.Contains(t, err.Error(), "--reply-to")
 	})
 }
 

--- a/internal/cmd/mail/draft_test.go
+++ b/internal/cmd/mail/draft_test.go
@@ -3,6 +3,7 @@ package mail
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -485,4 +486,301 @@ func TestDetectMimeType(t *testing.T) {
 			}
 		})
 	}
+}
+
+// --- Reply mode tests (#114) ---
+
+// srcReply is a fully-populated synthetic source message for reply tests.
+func srcReply() *gmailapi.Message {
+	return &gmailapi.Message{
+		ID:           "msg-src",
+		ThreadID:     "thread-src",
+		From:         "Alice <alice@example.com>",
+		To:           "me@example.com, bob@example.com",
+		Cc:           "carol@example.com",
+		Subject:      "Project sync",
+		RFCMessageID: "<orig@example.com>",
+		References:   "<earlier@example.com>",
+	}
+}
+
+func TestDraftCommand_ReplyTo_DerivesAllDefaults(t *testing.T) {
+	var seen gmailapi.DraftMessage
+	mock := &MockGmailClient{
+		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) {
+			return srcReply(), nil
+		},
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			seen = msg
+			return &gmailapi.DraftResult{ID: "d1"}, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--reply-to", "msg-src", "--body", "thanks", "--plain"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.NoError(t, err)
+		testutil.Equal(t, seen.ThreadID, "thread-src")
+		testutil.Equal(t, seen.InReplyTo, "<orig@example.com>")
+		testutil.LenSlice(t, len(seen.References), 2)
+		testutil.Equal(t, seen.References[0], "<earlier@example.com>")
+		testutil.Equal(t, seen.References[1], "<orig@example.com>")
+		testutil.LenSlice(t, len(seen.To), 1)
+		testutil.Equal(t, seen.To[0], "alice@example.com")
+		testutil.LenSlice(t, len(seen.Cc), 0)
+		testutil.Equal(t, seen.Subject, "Re: Project sync")
+	})
+}
+
+func TestDraftCommand_ReplyTo_ExplicitOverrides(t *testing.T) {
+	var seen gmailapi.DraftMessage
+	mock := &MockGmailClient{
+		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return srcReply(), nil },
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			seen = msg
+			return &gmailapi.DraftResult{ID: "d1"}, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{
+		"--reply-to", "msg-src",
+		"--to", "override@x.com",
+		"--cc", "extra@x.com",
+		"--subject", "Custom subject",
+		"--body", "x", "--plain",
+	})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.NoError(t, err)
+		testutil.LenSlice(t, len(seen.To), 1)
+		testutil.Equal(t, seen.To[0], "override@x.com")
+		testutil.LenSlice(t, len(seen.Cc), 1)
+		testutil.Equal(t, seen.Cc[0], "extra@x.com")
+		testutil.Equal(t, seen.Subject, "Custom subject")
+		// Headers and ThreadID still derived even when subject/to overridden.
+		testutil.Equal(t, seen.ThreadID, "thread-src")
+		testutil.Equal(t, seen.InReplyTo, "<orig@example.com>")
+	})
+}
+
+func TestDraftCommand_ReplyAll_AddsCc(t *testing.T) {
+	var seen gmailapi.DraftMessage
+	mock := &MockGmailClient{
+		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return srcReply(), nil },
+		GetProfileFunc: func(_ context.Context) (*gmailapi.Profile, error) {
+			return &gmailapi.Profile{EmailAddress: "me@example.com"}, nil
+		},
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			seen = msg
+			return &gmailapi.DraftResult{ID: "d1"}, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--reply-to", "msg-src", "--reply-all", "--body", "x", "--plain"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.NoError(t, err)
+		// Source To has me@example.com (filtered) + bob@example.com; Cc has carol@example.com.
+		testutil.LenSlice(t, len(seen.Cc), 2)
+		testutil.Equal(t, seen.Cc[0], "bob@example.com")
+		testutil.Equal(t, seen.Cc[1], "carol@example.com")
+	})
+}
+
+func TestDraftCommand_ReplyAll_FiltersFromAlias(t *testing.T) {
+	var seen gmailapi.DraftMessage
+	src := srcReply()
+	src.To = "alias@example.com, bob@example.com"
+	mock := &MockGmailClient{
+		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return src, nil },
+		GetProfileFunc: func(_ context.Context) (*gmailapi.Profile, error) {
+			return &gmailapi.Profile{EmailAddress: "me@example.com"}, nil
+		},
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			seen = msg
+			return &gmailapi.DraftResult{ID: "d1"}, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--reply-to", "msg-src", "--reply-all", "--from", "alias@example.com", "--body", "x", "--plain"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.NoError(t, err)
+		// alias@example.com filtered (via --from), me@example.com would have been (not present here), bob+carol remain.
+		for _, a := range seen.Cc {
+			if a == "alias@example.com" {
+				t.Errorf("alias not filtered from Cc: %v", seen.Cc)
+			}
+		}
+	})
+}
+
+func TestDraftCommand_ReplyAll_RequiresReplyTo(t *testing.T) {
+	mock := &MockGmailClient{}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--to", "a@x.com", "--subject", "Hi", "--body", "x", "--reply-all"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "--reply-all")
+		testutil.Contains(t, err.Error(), "--reply-to")
+	})
+}
+
+func TestDraftCommand_Reply_NoDoublePrefix(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Re: foo", "Re: foo"},
+		{"re: foo", "re: foo"},
+		{"RE: foo", "RE: foo"},
+		{"Aw: foo", "Re: Aw: foo"},
+		{"foo", "Re: foo"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.in, func(t *testing.T) {
+			src := srcReply()
+			src.Subject = tc.in
+			var seen gmailapi.DraftMessage
+			mock := &MockGmailClient{
+				GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return src, nil },
+				CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+					seen = msg
+					return &gmailapi.DraftResult{ID: "d1"}, nil
+				},
+			}
+			cmd := newDraftCommand()
+			cmd.SetArgs([]string{"--reply-to", "msg-src", "--body", "x", "--plain"})
+			withMockClient(mock, func() {
+				err := cmd.Execute()
+				testutil.NoError(t, err)
+				testutil.Equal(t, seen.Subject, tc.want)
+			})
+		})
+	}
+}
+
+func TestDraftCommand_ReplyTo_GetMessageFails(t *testing.T) {
+	mock := &MockGmailClient{
+		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) {
+			return nil, fmt.Errorf("not found")
+		},
+		CreateDraftFunc: func(_ context.Context, _ gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			t.Fatal("CreateDraft must not be called when GetMessage fails")
+			return nil, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--reply-to", "msg-src", "--body", "x", "--plain"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "fetching reply source")
+	})
+}
+
+func TestDraftCommand_ReplyTo_MissingFromHeader(t *testing.T) {
+	src := srcReply()
+	src.From = ""
+	mock := &MockGmailClient{
+		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return src, nil },
+		CreateDraftFunc: func(_ context.Context, _ gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			t.Fatal("CreateDraft must not be called")
+			return nil, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--reply-to", "msg-src", "--body", "x", "--plain"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "no From header")
+	})
+}
+
+func TestDraftCommand_ReplyTo_MissingMessageID(t *testing.T) {
+	src := srcReply()
+	src.RFCMessageID = ""
+	mock := &MockGmailClient{
+		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return src, nil },
+		CreateDraftFunc: func(_ context.Context, _ gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			t.Fatal("CreateDraft must not be called")
+			return nil, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--reply-to", "msg-src", "--body", "x", "--plain"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "no Message-Id header")
+	})
+}
+
+func TestDraftCommand_ReplyTo_MalformedFromHeader(t *testing.T) {
+	src := srcReply()
+	src.From = "not-an-email"
+	mock := &MockGmailClient{
+		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return src, nil },
+		CreateDraftFunc: func(_ context.Context, _ gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			t.Fatal("CreateDraft must not be called")
+			return nil, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--reply-to", "msg-src", "--body", "x", "--plain"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "parsing source From header")
+	})
+}
+
+func TestDraftCommand_ReplyAll_MalformedToHeader(t *testing.T) {
+	src := srcReply()
+	src.To = "not a valid header @@@"
+	mock := &MockGmailClient{
+		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return src, nil },
+		GetProfileFunc: func(_ context.Context) (*gmailapi.Profile, error) {
+			return &gmailapi.Profile{EmailAddress: "me@example.com"}, nil
+		},
+		CreateDraftFunc: func(_ context.Context, _ gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			t.Fatal("CreateDraft must not be called")
+			return nil, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--reply-to", "msg-src", "--reply-all", "--body", "x", "--plain"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "parsing source To/Cc headers")
+	})
+}
+
+func TestDraftCommand_LocalValidationBeforeFetch(t *testing.T) {
+	// --body + --stdin is invalid locally; GetMessage must not be called.
+	mock := &MockGmailClient{
+		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) {
+			t.Fatal("GetMessage must not be called when local validation fails")
+			return nil, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--reply-to", "msg-src", "--body", "x", "--stdin"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "exactly one of")
+	})
+}
+
+func TestDraftCommand_ReplyTo_RejectsHeaderInjection(t *testing.T) {
+	mock := &MockGmailClient{}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--reply-to", "msg-src\r\nBcc: evil@x.com", "--body", "x", "--plain"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "CR or LF")
+	})
 }

--- a/internal/cmd/mail/draft_test.go
+++ b/internal/cmd/mail/draft_test.go
@@ -701,6 +701,37 @@ func TestDraftCommand_ReplyTo_EmptyToOverrideRejectedLocally(t *testing.T) {
 	})
 }
 
+func TestDraftCommand_ReplyAll_ExplicitToOverride(t *testing.T) {
+	// --reply-all with explicit --to: To is user's value (needs.To=false), Cc is derived from source.
+	var seen gmailapi.DraftMessage
+	mock := &MockGmailClient{
+		GetMessageFunc:  func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return srcReply(), nil },
+		GetProfileFunc:  func(_ context.Context) (*gmailapi.Profile, error) { return &gmailapi.Profile{EmailAddress: "me@example.com"}, nil },
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) { seen = msg; return &gmailapi.DraftResult{ID: "d1"}, nil },
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--reply-to", "msg-src", "--reply-all", "--to", "different@x.com", "--body", "x", "--plain"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.NoError(t, err)
+		testutil.LenSlice(t, len(seen.To), 1)
+		testutil.Equal(t, seen.To[0], "different@x.com")
+		// Cc still derived from source To+Cc minus me@example.com.
+		testutil.LenSlice(t, len(seen.Cc), 2)
+		testutil.Equal(t, seen.Cc[0], "bob@example.com")
+		testutil.Equal(t, seen.Cc[1], "carol@example.com")
+	})
+}
+
+func TestBuildReferences_DedupesTrailingMessageID(t *testing.T) {
+	// If the source's References header already ends with its own Message-Id
+	// (some MUAs do this), the chain shouldn't duplicate.
+	got := buildReferences("<a@x> <orig@x>", "<orig@x>")
+	if len(got) != 2 || got[0] != "<a@x>" || got[1] != "<orig@x>" {
+		t.Errorf("buildReferences dedup = %v, want [<a@x> <orig@x>]", got)
+	}
+}
+
 func TestDraftCommand_ReplyAll_RequiresReplyTo(t *testing.T) {
 	mock := &MockGmailClient{}
 	cmd := newDraftCommand()

--- a/internal/cmd/mail/draft_test.go
+++ b/internal/cmd/mail/draft_test.go
@@ -705,9 +705,14 @@ func TestDraftCommand_ReplyAll_ExplicitToOverride(t *testing.T) {
 	// --reply-all with explicit --to: To is user's value (needs.To=false), Cc is derived from source.
 	var seen gmailapi.DraftMessage
 	mock := &MockGmailClient{
-		GetMessageFunc:  func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return srcReply(), nil },
-		GetProfileFunc:  func(_ context.Context) (*gmailapi.Profile, error) { return &gmailapi.Profile{EmailAddress: "me@example.com"}, nil },
-		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) { seen = msg; return &gmailapi.DraftResult{ID: "d1"}, nil },
+		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return srcReply(), nil },
+		GetProfileFunc: func(_ context.Context) (*gmailapi.Profile, error) {
+			return &gmailapi.Profile{EmailAddress: "me@example.com"}, nil
+		},
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			seen = msg
+			return &gmailapi.DraftResult{ID: "d1"}, nil
+		},
 	}
 	cmd := newDraftCommand()
 	cmd.SetArgs([]string{"--reply-to", "msg-src", "--reply-all", "--to", "different@x.com", "--body", "x", "--plain"})
@@ -917,9 +922,12 @@ func TestDraftCommand_ReplyAll_EmptyProfileFallsBackToFrom(t *testing.T) {
 	src := srcReply()
 	src.To = "alias@example.com, bob@example.com"
 	mock := &MockGmailClient{
-		GetMessageFunc:  func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return src, nil },
-		GetProfileFunc:  func(_ context.Context) (*gmailapi.Profile, error) { return &gmailapi.Profile{}, nil },
-		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) { seen = msg; return &gmailapi.DraftResult{ID: "d1"}, nil },
+		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return src, nil },
+		GetProfileFunc: func(_ context.Context) (*gmailapi.Profile, error) { return &gmailapi.Profile{}, nil },
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			seen = msg
+			return &gmailapi.DraftResult{ID: "d1"}, nil
+		},
 	}
 	cmd := newDraftCommand()
 	cmd.SetArgs([]string{"--reply-to", "msg-src", "--reply-all", "--from", "alias@example.com", "--body", "x", "--plain"})
@@ -939,8 +947,11 @@ func TestDraftCommand_ReplyTo_FirstReplyEmptyReferences(t *testing.T) {
 	src := srcReply()
 	src.References = ""
 	mock := &MockGmailClient{
-		GetMessageFunc:  func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return src, nil },
-		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) { seen = msg; return &gmailapi.DraftResult{ID: "d1"}, nil },
+		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return src, nil },
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			seen = msg
+			return &gmailapi.DraftResult{ID: "d1"}, nil
+		},
 	}
 	cmd := newDraftCommand()
 	cmd.SetArgs([]string{"--reply-to", "msg-src", "--body", "x", "--plain"})
@@ -961,8 +972,11 @@ func TestDraftCommand_ReplyTo_WithAttachment(t *testing.T) {
 	}
 	var seen gmailapi.DraftMessage
 	mock := &MockGmailClient{
-		GetMessageFunc:  func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return srcReply(), nil },
-		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) { seen = msg; return &gmailapi.DraftResult{ID: "d1"}, nil },
+		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return srcReply(), nil },
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			seen = msg
+			return &gmailapi.DraftResult{ID: "d1"}, nil
+		},
 	}
 	cmd := newDraftCommand()
 	cmd.SetArgs([]string{"--reply-to", "msg-src", "--body", "x", "--plain", "--attach", att})

--- a/internal/cmd/mail/draft_test.go
+++ b/internal/cmd/mail/draft_test.go
@@ -849,6 +849,90 @@ func TestDraftCommand_LocalValidationBeforeFetch(t *testing.T) {
 	})
 }
 
+func TestDraftCommand_ReplyAll_GetProfileFails(t *testing.T) {
+	mock := &MockGmailClient{
+		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return srcReply(), nil },
+		GetProfileFunc: func(_ context.Context) (*gmailapi.Profile, error) {
+			return nil, fmt.Errorf("profile boom")
+		},
+		CreateDraftFunc: func(_ context.Context, _ gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
+			t.Fatal("CreateDraft must not be called when GetProfile fails for --reply-all")
+			return nil, nil
+		},
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--reply-to", "msg-src", "--reply-all", "--body", "x", "--plain"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.Error(t, err)
+		testutil.Contains(t, err.Error(), "fetching profile")
+	})
+}
+
+func TestDraftCommand_ReplyAll_EmptyProfileFallsBackToFrom(t *testing.T) {
+	// Profile returns empty EmailAddress; --from alias supplies the self set.
+	var seen gmailapi.DraftMessage
+	src := srcReply()
+	src.To = "alias@example.com, bob@example.com"
+	mock := &MockGmailClient{
+		GetMessageFunc:  func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return src, nil },
+		GetProfileFunc:  func(_ context.Context) (*gmailapi.Profile, error) { return &gmailapi.Profile{}, nil },
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) { seen = msg; return &gmailapi.DraftResult{ID: "d1"}, nil },
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--reply-to", "msg-src", "--reply-all", "--from", "alias@example.com", "--body", "x", "--plain"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.NoError(t, err)
+		// alias filtered via --from only; carol@example.com from source Cc; bob remains.
+		testutil.LenSlice(t, len(seen.Cc), 2)
+		testutil.Equal(t, seen.Cc[0], "bob@example.com")
+		testutil.Equal(t, seen.Cc[1], "carol@example.com")
+	})
+}
+
+func TestDraftCommand_ReplyTo_FirstReplyEmptyReferences(t *testing.T) {
+	// First reply in a thread: source has no prior References — derived chain is just [Message-Id].
+	var seen gmailapi.DraftMessage
+	src := srcReply()
+	src.References = ""
+	mock := &MockGmailClient{
+		GetMessageFunc:  func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return src, nil },
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) { seen = msg; return &gmailapi.DraftResult{ID: "d1"}, nil },
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--reply-to", "msg-src", "--body", "x", "--plain"})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.NoError(t, err)
+		testutil.LenSlice(t, len(seen.References), 1)
+		testutil.Equal(t, seen.References[0], "<orig@example.com>")
+	})
+}
+
+func TestDraftCommand_ReplyTo_WithAttachment(t *testing.T) {
+	// Reply mode + --attach must still propagate threading headers through the multipart path.
+	tmp := t.TempDir()
+	att := filepath.Join(tmp, "note.txt")
+	if err := os.WriteFile(att, []byte("attached"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	var seen gmailapi.DraftMessage
+	mock := &MockGmailClient{
+		GetMessageFunc:  func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) { return srcReply(), nil },
+		CreateDraftFunc: func(_ context.Context, msg gmailapi.DraftMessage) (*gmailapi.DraftResult, error) { seen = msg; return &gmailapi.DraftResult{ID: "d1"}, nil },
+	}
+	cmd := newDraftCommand()
+	cmd.SetArgs([]string{"--reply-to", "msg-src", "--body", "x", "--plain", "--attach", att})
+	withMockClient(mock, func() {
+		err := cmd.Execute()
+		testutil.NoError(t, err)
+		testutil.Equal(t, seen.ThreadID, "thread-src")
+		testutil.Equal(t, seen.InReplyTo, "<orig@example.com>")
+		testutil.LenSlice(t, len(seen.Attachments), 1)
+	})
+}
+
 func TestDraftCommand_ReplyTo_RejectsHeaderInjection(t *testing.T) {
 	mock := &MockGmailClient{}
 	cmd := newDraftCommand()

--- a/internal/gmail/drafts.go
+++ b/internal/gmail/drafts.go
@@ -40,6 +40,16 @@ type DraftMessage struct {
 	Body        []byte
 	BodyKind    DraftBodyKind
 	Attachments []DraftAttachment
+
+	// ThreadID, when non-empty, threads the draft into an existing Gmail
+	// conversation via Draft.Message.ThreadId. Empty = new thread.
+	ThreadID string
+	// InReplyTo, when non-empty, is emitted as the RFC 5322 In-Reply-To
+	// header (typically the source message's Message-Id, brackets included).
+	InReplyTo string
+	// References, when non-empty, is emitted as the RFC 5322 References
+	// header (space-joined Message-Ids per §3.6.4).
+	References []string
 }
 
 // DraftAttachment is one attachment. Filename should be a basename; the gmail
@@ -68,7 +78,8 @@ func (c *Client) CreateDraft(ctx context.Context, msg DraftMessage) (*DraftResul
 
 	draft := &gmailapi.Draft{
 		Message: &gmailapi.Message{
-			Raw: base64.URLEncoding.EncodeToString(raw),
+			Raw:      base64.URLEncoding.EncodeToString(raw),
+			ThreadId: msg.ThreadID,
 		},
 	}
 	resp, err := c.service.Users.Drafts.Create(c.userID, draft).Context(ctx).Do()
@@ -108,6 +119,12 @@ func buildMIME(msg DraftMessage) ([]byte, error) {
 	}
 	if h := addressHeader("Bcc", msg.Bcc); h != "" {
 		buf.WriteString(h)
+	}
+	if msg.InReplyTo != "" {
+		fmt.Fprintf(&buf, "In-Reply-To: %s\r\n", msg.InReplyTo)
+	}
+	if len(msg.References) > 0 {
+		fmt.Fprintf(&buf, "References: %s\r\n", strings.Join(msg.References, " "))
 	}
 	fmt.Fprintf(&buf, "Subject: %s\r\n", mime.QEncoding.Encode("utf-8", msg.Subject))
 
@@ -200,6 +217,14 @@ func guardHeaderInjection(msg DraftMessage) error {
 	}
 	for _, att := range msg.Attachments {
 		if err := check("attachment filename", att.Filename); err != nil {
+			return err
+		}
+	}
+	if err := check("in-reply-to", msg.InReplyTo); err != nil {
+		return err
+	}
+	for _, r := range msg.References {
+		if err := check("references", r); err != nil {
 			return err
 		}
 	}

--- a/internal/gmail/drafts_test.go
+++ b/internal/gmail/drafts_test.go
@@ -669,6 +669,124 @@ func TestBuildMIME_MultipartHTMLBody(t *testing.T) {
 	}
 }
 
+// --- Reply mode tests (#114) ---
+
+func TestBuildMIME_ReplyHeaders(t *testing.T) {
+	t.Parallel()
+	msg := DraftMessage{
+		To:         []string{"a@x.com"},
+		Subject:    "Re: Hi",
+		Body:       []byte("body"),
+		BodyKind:   DraftBodyPlainText,
+		InReplyTo:  "<orig@example.com>",
+		References: []string{"<earlier@example.com>", "<orig@example.com>"},
+	}
+	raw, err := buildMIME(msg)
+	if err != nil {
+		t.Fatalf("buildMIME: %v", err)
+	}
+	m, _, _, _ := parseMIME(t, raw)
+	if got := m.Header.Get("In-Reply-To"); got != "<orig@example.com>" {
+		t.Errorf("In-Reply-To = %q", got)
+	}
+	if got := m.Header.Get("References"); got != "<earlier@example.com> <orig@example.com>" {
+		t.Errorf("References = %q", got)
+	}
+}
+
+func TestBuildMIME_NoReplyHeadersWhenUnset(t *testing.T) {
+	t.Parallel()
+	msg := DraftMessage{
+		To:       []string{"a@x.com"},
+		Subject:  "Hi",
+		Body:     []byte("body"),
+		BodyKind: DraftBodyPlainText,
+	}
+	raw, err := buildMIME(msg)
+	if err != nil {
+		t.Fatalf("buildMIME: %v", err)
+	}
+	m, _, _, _ := parseMIME(t, raw)
+	if got := m.Header.Get("In-Reply-To"); got != "" {
+		t.Errorf("In-Reply-To present when unset: %q", got)
+	}
+	if got := m.Header.Get("References"); got != "" {
+		t.Errorf("References present when unset: %q", got)
+	}
+}
+
+func TestBuildMIME_RejectsHeaderInjection_Reply(t *testing.T) {
+	t.Parallel()
+	base := DraftMessage{
+		To:       []string{"a@x.com"},
+		Subject:  "Hi",
+		Body:     []byte("body"),
+		BodyKind: DraftBodyPlainText,
+	}
+	cases := []struct {
+		name string
+		mut  func(*DraftMessage)
+	}{
+		{"in-reply-to CRLF", func(m *DraftMessage) { m.InReplyTo = "<a@x>\r\nBcc: evil@x.com" }},
+		{"in-reply-to LF", func(m *DraftMessage) { m.InReplyTo = "<a@x>\nBcc: evil@x.com" }},
+		{"references CRLF", func(m *DraftMessage) {
+			m.References = []string{"<earlier@x>", "<a@x>\r\nBcc: evil@x.com"}
+		}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m := base
+			tc.mut(&m)
+			if _, err := buildMIME(m); err == nil {
+				t.Errorf("expected error for %s, got nil", tc.name)
+			}
+		})
+	}
+}
+
+func TestCreateDraft_APIWiring_PropagatesThreadID(t *testing.T) {
+	t.Parallel()
+	msg := DraftMessage{
+		To:       []string{"a@x.com"},
+		Subject:  "Re: Hi",
+		Body:     []byte("body"),
+		BodyKind: DraftBodyPlainText,
+		ThreadID: "thread-abc",
+	}
+	var gotThreadID string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Message struct {
+				ThreadId string `json:"threadId"`
+			} `json:"message"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotThreadID = body.Message.ThreadId
+		resp := &gmailapi.Draft{Id: "d-1", Message: &gmailapi.Message{Id: "m-1", ThreadId: "thread-abc"}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+	ctx := context.Background()
+	svc, err := gmailapi.NewService(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	c := &Client{service: svc, userID: "me"}
+	if _, err := c.CreateDraft(ctx, msg); err != nil {
+		t.Fatalf("CreateDraft: %v", err)
+	}
+	if gotThreadID != "thread-abc" {
+		t.Errorf("threadId on the wire = %q, want thread-abc", gotThreadID)
+	}
+}
+
 func hasBareLF(s string) bool {
 	for i := 0; i < len(s); i++ {
 		if s[i] == '\n' && (i == 0 || s[i-1] != '\r') {

--- a/internal/gmail/drafts_test.go
+++ b/internal/gmail/drafts_test.go
@@ -759,11 +759,11 @@ func TestCreateDraft_APIWiring_PropagatesThreadID(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body struct {
 			Message struct {
-				ThreadId string `json:"threadId"`
+				ThreadID string `json:"threadId"`
 			} `json:"message"`
 		}
 		_ = json.NewDecoder(r.Body).Decode(&body)
-		gotThreadID = body.Message.ThreadId
+		gotThreadID = body.Message.ThreadID
 		resp := &gmailapi.Draft{Id: "d-1", Message: &gmailapi.Message{Id: "m-1", ThreadId: "thread-abc"}}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(resp)

--- a/internal/gmail/messages.go
+++ b/internal/gmail/messages.go
@@ -24,6 +24,17 @@ type Message struct {
 	Attachments []*Attachment `json:"attachments,omitempty"`
 	Labels      []string      `json:"labels,omitempty"`
 	Categories  []string      `json:"categories,omitempty"`
+	// Cc carries the raw "Cc" header value (comma-separated address list).
+	Cc string `json:"cc,omitempty"`
+	// RFCMessageID is the RFC 5322 Message-Id header, distinct from ID
+	// (Gmail's internal message id). Used by reply derivation to populate
+	// In-Reply-To and References on outgoing drafts.
+	RFCMessageID string `json:"rfcMessageId,omitempty"`
+	// References is the raw "References" header value (whitespace-separated
+	// chain of Message-Ids).
+	References string `json:"references,omitempty"`
+	// InReplyTo is the raw "In-Reply-To" header value.
+	InReplyTo string `json:"inReplyTo,omitempty"`
 }
 
 // Attachment represents metadata about an email attachment
@@ -172,6 +183,14 @@ func parseMessage(msg *gmail.Message, includeBody bool, resolver LabelResolver) 
 			m.To = header.Value
 		case "date":
 			m.Date = header.Value
+		case "cc":
+			m.Cc = header.Value
+		case "message-id":
+			m.RFCMessageID = header.Value
+		case "references":
+			m.References = header.Value
+		case "in-reply-to":
+			m.InReplyTo = header.Value
 		}
 	}
 

--- a/internal/gmail/messages_test.go
+++ b/internal/gmail/messages_test.go
@@ -51,6 +51,36 @@ func TestParseMessage(t *testing.T) {
 		}
 	})
 
+	t.Run("extracts reply-related headers", func(t *testing.T) {
+		t.Parallel()
+		msg := &gmail.Message{
+			Id:       "msg123",
+			ThreadId: "thread456",
+			Payload: &gmail.MessagePart{
+				Headers: []*gmail.MessagePartHeader{
+					{Name: "From", Value: "alice@example.com"},
+					{Name: "Cc", Value: "carol@example.com, dave@example.com"},
+					{Name: "Message-Id", Value: "<orig@example.com>"},
+					{Name: "References", Value: "<a@x.com> <b@x.com>"},
+					{Name: "In-Reply-To", Value: "<b@x.com>"},
+				},
+			},
+		}
+		result := parseMessage(msg, false, nil)
+		if result.Cc != "carol@example.com, dave@example.com" {
+			t.Errorf("Cc = %q", result.Cc)
+		}
+		if result.RFCMessageID != "<orig@example.com>" {
+			t.Errorf("RFCMessageID = %q", result.RFCMessageID)
+		}
+		if result.References != "<a@x.com> <b@x.com>" {
+			t.Errorf("References = %q", result.References)
+		}
+		if result.InReplyTo != "<b@x.com>" {
+			t.Errorf("InReplyTo = %q", result.InReplyTo)
+		}
+	})
+
 	t.Run("extracts thread ID", func(t *testing.T) {
 		t.Parallel()
 		msg := &gmail.Message{


### PR DESCRIPTION
## Summary

Closes #114.

Extends `gro mail draft` with `--reply-to <message-id>` and `--reply-all` flags so it can compose threaded replies. Same command, same MIME pipeline, same client interface — strictly additive on #113.

With `--reply-to`:
- `To` defaults to the source's `From`; `Subject` becomes `Re: <orig>` (case-insensitive, no double prefix).
- `In-Reply-To` / `References` headers are emitted; `Draft.Message.ThreadId` is set so the draft lands inside the source conversation.
- Explicit `--to`/`--cc`/`--subject` override derived values (`cmd.Flags().Changed()` pattern). Lazy derivation: source headers are only parsed for slots the caller actually consumes.
- `--reply-all` adds the source To+Cc as Cc, filtered to remove the authenticated account **and** any `--from` alias.

Validation: all local-only checks run before any Gmail API call. `--reply-to ""` is rejected explicitly (no silent fallback). `deriveReplyDefaults` is fallible — empty/malformed `From` or `Message-Id` headers fail before `CreateDraft`. Header-injection guard extended to cover `--reply-to`, `In-Reply-To`, and `References`.

## Reuse, no rebuild

Per the ticket's "reuse don't rebuild" mandate:
- No new `gro mail reply` command — two flags on the existing `newDraftCommand`.
- No new `ReplyMessage` type — three fields on the existing `DraftMessage`.
- No new `MailClient` methods — `GetMessage` and `GetProfile` are already there.
- No refactor of #113 paths — every change is an insertion.

## Test plan

- [x] 1342 tests across 28 packages pass (`make test`)
- [x] ~30 new tests across gmail and command layers — happy paths, every override case, malformed/missing source headers, local-validation-before-fetch, alias-aware self filtering, multipart+threading, first-reply-no-prior-References
- [x] go vet clean
- [x] T21-T26 integration scenarios added to integration-tests.md; verify draft headers via `gro mail read --json` rather than UI eyeballing
- [ ] Manual integration run against live Gmail (after PR review)