### PR TITLE
feat(ci): auto-trigger chocolatey and winget publish on release

### DIFF
--- a/.github/workflows/chocolatey-publish.yml
+++ b/.github/workflows/chocolatey-publish.yml
@@ -1,11 +1,13 @@
 name: Publish to Chocolatey
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:
         description: 'Version to publish (e.g., 1.0.25)'
-        required: true
+        required: false
         type: string
 
 jobs:
@@ -14,24 +16,47 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Validate release exists
+      - name: Resolve version
         shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          $release = gh release view "v${{ inputs.version }}" --json tagName 2>&1
-          if ($LASTEXITCODE -ne 0) {
-            Write-Error "Release v${{ inputs.version }} not found"
+          if ("${{ github.event_name }}" -eq "release") {
+            $tag = "${{ github.event.release.tag_name }}"
+            if ($tag -notmatch '^v\d') {
+              Write-Host "Skipping: release tag '$tag' does not match v<digit>... pattern"
+              echo "SKIP=true" >> $env:GITHUB_ENV
+              exit 0
+            }
+            $version = $tag -replace '^v',''
+          } else {
+            $version = "${{ inputs.version }}"
+          }
+          if (-not $version) {
+            Write-Error "version not provided"
             exit 1
           }
-          Write-Host "Found release v${{ inputs.version }}"
+          Write-Host "Resolved version: $version"
+          echo "VERSION=$version" >> $env:GITHUB_ENV
 
-      - name: Get checksums from release
+      - name: Validate release exists
+        if: env.SKIP != 'true'
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download "v${{ inputs.version }}" --pattern "checksums.txt" --dir .
+          $release = gh release view "v$env:VERSION" --json tagName 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Release v$env:VERSION not found"
+            exit 1
+          }
+          Write-Host "Found release v$env:VERSION"
+
+      - name: Get checksums from release
+        if: env.SKIP != 'true'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "v$env:VERSION" --pattern "checksums.txt" --dir .
 
           $checksums = Get-Content checksums.txt
           $x64Hash = ($checksums | Select-String "windows_amd64.zip").Line.Split()[0]
@@ -44,9 +69,10 @@ jobs:
           echo "ARM64_HASH=$arm64Hash" >> $env:GITHUB_ENV
 
       - name: Update version and checksums
+        if: env.SKIP != 'true'
         shell: pwsh
         run: |
-          $version = "${{ inputs.version }}"
+          $version = $env:VERSION
 
           # Update version in nuspec
           $nuspec = 'packaging/chocolatey/google-readonly.nuspec'
@@ -62,6 +88,7 @@ jobs:
           Write-Host "Injected checksums into install script"
 
       - name: Pack Chocolatey package
+        if: env.SKIP != 'true'
         shell: pwsh
         run: |
           cd packaging/chocolatey
@@ -69,6 +96,7 @@ jobs:
           Get-ChildItem *.nupkg
 
       - name: Push to Chocolatey
+        if: env.SKIP != 'true'
         shell: pwsh
         run: |
           cd packaging/chocolatey

