### PR TITLE
fix: clear golangci-lint failures

### DIFF
--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -182,7 +182,7 @@ func setInConfigFile(token *oauth2.Token) error {
 	}
 	defer f.Close()
 
-	if err := json.NewEncoder(f).Encode(token); err != nil {
+	if err := json.NewEncoder(f).Encode(token); err != nil { //nolint:gosec // G117: token persistence is the intended purpose; file written with 0600
 		return fmt.Errorf("writing token: %w", err)
 	}
 

--- a/internal/keychain/keychain_darwin.go
+++ b/internal/keychain/keychain_darwin.go
@@ -87,7 +87,7 @@ func getFromKeychain() (*oauth2.Token, error) {
 }
 
 func setInKeychain(token *oauth2.Token) error {
-	data, err := json.Marshal(token)
+	data, err := json.Marshal(token) //nolint:gosec // G117: token serialization is the intended purpose; stored in macOS Keychain
 	if err != nil {
 		return fmt.Errorf("serializing token: %w", err)
 	}

--- a/internal/testutil/assert.go
+++ b/internal/testutil/assert.go
@@ -74,7 +74,7 @@ func Nil(t testing.TB, val any) {
 	}
 	v := reflect.ValueOf(val)
 	switch v.Kind() { //nolint:exhaustive // only nillable kinds are relevant
-	case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Chan, reflect.Func, reflect.Interface:
+	case reflect.Pointer, reflect.Slice, reflect.Map, reflect.Chan, reflect.Func, reflect.Interface:
 		if v.IsNil() {
 			return
 		}


### PR DESCRIPTION
## Summary
- Silence gosec G117 on intentional oauth2 token persistence in `internal/keychain/keychain.go` and `keychain_darwin.go` — serializing the token is the whole point; the file path uses `0600` perms and the darwin path stores into the macOS Keychain.
- Replace deprecated `reflect.Ptr` with `reflect.Pointer` in `internal/testutil/assert.go` to satisfy the govet `inline` check.

## Test plan
- [x] `make lint` → 0 issues
- [x] `go test ./...` → all 1344 tests pass