### PR TITLE
feat(init): add audience prompt for admin-provided vs DIY OAuth setup

### DIFF
--- a/internal/cmd/initcmd/init.go
+++ b/internal/cmd/initcmd/init.go
@@ -44,7 +44,7 @@ func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Set up Google API authentication",
-		Long: `Guided OAuth setup. Walks you through:
+		Long: fmt.Sprintf(`Guided OAuth setup. Walks you through:
 
   1. Reading your downloaded OAuth client JSON (clipboard, paste, or file path).
   2. Opening the consent URL in your browser.
@@ -60,10 +60,10 @@ The wizard first asks how you're getting your credentials.json:
 
 If you're a Google Workspace admin and want to set up one Internal OAuth app
 for your whole org, see:
-  https://github.com/open-cli-collective/google-readonly/blob/main/WORKSPACE_ADMINS.md
+  %s
 
 You can also copy your credentials.json to the clipboard and run 'gro init' —
-it will read, validate, and write it to the config directory for you.`,
+it will read, validate, and write it to the config directory for you.`, workspaceAdminsURL),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runWith(cmd.Context(), defaultDeps(), opts)
@@ -451,7 +451,7 @@ func ensureCredentials(d initDeps, opts *initOptions, credPath string) error {
 		d.View.Println("Optional: publish your OAuth app to avoid 7-day token expiry.")
 		d.View.Println("")
 		d.View.Println("Workspace admin? Set up an Internal OAuth app once for your whole org:")
-		d.View.Println("  https://github.com/open-cli-collective/google-readonly/blob/main/WORKSPACE_ADMINS.md")
+		d.View.Println("  " + workspaceAdminsURL)
 	default:
 		return fmt.Errorf("unknown audience: %s", audience)
 	}
@@ -585,6 +585,11 @@ func isAuthError(err error) bool {
 }
 
 var errorAs = errors.As
+
+// workspaceAdminsURL points to the repo's Workspace-admin walkthrough.
+// Referenced from both cmd.Long and the runtime wizard, so installed-CLI
+// users (Homebrew/Chocolatey/Winget) reach it without a local checkout.
+const workspaceAdminsURL = "https://github.com/open-cli-collective/google-readonly/blob/main/WORKSPACE_ADMINS.md"
 
 // huhPrompter is the production prompter — wraps huh.
 type huhPrompter struct{}