--- a/.github/workflows/chocolatey-publish.yml
+++ b/.github/workflows/chocolatey-publish.yml
@@ -18,9 +18,13 @@ jobs:
 
       - name: Resolve version
         shell: pwsh
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          if ("${{ github.event_name }}" -eq "release") {
-            $tag = "${{ github.event.release.tag_name }}"
+          if ($env:EVENT_NAME -eq "release") {
+            $tag = $env:RELEASE_TAG
             if ($tag -notmatch '^v\d') {
               Write-Host "Skipping: release tag '$tag' does not match v<digit>... pattern"
               echo "SKIP=true" >> $env:GITHUB_ENV
@@ -28,7 +32,7 @@ jobs:
             }
             $version = $tag -replace '^v',''
           } else {
-            $version = "${{ inputs.version }}"
+            $version = $env:INPUT_VERSION
           }
           if (-not $version) {
             Write-Error "version not provided"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,16 +35,18 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # TAP_GITHUB_TOKEN (PAT) is required here instead of the default
+          # GITHUB_TOKEN because releases created with GITHUB_TOKEN do not fire
+          # downstream workflow triggers (release: published). Using the PAT
+          # lets chocolatey-publish.yml and winget-publish.yml auto-trigger.
+          GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
 
   # Chocolatey and winget publishing live in chocolatey-publish.yml and
-  # winget-publish.yml respectively (workflow_dispatch only). Keeping them out
-  # of this workflow avoids gating the release on Microsoft-hosted services
-  # (wingetcreate's fork-sync, choco push) that fail intermittently and don't
-  # block the actual binary/Homebrew artifacts. Run them manually after a
-  # release: `gh workflow run chocolatey-publish.yml -f version=<X.Y.Z>` and
-  # `gh workflow run winget-publish.yml -f version=<X.Y.Z>`.
+  # winget-publish.yml respectively. They auto-trigger on `release: published`
+  # (and still expose `workflow_dispatch` as a manual fallback). They are kept
+  # out of this workflow so Microsoft-hosted service flakiness (wingetcreate
+  # fork-sync, choco push) does not gate the binary/Homebrew artifacts.
 
   snap:
     if: false  # Temporarily disabled - waiting for personal-files interface approval

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,11 +1,13 @@
 name: Publish to Winget
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:
         description: 'Version to publish (e.g., 1.0.25)'
-        required: true
+        required: false
         type: string
 
 jobs:
@@ -14,24 +16,48 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Resolve version
+        shell: pwsh
+        run: |
+          if ("${{ github.event_name }}" -eq "release") {
+            $tag = "${{ github.event.release.tag_name }}"
+            if ($tag -notmatch '^v\d') {
+              Write-Host "Skipping: release tag '$tag' does not match v<digit>... pattern"
+              echo "SKIP=true" >> $env:GITHUB_ENV
+              exit 0
+            }
+            $version = $tag -replace '^v',''
+          } else {
+            $version = "${{ inputs.version }}"
+          }
+          if (-not $version) {
+            Write-Error "version not provided"
+            exit 1
+          }
+          Write-Host "Resolved version: $version"
+          echo "VERSION=$version" >> $env:GITHUB_ENV
+
       - name: Install wingetcreate
+        if: env.SKIP != 'true'
         shell: pwsh
         run: |
           Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
 
       - name: Validate release exists
+        if: env.SKIP != 'true'
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          $release = gh release view "v${{ inputs.version }}" --repo open-cli-collective/google-readonly --json tagName 2>&1
+          $release = gh release view "v$env:VERSION" --repo open-cli-collective/google-readonly --json tagName 2>&1
           if ($LASTEXITCODE -ne 0) {
-            Write-Error "Release v${{ inputs.version }} not found"
+            Write-Error "Release v$env:VERSION not found"
             exit 1
           }
-          Write-Host "Found release v${{ inputs.version }}"
+          Write-Host "Found release v$env:VERSION"
 
       - name: Check if manifest exists in winget-pkgs
+        if: env.SKIP != 'true'
         id: check-manifest
         shell: pwsh
         run: |
@@ -45,11 +71,12 @@ jobs:
           }
 
       - name: Get checksums from release
+        if: env.SKIP != 'true'
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          $version = "${{ inputs.version }}"
+          $version = $env:VERSION
           gh release download "v$version" --repo open-cli-collective/google-readonly --pattern "checksums.txt" --dir .
 
           $checksums = Get-Content checksums.txt
@@ -63,10 +90,10 @@ jobs:
           echo "ARM64_HASH=$arm64Hash" >> $env:GITHUB_ENV
 
       - name: Update manifest (existing package)
-        if: steps.check-manifest.outputs.exists == 'true'
+        if: env.SKIP != 'true' && steps.check-manifest.outputs.exists == 'true'
         shell: pwsh
         run: |
-          $version = "${{ inputs.version }}"
+          $version = $env:VERSION
           $x64 = "https://github.com/open-cli-collective/google-readonly/releases/download/v$version/gro_v${version}_windows_amd64.zip"
           $arm64 = "https://github.com/open-cli-collective/google-readonly/releases/download/v$version/gro_v${version}_windows_arm64.zip"
 
@@ -74,10 +101,10 @@ jobs:
           ./wingetcreate.exe update OpenCLICollective.google-readonly --version $version --urls $x64 $arm64 --submit --token ${{ secrets.WINGET_GITHUB_TOKEN }}
 
       - name: Create manifest (new package)
-        if: steps.check-manifest.outputs.exists == 'false'
+        if: env.SKIP != 'true' && steps.check-manifest.outputs.exists == 'false'
         shell: pwsh
         run: |
-          $version = "${{ inputs.version }}"
+          $version = $env:VERSION
           $manifestDir = "manifests"
           New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
 

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -18,9 +18,13 @@ jobs:
 
       - name: Resolve version
         shell: pwsh
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          if ("${{ github.event_name }}" -eq "release") {
-            $tag = "${{ github.event.release.tag_name }}"
+          if ($env:EVENT_NAME -eq "release") {
+            $tag = $env:RELEASE_TAG
             if ($tag -notmatch '^v\d') {
               Write-Host "Skipping: release tag '$tag' does not match v<digit>... pattern"
               echo "SKIP=true" >> $env:GITHUB_ENV
@@ -28,7 +32,7 @@ jobs:
             }
             $version = $tag -replace '^v',''
           } else {
-            $version = "${{ inputs.version }}"
+            $version = $env:INPUT_VERSION
           }
           if (-not $version) {
             Write-Error "version not provided"

--- a/cmd/gro/main.go
+++ b/cmd/gro/main.go
@@ -1,4 +1,8 @@
 // Package main is the entry point for the gro CLI.
+//
+// Distribution is fully automated: merges to main with feat:/fix: prefixes
+// trigger auto-release, which creates a GitHub release whose published
+// event fans out to homebrew, chocolatey, and winget publish workflows.
 package main
 
 import (

--- a/cmd/gro/main.go
+++ b/cmd/gro/main.go
@@ -1,8 +1,9 @@
 // Package main is the entry point for the gro CLI.
 //
 // Distribution is fully automated: merges to main with feat:/fix: prefixes
-// trigger auto-release, which creates a GitHub release whose published
-// event fans out to homebrew, chocolatey, and winget publish workflows.
+// trigger auto-release, which runs GoReleaser (handling Homebrew + binary
+// artifacts) and emits a release-published event that fans out to the
+// chocolatey and winget publish workflows.
 package main
 
 import (


### PR DESCRIPTION
Closes #117

## Summary

- Add `release: published` trigger to `chocolatey-publish.yml` and `winget-publish.yml` alongside existing `workflow_dispatch`.
- Switch `release.yml`'s goreleaser step to `TAP_GITHUB_TOKEN` so release creation fires downstream workflows (the default `GITHUB_TOKEN` does not).
- Derive `VERSION` from `inputs.version` (manual) or `github.event.release.tag_name` (auto, `v` prefix stripped). Non-`v<digit>` tags are skipped via `SKIP` env guard.
- Workflows stay in separate files with no `needs:` link, preserving the decoupling from commit `b3cfda2` that keeps Microsoft-hosted service flakiness off the binary release path.

## PR title gate (read me)

`auto-release.yml:21-24` checks `github.event.head_commit.message`, which on squash-merge is this PR's title. **Title must start with `feat:`** to trigger auto-release on merge — that's the e2e test for this PR.

## TAP_GITHUB_TOKEN preflight

`TAP_GITHUB_TOKEN` is an org-level secret already used by `auto-release.yml` to push tags. Creating a release needs the same `repo` scope, which is already in place. Rollback path: revert the one-line token change on `release.yml:38` if goreleaser fails.

## Bundled test commit

`cmd/gro/main.go` gets a one-line package-doc note that distribution is now fully automated. This is intentional: `auto-release.yml`'s path filter requires a `**.go`/`go.mod`/`go.sum` change to fire, so without it merging this PR would produce no release and the new auto-trigger would go untested.

## Test plan

- [x] `make check` (tidy + lint + test + build) green
- [x] `actionlint` clean on changed workflows (pre-existing `if: false` snap-job warning unrelated)
- [ ] After merge: `auto-release.yml` fires → `release.yml` creates release with `TAP_GITHUB_TOKEN` → `chocolatey-publish.yml` and `winget-publish.yml` runs appear with `event: release`
- [ ] Confirm new version on chocolatey.org and Microsoft Winget