### PR TITLE
fix(auth): add missing profile scope for people/me verification

### DIFF
--- a/internal/architecture/architecture_test.go
+++ b/internal/architecture/architecture_test.go
@@ -316,6 +316,7 @@ var allowedScopes = map[string]bool{
 	"https://www.googleapis.com/auth/calendar.events":   true, // RSVP, color (NOT calendar settings)
 	"https://www.googleapis.com/auth/contacts.readonly": true,
 	"https://www.googleapis.com/auth/contacts":          true, // group membership, starring (NOT create/delete contacts)
+	"https://www.googleapis.com/auth/userinfo.profile":  true, // read authenticated user's name/email for people/me (NOT contacts list)
 	"https://www.googleapis.com/auth/drive.readonly":    true,
 	"https://www.googleapis.com/auth/drive.metadata":    true, // star/unstar files (NOT file content write)
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -26,11 +26,13 @@ import (
 // The architecture test (TestNoDestructiveAPIMethodsInProductionCode) prevents accidental misuse.
 // Contacts uses the full contacts scope for group management and starring.
 // The contacts scope is a superset of contacts.readonly — it includes all read access.
+// Profile is required for people/me (names, emailAddresses fields) used by `gro me` and init verification.
 var AllScopes = []string{
 	gmail.GmailModifyScope,
 	calendar.CalendarReadonlyScope,
 	calendar.CalendarEventsScope,
 	people.ContactsScope,
+	people.UserinfoProfileScope,
 	drive.DriveReadonlyScope,
 	drive.DriveMetadataScope,
 }
@@ -43,6 +45,7 @@ var ScopeDescriptions = map[string]string{
 	calendar.CalendarEventsScope:   "Calendar Events — read and update events (RSVP, color). No calendar settings access.",
 	people.ContactsScope:           "Contacts — read contacts and groups, plus manage group membership and starring.",
 	people.ContactsReadonlyScope:   "Contacts Read-Only — read contacts and groups.",
+	people.UserinfoProfileScope:    "Profile — read the authenticated user's name and email address (required for 'gro me').",
 	drive.DriveReadonlyScope:       "Drive Read-Only — read files and metadata.",
 	drive.DriveMetadataScope:       "Drive Metadata — read and update file metadata (star/unstar). No file content write access.",
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -101,8 +101,8 @@ func TestDeprecatedWrappers(t *testing.T) {
 
 func TestAllScopes(t *testing.T) {
 	t.Parallel()
-	if len(AllScopes) != 6 {
-		t.Errorf("got length %d, want %d", len(AllScopes), 6)
+	if len(AllScopes) != 7 {
+		t.Errorf("got length %d, want %d", len(AllScopes), 7)
 	}
 	scopeSet := strings.Join(AllScopes, " ")
 	if !strings.Contains(scopeSet, "https://www.googleapis.com/auth/gmail.modify") {
@@ -122,6 +122,9 @@ func TestAllScopes(t *testing.T) {
 	}
 	if !strings.Contains(scopeSet, "https://www.googleapis.com/auth/drive.metadata") {
 		t.Errorf("expected AllScopes to contain %q", "https://www.googleapis.com/auth/drive.metadata")
+	}
+	if !strings.Contains(scopeSet, "https://www.googleapis.com/auth/userinfo.profile") {
+		t.Errorf("expected AllScopes to contain %q", "https://www.googleapis.com/auth/userinfo.profile")
 	}
 }
 


### PR DESCRIPTION
## What

Adds `people.UserinfoProfileScope` (`https://www.googleapis.com/auth/userinfo.profile`) to `AllScopes` and `ScopeDescriptions` in `internal/auth/auth.go`.

## Why

`gro init` verifies each Google API after OAuth by making a live call. The People API verification calls `people/me` with `PersonFields("names,emailAddresses")` — this also powers `gro me`. Google requires the `userinfo.profile` scope for this endpoint; the `contacts` scope only grants access to the user's contacts list, not their own profile.

Without this fix, `gro init` always exits with a 403 on the People API verification step:

```
Error: verifying People API: googleapi: Error 403: The caller does not have permission
to request "people/me". Request requires one of the following scopes: [profile].
```

This makes fresh credential setup completely broken for anyone following the setup instructions.

## Migration

Existing users with a stored token will need to re-authenticate after upgrading:

```bash
gro config clear && gro init
```

Closes #119