--- a/internal/cmd/initcmd/init.go
+++ b/internal/cmd/initcmd/init.go
@@ -52,15 +52,17 @@ func NewCommand() *cobra.Command {
 
 After setup, run 'gro me' to see who you're authenticated as.
 
-Prerequisites — at https://console.cloud.google.com:
-  - Create a project and enable: Gmail API, Google Calendar API,
-    Google Drive API, and People API (used for both 'gro contacts'
-    and 'gro me').
-  - Create OAuth 2.0 Desktop-app credentials and download the JSON.
+The wizard first asks how you're getting your credentials.json:
+  - Admin-provided (e.g. via 1Password): paste or point to the file.
+  - DIY: walks you through creating a Google Cloud project yourself,
+    enabling the Gmail API, Google Calendar API, Google Drive API, and
+    People API, and downloading OAuth 2.0 Desktop-app credentials.
 
-You can copy that JSON to your clipboard and run 'gro init' — it will read,
-validate, and write it to the config directory for you. No need to download
-the file separately.`,
+If you're a Google Workspace admin and want to set up one Internal OAuth app
+for your whole org, see WORKSPACE_ADMINS.md in the repository.
+
+You can also copy your credentials.json to the clipboard and run 'gro init' —
+it will read, validate, and write it to the config directory for you.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runWith(cmd.Context(), defaultDeps(), opts)
@@ -119,6 +121,7 @@ type initDeps struct {
 // prompter abstracts huh's interactive prompts so tests can drive the
 // wizard with deterministic inputs.
 type prompter interface {
+	SelectAudience() (string, error)                          // returns "admin" | "diy"
 	SelectCredSource(clipboardSupported bool) (string, error) // returns "clipboard" | "paste" | "file"
 	PasteJSON() (string, error)
 	FilePath() (string, error)
@@ -424,16 +427,30 @@ func ensureCredentials(d initDeps, opts *initOptions, credPath string) error {
 		return nil
 	}
 
-	// Otherwise drive the wizard.
+	// Otherwise drive the wizard. Ask once whether the user is admin-provisioned
+	// or doing their own Google Cloud setup, so we only show the steps they need.
+	audience, err := d.Prompter.SelectAudience()
+	if err != nil {
+		return err
+	}
+
 	d.View.Println("")
-	d.View.Println("Set up Google OAuth credentials at https://console.cloud.google.com:")
-	d.View.Println("  1. Create or select a project.")
-	d.View.Println("  2. Enable APIs: Gmail, Google Calendar, Google Drive, and People")
-	d.View.Println("     (the People API powers both 'gro contacts' and 'gro me').")
-	d.View.Println("  3. Create OAuth 2.0 Desktop-app credentials.")
-	d.View.Println("  4. Copy the JSON to your clipboard, OR download the JSON file.")
-	d.View.Println("")
-	d.View.Println("Optional: publish your OAuth app to avoid 7-day token expiry.")
+	if audience == "admin" {
+		d.View.Println("Your admin should have shared credentials.json (e.g. via 1Password).")
+		d.View.Println("Paste the JSON, or point to the file when prompted.")
+	} else {
+		d.View.Println("Set up Google OAuth credentials at https://console.cloud.google.com:")
+		d.View.Println("  1. Create or select a project.")
+		d.View.Println("  2. Enable APIs: Gmail, Google Calendar, Google Drive, and People")
+		d.View.Println("     (the People API powers both 'gro contacts' and 'gro me').")
+		d.View.Println("  3. Create OAuth 2.0 Desktop-app credentials.")
+		d.View.Println("  4. Copy the JSON to your clipboard, OR download the JSON file.")
+		d.View.Println("")
+		d.View.Println("Optional: publish your OAuth app to avoid 7-day token expiry.")
+		d.View.Println("")
+		d.View.Println("Workspace admin? Set up an Internal OAuth app once for your whole org:")
+		d.View.Println("  https://github.com/open-cli-collective/google-readonly/blob/main/WORKSPACE_ADMINS.md")
+	}
 	d.View.Println("")
 
 	// Up to 3 attempts to recover from *content* errors (unreadable
@@ -567,6 +584,19 @@ var errorAs = errors.As
 
 // huhPrompter is the production prompter — wraps huh.
 type huhPrompter struct{}
+
+func (huhPrompter) SelectAudience() (string, error) {
+	var choice string
+	err := huh.NewSelect[string]().
+		Title("How are you getting your OAuth credentials?").
+		Options(
+			huh.NewOption("My admin gave me a credentials.json (e.g. via 1Password)", "admin"),
+			huh.NewOption("I'll set up my own Google Cloud project", "diy"),
+		).
+		Value(&choice).
+		Run()
+	return choice, err
+}
 
 func (huhPrompter) SelectCredSource(clipboardSupported bool) (string, error) {
 	options := []huh.Option[string]{}

--- a/internal/cmd/initcmd/init.go
+++ b/internal/cmd/initcmd/init.go
@@ -59,7 +59,8 @@ The wizard first asks how you're getting your credentials.json:
     People API, and downloading OAuth 2.0 Desktop-app credentials.
 
 If you're a Google Workspace admin and want to set up one Internal OAuth app
-for your whole org, see WORKSPACE_ADMINS.md in the repository.
+for your whole org, see:
+  https://github.com/open-cli-collective/google-readonly/blob/main/WORKSPACE_ADMINS.md
 
 You can also copy your credentials.json to the clipboard and run 'gro init' —
 it will read, validate, and write it to the config directory for you.`,
@@ -435,10 +436,11 @@ func ensureCredentials(d initDeps, opts *initOptions, credPath string) error {
 	}
 
 	d.View.Println("")
-	if audience == "admin" {
+	switch audience {
+	case "admin":
 		d.View.Println("Your admin should have shared credentials.json (e.g. via 1Password).")
 		d.View.Println("Paste the JSON, or point to the file when prompted.")
-	} else {
+	case "diy":
 		d.View.Println("Set up Google OAuth credentials at https://console.cloud.google.com:")
 		d.View.Println("  1. Create or select a project.")
 		d.View.Println("  2. Enable APIs: Gmail, Google Calendar, Google Drive, and People")
@@ -450,6 +452,8 @@ func ensureCredentials(d initDeps, opts *initOptions, credPath string) error {
 		d.View.Println("")
 		d.View.Println("Workspace admin? Set up an Internal OAuth app once for your whole org:")
 		d.View.Println("  https://github.com/open-cli-collective/google-readonly/blob/main/WORKSPACE_ADMINS.md")
+	default:
+		return fmt.Errorf("unknown audience: %s", audience)
 	}
 	d.View.Println("")
 

--- a/internal/cmd/initcmd/init_test.go
+++ b/internal/cmd/initcmd/init_test.go
@@ -137,6 +137,7 @@ func TestValidateOAuthJSONRejectsGarbage(t *testing.T) {
 
 // stubPrompter records calls and returns canned values.
 type stubPrompter struct {
+	audience    string
 	credChoice  string
 	pasteJSON   string
 	filePath    string
@@ -149,6 +150,14 @@ type stubPrompter struct {
 	filePathErr  error
 
 	calls []string
+}
+
+func (s *stubPrompter) SelectAudience() (string, error) {
+	s.calls = append(s.calls, "audience")
+	if s.audience == "" {
+		return "diy", nil
+	}
+	return s.audience, nil
 }
 
 func (s *stubPrompter) SelectCredSource(_ bool) (string, error) {
@@ -286,7 +295,8 @@ func TestEnsureCredentialsFlagFile(t *testing.T) {
 	}
 	dst, _ := d.GetCredentialsPath()
 
-	d.Prompter = &stubPrompter{}
+	stub := &stubPrompter{}
+	d.Prompter = stub
 	if err := ensureCredentials(d, &initOptions{credentialsFile: src}, dst); err != nil {
 		t.Fatalf("ensureCredentials: %v", err)
 	}
@@ -299,6 +309,10 @@ func TestEnsureCredentialsFlagFile(t *testing.T) {
 	}
 	if perm := fs.perms[dst]; perm != 0600 {
 		t.Errorf("expected perms 0600, got %o", perm)
+	}
+	// --credentials-file bypasses the wizard entirely; audience must not be asked.
+	if contains(stub.calls, "audience") {
+		t.Errorf("expected --credentials-file bypass; SelectAudience was called: calls=%v", stub.calls)
 	}
 }
 
@@ -396,6 +410,91 @@ func TestEnsureCredentialsShortCircuitsWhenAlreadyPresent(t *testing.T) {
 	// SelectCredSource (the wizard's first prompt) must NOT have fired.
 	if contains(stub.calls, "select") {
 		t.Errorf("expected wizard short-circuit, but SelectCredSource was called: calls=%v", stub.calls)
+	}
+	// Audience prompt must not be reached before the credentials.json short-circuit.
+	if contains(stub.calls, "audience") {
+		t.Errorf("expected short-circuit before audience prompt; calls=%v", stub.calls)
+	}
+}
+
+func TestEnsureCredentialsAudienceAdminSkipsDIYSteps(t *testing.T) {
+	t.Parallel()
+	fs := newFakeFS()
+	d := baseDeps(t, fs)
+	out := &bytes.Buffer{}
+	d.View = view.NewWithWriters(out, &bytes.Buffer{})
+	dst, _ := d.GetCredentialsPath()
+	d.Prompter = &stubPrompter{audience: "admin", credChoice: "paste", pasteJSON: validOAuthJSON}
+
+	if err := ensureCredentials(d, &initOptions{}, dst); err != nil {
+		t.Fatalf("ensureCredentials: %v", err)
+	}
+	got := out.String()
+	if strings.Contains(got, "Enable APIs: Gmail") {
+		t.Errorf("admin audience should not show DIY steps; output:\n%s", got)
+	}
+	if !strings.Contains(got, "Your admin should have shared credentials.json") {
+		t.Errorf("admin audience should show the admin-provisioned one-liner; output:\n%s", got)
+	}
+}
+
+func TestEnsureCredentialsAudienceDIYShowsDIYStepsAndAdminPointer(t *testing.T) {
+	t.Parallel()
+	fs := newFakeFS()
+	d := baseDeps(t, fs)
+	out := &bytes.Buffer{}
+	d.View = view.NewWithWriters(out, &bytes.Buffer{})
+	dst, _ := d.GetCredentialsPath()
+	d.Prompter = &stubPrompter{audience: "diy", credChoice: "paste", pasteJSON: validOAuthJSON}
+
+	if err := ensureCredentials(d, &initOptions{}, dst); err != nil {
+		t.Fatalf("ensureCredentials: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Enable APIs: Gmail") {
+		t.Errorf("diy audience should show DIY steps; output:\n%s", got)
+	}
+	if !strings.Contains(got, "WORKSPACE_ADMINS.md") {
+		t.Errorf("diy audience should show the Workspace admin doc pointer; output:\n%s", got)
+	}
+}
+
+func TestEnsureCredentialsAudienceIsAskedOncePerWizard(t *testing.T) {
+	t.Parallel()
+	fs := newFakeFS()
+	d := baseDeps(t, fs)
+	d.ClipboardSupported = func() bool { return true }
+	// First clipboard read returns invalid JSON, second returns valid. This
+	// forces the wizard's retry loop to run twice while audience must remain
+	// sticky.
+	reads := []string{"not valid json", validOAuthJSON}
+	idx := 0
+	d.ClipboardReadAll = func() (string, error) {
+		s := reads[idx]
+		idx++
+		return s, nil
+	}
+	dst, _ := d.GetCredentialsPath()
+	stub := &stubPrompter{audience: "admin", credChoice: "clipboard"}
+	d.Prompter = stub
+
+	if err := ensureCredentials(d, &initOptions{}, dst); err != nil {
+		t.Fatalf("ensureCredentials: %v", err)
+	}
+	gotAudience, gotSelect := 0, 0
+	for _, c := range stub.calls {
+		switch c {
+		case "audience":
+			gotAudience++
+		case "select":
+			gotSelect++
+		}
+	}
+	if gotAudience != 1 {
+		t.Errorf("expected SelectAudience called exactly once, got %d; calls=%v", gotAudience, stub.calls)
+	}
+	if gotSelect != 2 {
+		t.Errorf("expected SelectCredSource called exactly twice (retry), got %d; calls=%v", gotSelect, stub.calls)
 	}
 }
 

--- a/internal/cmd/initcmd/init_test.go
+++ b/internal/cmd/initcmd/init_test.go
@@ -466,10 +466,14 @@ func TestEnsureCredentialsAudienceIsAskedOncePerWizard(t *testing.T) {
 	d.ClipboardSupported = func() bool { return true }
 	// First clipboard read returns invalid JSON, second returns valid. This
 	// forces the wizard's retry loop to run twice while audience must remain
-	// sticky.
+	// sticky. Bounds-check: if the wizard reads more than twice (e.g. a future
+	// retry-cap change), fail cleanly instead of panicking.
 	reads := []string{"not valid json", validOAuthJSON}
 	idx := 0
 	d.ClipboardReadAll = func() (string, error) {
+		if idx >= len(reads) {
+			t.Fatalf("unexpected extra ClipboardReadAll call #%d; wizard should have succeeded after 2 reads", idx+1)
+		}
 		s := reads[idx]
 		idx++
 		return s, nil

--- a/internal/cmd/initcmd/init_test.go
+++ b/internal/cmd/initcmd/init_test.go
@@ -454,8 +454,8 @@ func TestEnsureCredentialsAudienceDIYShowsDIYStepsAndAdminPointer(t *testing.T) 
 	if !strings.Contains(got, "Enable APIs: Gmail") {
 		t.Errorf("diy audience should show DIY steps; output:\n%s", got)
 	}
-	if !strings.Contains(got, "WORKSPACE_ADMINS.md") {
-		t.Errorf("diy audience should show the Workspace admin doc pointer; output:\n%s", got)
+	if !strings.Contains(got, "https://github.com/open-cli-collective/google-readonly/blob/main/WORKSPACE_ADMINS.md") {
+		t.Errorf("diy audience should show the fully-qualified Workspace admin doc URL (so Homebrew/Choco users can reach it); output:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a top-level `SelectAudience` prompt to `gro init` that routes users between two prefatory messages: admin-provisioned (paste/point to credentials.json shared via 1Password etc.) and DIY (the existing Google Cloud Console setup steps, now augmented with a pointer to `WORKSPACE_ADMINS.md` for admins who'd rather provision once for their whole org).
- Both paths fall into the same `SelectCredSource` → save logic. `--credentials-file` still bypasses the wizard entirely.
- `SelectAudience` is asked exactly once per wizard invocation — sticky across credential-validation retries.

## Why now

PR #122 merged `WORKSPACE_ADMINS.md`. Today, every user who runs `gro init` sees Google Cloud Console setup steps even if their admin already handed them a credentials.json. This PR aligns the wizard with the new doc so neither audience reads past content they don't need.

## Tests

Three new tests in `init_test.go`:
- `TestEnsureCredentialsAudienceAdminSkipsDIYSteps` — admin audience does not print the 7-line DIY block but does print the admin one-liner.
- `TestEnsureCredentialsAudienceDIYShowsDIYStepsAndAdminPointer` — DIY audience prints the existing block plus a fully-qualified link to WORKSPACE_ADMINS.md on GitHub.
- `TestEnsureCredentialsAudienceIsAskedOncePerWizard` — sticky behavior: clipboard returns invalid JSON on call 1 and valid JSON on call 2; \`audience\` is called exactly once and \`select\` exactly twice across the retry.

Two existing bypass tests extended to assert \`audience\` is NOT called:
- \`TestEnsureCredentialsFlagFile\` (--credentials-file bypass)
- \`TestEnsureCredentialsShortCircuitsWhenAlreadyPresent\` (existing creds.json bypass)

## Test plan

- [ ] \`make check\` passes (was green locally; 49 tests pass in initcmd)
- [ ] Manual: \`rm -f ~/.config/google-readonly/credentials.json && gro config clear\` then \`gro init\` — admin path shows no DIY block, DIY path shows block + admin doc URL.

Closes #123