### PR TITLE
refactor: relocate Drive metadata cache to the OS cache dir (B2b)

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,10 +543,12 @@ Usage: gro config test
 
 ### gro config clear
 
-Remove stored OAuth token (forces re-authentication).
+Remove the stored OAuth token (forces re-authentication). `--all` also removes
+`config.yml` and the Drive metadata cache; `--dry-run` reports what would be
+removed without removing anything.
 
 ```
-Usage: gro config clear
+Usage: gro config clear [--all] [--dry-run]
 ```
 
 ### gro config cache show
@@ -1262,6 +1264,13 @@ gro config cache clear
 # Change cache TTL
 gro config cache ttl 12    # Set to 12 hours
 ```
+
+The cache lives in the OS cache directory — `$XDG_CACHE_HOME/google-readonly`
+(or `~/.cache/google-readonly`) on Linux, `~/Library/Caches/google-readonly`
+on macOS, `%LocalAppData%\google-readonly` on Windows — kept separate from
+your config. A cache left by an older gro version (inside the config dir) is
+relocated automatically on first use; `gro config clear --all` also clears the
+Drive metadata cache.
 
 The cache is automatically repopulated when stale or after being cleared.
 

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -13,8 +13,6 @@ import (
 const (
 	// DefaultTTLHours is the default cache TTL if not configured
 	DefaultTTLHours = 24
-	// CacheDir is the subdirectory within config for cache files
-	CacheDir = "cache"
 	// DrivesFile is the cache file for shared drives
 	DrivesFile = "drives.json"
 )
@@ -38,17 +36,17 @@ type Cache struct {
 	ttlHours int
 }
 
-// New creates a new Cache instance
+// New creates a new Cache instance rooted at the OS cache dir (B2b). It also
+// runs a transparent, best-effort one-time relocation of a pre-B2b cache that
+// lived inside the config dir; relocation never fails New (the cache is
+// disposable — it simply repopulates).
 func New(ttlHours int) (*Cache, error) {
-	configDir, err := config.GetConfigDir()
+	cacheDir, err := config.GetCacheDir()
 	if err != nil {
 		return nil, err
 	}
 
-	cacheDir := filepath.Join(configDir, CacheDir)
-	if err := os.MkdirAll(cacheDir, config.DirPerm); err != nil {
-		return nil, err
-	}
+	migrateLegacyCacheDir(cacheDir)
 
 	if ttlHours <= 0 {
 		ttlHours = DefaultTTLHours
@@ -58,6 +56,33 @@ func New(ttlHours int) (*Cache, error) {
 		dir:      cacheDir,
 		ttlHours: ttlHours,
 	}, nil
+}
+
+// migrateLegacyCacheDir relocates a pre-B2b cache (a "cache" subdir of the
+// config dir) into newDir, then removes the legacy dir. Strictly silent and
+// best-effort: any failure is abandoned without touching New's result. If the
+// warm-cache carry fails the legacy dir is left intact (don't delete data we
+// could not carry); a stuck legacy dir is force-cleaned by `config clear
+// --all`. Idempotent: once the legacy dir is gone this is a single stat.
+func migrateLegacyCacheDir(newDir string) {
+	legacy, err := config.LegacyCacheDir()
+	if err != nil {
+		return
+	}
+	if _, err := os.Stat(legacy); err != nil {
+		return // absent (steady state) or unreadable — nothing safe to do
+	}
+
+	legacyDrives := filepath.Join(legacy, DrivesFile)
+	newDrives := filepath.Join(newDir, DrivesFile)
+	if _, err := os.Stat(newDrives); os.IsNotExist(err) {
+		if data, rerr := os.ReadFile(legacyDrives); rerr == nil { //nolint:gosec // G304: path from config dir, not user input
+			if werr := os.WriteFile(newDrives, data, config.TokenPerm); werr != nil { //nolint:gosec // G703: config-derived cache path, user's own disposable data
+				return // carry failed: keep legacy intact, try again next run
+			}
+		}
+	}
+	_ = os.RemoveAll(legacy) // best-effort; cosmetic if it lingers
 }
 
 // GetDrives returns cached shared drives, or nil if cache is stale or missing

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -75,11 +75,18 @@ func migrateLegacyCacheDir(newDir string) {
 
 	legacyDrives := filepath.Join(legacy, DrivesFile)
 	newDrives := filepath.Join(newDir, DrivesFile)
-	if _, err := os.Stat(newDrives); os.IsNotExist(err) {
-		if data, rerr := os.ReadFile(legacyDrives); rerr == nil { //nolint:gosec // G304: path from config dir, not user input
+	if _, serr := os.Stat(newDrives); os.IsNotExist(serr) {
+		// New cache absent: try to carry the warm legacy file.
+		data, rerr := os.ReadFile(legacyDrives) //nolint:gosec // G304: path from config dir, not user input
+		switch {
+		case rerr == nil:
 			if werr := os.WriteFile(newDrives, data, config.TokenPerm); werr != nil { //nolint:gosec // G703: config-derived cache path, user's own disposable data
-				return // carry failed: keep legacy intact, try again next run
+				return // carry failed: keep legacy intact, retry next run
 			}
+		case os.IsNotExist(rerr):
+			// No warm file to carry — fine, fall through to cleanup.
+		default:
+			return // legacy drives file exists but unreadable: do NOT delete it
 		}
 	}
 	_ = os.RemoveAll(legacy) // best-effort; cosmetic if it lingers

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -75,7 +75,10 @@ func migrateLegacyCacheDir(newDir string) {
 
 	legacyDrives := filepath.Join(legacy, DrivesFile)
 	newDrives := filepath.Join(newDir, DrivesFile)
-	if _, serr := os.Stat(newDrives); os.IsNotExist(serr) {
+	switch _, serr := os.Stat(newDrives); {
+	case serr == nil:
+		// New cache already present: nothing to carry, safe to drop legacy.
+	case os.IsNotExist(serr):
 		// New cache absent: try to carry the warm legacy file.
 		data, rerr := os.ReadFile(legacyDrives) //nolint:gosec // G304: path from config dir, not user input
 		switch {
@@ -88,6 +91,8 @@ func migrateLegacyCacheDir(newDir string) {
 		default:
 			return // legacy drives file exists but unreadable: do NOT delete it
 		}
+	default:
+		return // ambiguous stat on the new path: do not risk deleting un-carried legacy
 	}
 	_ = os.RemoveAll(legacy) // best-effort; cosmetic if it lingers
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -7,10 +7,26 @@ import (
 	"testing"
 	"time"
 
+	"github.com/open-cli-collective/google-readonly/internal/config"
 	"github.com/open-cli-collective/google-readonly/internal/testutil"
 )
 
+// hermetic isolates every cache path resolver from the developer's real
+// dirs (also fixes a pre-existing pollution bug). Covers all OSes
+// os.UserCacheDir / config dir resolution can consult: HOME (macOS
+// ~/Library/Caches), XDG_CACHE_HOME (Linux/CI), LOCALAPPDATA (Windows),
+// XDG_CONFIG_HOME (legacy-cache-dir resolution).
+func hermetic(t *testing.T) {
+	t.Helper()
+	d := t.TempDir()
+	t.Setenv("HOME", d)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(d, "xcache"))
+	t.Setenv("LOCALAPPDATA", filepath.Join(d, "localappdata"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(d, "xconfig"))
+}
+
 func TestNew(t *testing.T) {
+	hermetic(t)
 	t.Run("creates cache with default TTL", func(t *testing.T) {
 		c, err := New(0)
 		testutil.NoError(t, err)
@@ -37,6 +53,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestCache_GetSetDrives(t *testing.T) {
+	hermetic(t)
 	c, err := New(24)
 	testutil.NoError(t, err)
 	defer c.Clear()
@@ -67,6 +84,7 @@ func TestCache_GetSetDrives(t *testing.T) {
 }
 
 func TestCache_Expiration(t *testing.T) {
+	hermetic(t)
 	c, err := New(1) // 1 hour TTL
 	testutil.NoError(t, err)
 	defer c.Clear()
@@ -118,6 +136,7 @@ func TestCache_Expiration(t *testing.T) {
 }
 
 func TestCache_CorruptedCache(t *testing.T) {
+	hermetic(t)
 	c, err := New(24)
 	testutil.NoError(t, err)
 	defer c.Clear()
@@ -134,6 +153,7 @@ func TestCache_CorruptedCache(t *testing.T) {
 }
 
 func TestCache_Clear(t *testing.T) {
+	hermetic(t)
 	c, err := New(24)
 	testutil.NoError(t, err)
 
@@ -156,6 +176,7 @@ func TestCache_Clear(t *testing.T) {
 }
 
 func TestCache_GetStatus(t *testing.T) {
+	hermetic(t)
 	c, err := New(24)
 	testutil.NoError(t, err)
 	defer c.Clear()
@@ -202,10 +223,78 @@ func TestCache_GetStatus(t *testing.T) {
 }
 
 func TestCache_GetDir(t *testing.T) {
+	hermetic(t)
 	c, err := New(24)
 	testutil.NoError(t, err)
 	defer c.Clear()
 
+	// Assert the exact resolved path, not a substring: with no Windows
+	// \Cache suffix and macOS ~/Library/Caches there is no portable
+	// "cache" substring (Codex Minor-2).
+	want, err := config.CacheDirPath()
+	testutil.NoError(t, err)
 	testutil.NotEmpty(t, c.GetDir())
-	testutil.Contains(t, c.GetDir(), "cache")
+	testutil.Equal(t, c.GetDir(), want)
+}
+
+func TestMigrateLegacyCacheDir(t *testing.T) {
+	hermetic(t)
+
+	legacy, err := config.LegacyCacheDir()
+	testutil.NoError(t, err)
+	newDir, err := config.CacheDirPath()
+	testutil.NoError(t, err)
+
+	seedLegacy := func(t *testing.T, payload string) {
+		t.Helper()
+		testutil.NoError(t, os.MkdirAll(legacy, 0o700))
+		testutil.NoError(t, os.WriteFile(filepath.Join(legacy, DrivesFile), []byte(payload), 0o600))
+	}
+
+	t.Run("carries warm cache then removes legacy", func(t *testing.T) {
+		seedLegacy(t, `{"cached_at":"2026-01-01T00:00:00Z","ttl_hours":24,"drives":[{"id":"d1","name":"Eng"}]}`)
+
+		c, err := New(24)
+		testutil.NoError(t, err)
+		defer c.Clear()
+
+		got, err := os.ReadFile(filepath.Join(newDir, DrivesFile))
+		testutil.NoError(t, err)
+		testutil.Contains(t, string(got), `"d1"`)
+		_, statErr := os.Stat(legacy)
+		testutil.True(t, os.IsNotExist(statErr)) // legacy removed
+
+		// Idempotent: a second New is a no-op and keeps the new cache.
+		c2, err := New(24)
+		testutil.NoError(t, err)
+		defer c2.Clear()
+		_, err = os.Stat(filepath.Join(newDir, DrivesFile))
+		testutil.NoError(t, err)
+	})
+
+	t.Run("does not overwrite an existing new cache; still removes legacy", func(t *testing.T) {
+		// New cache already warm with distinct content.
+		c, err := New(24)
+		testutil.NoError(t, err)
+		defer c.Clear()
+		testutil.NoError(t, c.SetDrives([]*CachedDrive{{ID: "new", Name: "Keep"}}))
+		seedLegacy(t, `{"drives":[{"id":"old","name":"Stale"}]}`)
+
+		c2, err := New(24)
+		testutil.NoError(t, err)
+		defer c2.Clear()
+
+		drives, err := c2.GetDrives()
+		testutil.NoError(t, err)
+		testutil.Len(t, drives, 1)
+		testutil.Equal(t, drives[0].ID, "new") // not overwritten by legacy
+		_, statErr := os.Stat(legacy)
+		testutil.True(t, os.IsNotExist(statErr)) // legacy still removed
+	})
+
+	t.Run("no legacy is a clean no-op", func(t *testing.T) {
+		c, err := New(24)
+		testutil.NoError(t, err) // migration never fails New
+		defer c.Clear()
+	})
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -238,21 +238,27 @@ func TestCache_GetDir(t *testing.T) {
 }
 
 func TestMigrateLegacyCacheDir(t *testing.T) {
-	hermetic(t)
-
-	legacy, err := config.LegacyCacheDir()
-	testutil.NoError(t, err)
-	newDir, err := config.CacheDirPath()
-	testutil.NoError(t, err)
-
-	seedLegacy := func(t *testing.T, payload string) {
+	// Each subtest fully isolates its own fixtures: a fresh hermetic env +
+	// freshly-resolved legacy/newDir, so there is no ordered-cleanup coupling
+	// between subtests.
+	setup := func(t *testing.T) (legacy, newDir string) {
+		t.Helper()
+		hermetic(t)
+		legacy, err := config.LegacyCacheDir()
+		testutil.NoError(t, err)
+		newDir, err = config.CacheDirPath()
+		testutil.NoError(t, err)
+		return legacy, newDir
+	}
+	seedLegacy := func(t *testing.T, legacy, payload string) {
 		t.Helper()
 		testutil.NoError(t, os.MkdirAll(legacy, 0o700))
 		testutil.NoError(t, os.WriteFile(filepath.Join(legacy, DrivesFile), []byte(payload), 0o600))
 	}
 
 	t.Run("carries warm cache then removes legacy", func(t *testing.T) {
-		seedLegacy(t, `{"cached_at":"2026-01-01T00:00:00Z","ttl_hours":24,"drives":[{"id":"d1","name":"Eng"}]}`)
+		legacy, newDir := setup(t)
+		seedLegacy(t, legacy, `{"cached_at":"2026-01-01T00:00:00Z","ttl_hours":24,"drives":[{"id":"d1","name":"Eng"}]}`)
 
 		c, err := New(24)
 		testutil.NoError(t, err)
@@ -273,12 +279,13 @@ func TestMigrateLegacyCacheDir(t *testing.T) {
 	})
 
 	t.Run("does not overwrite an existing new cache; still removes legacy", func(t *testing.T) {
+		legacy, _ := setup(t)
 		// New cache already warm with distinct content.
 		c, err := New(24)
 		testutil.NoError(t, err)
 		defer c.Clear()
 		testutil.NoError(t, c.SetDrives([]*CachedDrive{{ID: "new", Name: "Keep"}}))
-		seedLegacy(t, `{"drives":[{"id":"old","name":"Stale"}]}`)
+		seedLegacy(t, legacy, `{"drives":[{"id":"old","name":"Stale"}]}`)
 
 		c2, err := New(24)
 		testutil.NoError(t, err)
@@ -292,7 +299,25 @@ func TestMigrateLegacyCacheDir(t *testing.T) {
 		testutil.True(t, os.IsNotExist(statErr)) // legacy still removed
 	})
 
+	t.Run("unreadable legacy drives file: legacy preserved, no partial carry", func(t *testing.T) {
+		legacy, newDir := setup(t)
+		// drives.json as a directory => os.ReadFile errors with a
+		// non-IsNotExist error => carry fails => legacy must NOT be removed
+		// and nothing must be written into the new cache.
+		testutil.NoError(t, os.MkdirAll(filepath.Join(legacy, DrivesFile), 0o700))
+
+		c, err := New(24)
+		testutil.NoError(t, err) // migration never fails New
+		defer c.Clear()
+
+		_, statErr := os.Stat(legacy)
+		testutil.NoError(t, statErr) // legacy left intact (not deleted)
+		_, newErr := os.Stat(filepath.Join(newDir, DrivesFile))
+		testutil.True(t, os.IsNotExist(newErr)) // no partial/corrupt carry
+	})
+
 	t.Run("no legacy is a clean no-op", func(t *testing.T) {
+		setup(t)
 		c, err := New(24)
 		testutil.NoError(t, err) // migration never fails New
 		defer c.Clear()

--- a/internal/cmd/config/behavior_test.go
+++ b/internal/cmd/config/behavior_test.go
@@ -152,7 +152,7 @@ func TestRunClearSemantics(t *testing.T) {
 		}
 	})
 
-	t.Run("--all force-cleans legacy even when the shim skipped it (carry-failed)", func(t *testing.T) {
+	t.Run("--all removes both the new and the legacy cache dirs directly", func(t *testing.T) {
 		seedTokenAndClient(t)
 		newDir, err := appconfig.CacheDirPath()
 		if err != nil {
@@ -162,9 +162,16 @@ func TestRunClearSemantics(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		// drives.json-as-dir => cache.New's shim carry fails and it leaves
-		// legacy intact. Only runClear's explicit RemoveAll(legacy) fallback
-		// can clean it — this exercises that fallback specifically.
+		// Seed both: a real new cache and a legacy dir whose drives.json is
+		// itself a directory (a state the migration shim refuses to carry).
+		// --all must remove BOTH directly (no cache.New / no migration).
+		c, err := cache.New(24)
+		if err != nil {
+			t.Fatalf("cache.New: %v", err)
+		}
+		if err := c.SetDrives([]*cache.CachedDrive{{ID: "d1", Name: "Eng"}}); err != nil {
+			t.Fatalf("SetDrives: %v", err)
+		}
 		if err := os.MkdirAll(filepath.Join(legacy, cache.DrivesFile), 0o700); err != nil {
 			t.Fatal(err)
 		}
@@ -175,7 +182,7 @@ func TestRunClearSemantics(t *testing.T) {
 			t.Fatalf("--all must remove the new Drive cache dir (stat err=%v)", err)
 		}
 		if _, err := os.Stat(legacy); !os.IsNotExist(err) {
-			t.Fatalf("--all must force-clean the carry-failed legacy cache dir (stat err=%v)", err)
+			t.Fatalf("--all must remove the legacy Drive cache dir (stat err=%v)", err)
 		}
 	})
 

--- a/internal/cmd/config/behavior_test.go
+++ b/internal/cmd/config/behavior_test.go
@@ -11,6 +11,7 @@ import (
 
 	"golang.org/x/oauth2"
 
+	"github.com/open-cli-collective/google-readonly/internal/cache"
 	appconfig "github.com/open-cli-collective/google-readonly/internal/config"
 	"github.com/open-cli-collective/google-readonly/internal/credtest"
 	"github.com/open-cli-collective/google-readonly/internal/keychain"
@@ -148,6 +149,88 @@ func TestRunClearSemantics(t *testing.T) {
 		_ = capture(t, func() { _ = runClear(true, false) })
 		if _, err := os.Stat(cfgPath); !os.IsNotExist(err) {
 			t.Fatal("--all must remove config.yml")
+		}
+	})
+
+	t.Run("--all removes the Drive cache (new + legacy)", func(t *testing.T) {
+		seedTokenAndClient(t)
+		c, err := cache.New(24)
+		if err != nil {
+			t.Fatalf("cache.New: %v", err)
+		}
+		if err := c.SetDrives([]*cache.CachedDrive{{ID: "d1", Name: "Eng"}}); err != nil {
+			t.Fatalf("SetDrives: %v", err)
+		}
+		newDir := c.GetDir()
+		legacy, err := appconfig.LegacyCacheDir()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(legacy, 0o700); err != nil {
+			t.Fatal(err)
+		}
+
+		_ = capture(t, func() { _ = runClear(true, false) })
+
+		if _, err := os.Stat(newDir); !os.IsNotExist(err) {
+			t.Fatalf("--all must remove the new Drive cache dir (stat err=%v)", err)
+		}
+		if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+			t.Fatalf("--all must force-clean the legacy cache dir (stat err=%v)", err)
+		}
+	})
+
+	t.Run("plain clear neither initializes nor migrates the cache", func(t *testing.T) {
+		seedTokenAndClient(t)
+		legacy, err := appconfig.LegacyCacheDir()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(legacy, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(legacy, cache.DrivesFile), []byte(`{"drives":[]}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		newDir, err := appconfig.CacheDirPath()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_ = capture(t, func() { _ = runClear(false, false) })
+
+		if _, err := os.Stat(legacy); err != nil {
+			t.Fatalf("plain clear must not migrate/remove the legacy cache (stat err=%v)", err)
+		}
+		if _, err := os.Stat(newDir); !os.IsNotExist(err) {
+			t.Fatalf("plain clear must not initialize the new cache dir (stat err=%v)", err)
+		}
+	})
+
+	t.Run("--dry-run --all creates and removes nothing, names the cache", func(t *testing.T) {
+		seedTokenAndClient(t)
+		legacy, err := appconfig.LegacyCacheDir()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(legacy, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		newDir, err := appconfig.CacheDirPath()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		out := capture(t, func() { _ = runClear(true, true) })
+
+		if _, err := os.Stat(legacy); err != nil {
+			t.Fatalf("--dry-run must not touch the legacy cache (stat err=%v)", err)
+		}
+		if _, err := os.Stat(newDir); !os.IsNotExist(err) {
+			t.Fatalf("--dry-run must not create the new cache dir (stat err=%v)", err)
+		}
+		if !strings.Contains(out, "Drive metadata cache") {
+			t.Fatalf("--dry-run --all output should name the Drive metadata cache, got:\n%s", out)
 		}
 	})
 }

--- a/internal/cmd/config/behavior_test.go
+++ b/internal/cmd/config/behavior_test.go
@@ -152,21 +152,20 @@ func TestRunClearSemantics(t *testing.T) {
 		}
 	})
 
-	t.Run("--all removes the Drive cache (new + legacy)", func(t *testing.T) {
+	t.Run("--all force-cleans legacy even when the shim skipped it (carry-failed)", func(t *testing.T) {
 		seedTokenAndClient(t)
-		c, err := cache.New(24)
+		newDir, err := appconfig.CacheDirPath()
 		if err != nil {
-			t.Fatalf("cache.New: %v", err)
+			t.Fatal(err)
 		}
-		if err := c.SetDrives([]*cache.CachedDrive{{ID: "d1", Name: "Eng"}}); err != nil {
-			t.Fatalf("SetDrives: %v", err)
-		}
-		newDir := c.GetDir()
 		legacy, err := appconfig.LegacyCacheDir()
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := os.MkdirAll(legacy, 0o700); err != nil {
+		// drives.json-as-dir => cache.New's shim carry fails and it leaves
+		// legacy intact. Only runClear's explicit RemoveAll(legacy) fallback
+		// can clean it — this exercises that fallback specifically.
+		if err := os.MkdirAll(filepath.Join(legacy, cache.DrivesFile), 0o700); err != nil {
 			t.Fatal(err)
 		}
 
@@ -176,7 +175,7 @@ func TestRunClearSemantics(t *testing.T) {
 			t.Fatalf("--all must remove the new Drive cache dir (stat err=%v)", err)
 		}
 		if _, err := os.Stat(legacy); !os.IsNotExist(err) {
-			t.Fatalf("--all must force-clean the legacy cache dir (stat err=%v)", err)
+			t.Fatalf("--all must force-clean the carry-failed legacy cache dir (stat err=%v)", err)
 		}
 	})
 

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/open-cli-collective/cli-common/credstore"
 
+	"github.com/open-cli-collective/google-readonly/internal/cache"
 	"github.com/open-cli-collective/google-readonly/internal/config"
 	"github.com/open-cli-collective/google-readonly/internal/gmail"
 	"github.com/open-cli-collective/google-readonly/internal/keychain"
@@ -69,18 +70,15 @@ func newClearCommand() *cobra.Command {
 		Use:   "clear",
 		Short: "Remove the stored OAuth token (active profile)",
 		Long: `Remove the stored OAuth token under the active credential_ref,
-forcing re-authentication (§1.7). --all also removes config.yml. --dry-run
-reports what would be removed without removing it. The OAuth client JSON
-(deployment material) is never removed.
-
-Note: the Drive metadata cache is not yet relocated/cleared here — that
-lands in a follow-up unit (B2b).`,
+forcing re-authentication (§1.7). --all also removes config.yml and the Drive
+metadata cache. --dry-run reports what would be removed without removing it.
+The OAuth client JSON (deployment material) is never removed.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runClear(all, dryRun)
 		},
 	}
-	cmd.Flags().BoolVar(&all, "all", false, "Also remove config.yml (active-profile scope)")
+	cmd.Flags().BoolVar(&all, "all", false, "Also remove config.yml and the Drive metadata cache")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Report what would be removed; remove nothing")
 	return cmd
 }
@@ -239,6 +237,10 @@ func runClear(all, dryRun bool) error {
 		}
 		if all {
 			fmt.Printf("Would remove: %s\n", config.ShortenPath(cfgPath))
+			// Non-creating resolver: --dry-run must not create or migrate.
+			if cacheDir, cerr := config.CacheDirPath(); cerr == nil {
+				fmt.Printf("Would remove: Drive metadata cache at %s\n", config.ShortenPath(cacheDir))
+			}
 		}
 		fmt.Println()
 		fmt.Println("--dry-run: nothing was removed.")
@@ -262,6 +264,20 @@ func runClear(all, dryRun bool) error {
 			fmt.Printf("No %s to remove.\n", config.ShortenPath(cfgPath))
 		default:
 			return fmt.Errorf("removing %s: %w", config.ShortenPath(cfgPath), err)
+		}
+
+		// Drive metadata cache: cache.New also runs the transparent legacy
+		// relocation, then Clear removes the (new) cache dir. An explicit
+		// full reset additionally force-cleans the legacy dir even if the
+		// transparent shim had skipped it (carry-failed). All best-effort —
+		// the cache is disposable.
+		if c, cerr := cache.New(config.GetCacheTTLHours()); cerr == nil {
+			if clrErr := c.Clear(); clrErr == nil {
+				fmt.Printf("Removed Drive metadata cache at %s.\n", config.ShortenPath(c.GetDir()))
+			}
+		}
+		if legacy, lerr := config.LegacyCacheDir(); lerr == nil {
+			_ = os.RemoveAll(legacy)
 		}
 	}
 

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -224,7 +224,9 @@ func runClear(all, dryRun bool) error {
 	if err != nil {
 		return fmt.Errorf("checking stored token: %w", err)
 	}
-	cfgPath, err := config.GetConfigPath()
+	// NoCreate: clear (incl. --dry-run) must not create the config dir as a
+	// side-effect. os.Remove below tolerates an absent dir/file.
+	cfgPath, err := config.GetConfigPathNoCreate()
 	if err != nil {
 		return fmt.Errorf("resolving config path: %w", err)
 	}

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/open-cli-collective/cli-common/credstore"
 
-	"github.com/open-cli-collective/google-readonly/internal/cache"
 	"github.com/open-cli-collective/google-readonly/internal/config"
 	"github.com/open-cli-collective/google-readonly/internal/gmail"
 	"github.com/open-cli-collective/google-readonly/internal/keychain"
@@ -268,18 +267,21 @@ func runClear(all, dryRun bool) error {
 			return fmt.Errorf("removing %s: %w", config.ShortenPath(cfgPath), err)
 		}
 
-		// Drive metadata cache: cache.New also runs the transparent legacy
-		// relocation, then Clear removes the (new) cache dir. An explicit
-		// full reset additionally force-cleans the legacy dir even if the
-		// transparent shim had skipped it (carry-failed). All best-effort —
-		// the cache is disposable.
-		if c, cerr := cache.New(config.GetCacheTTLHours()); cerr == nil {
-			if clrErr := c.Clear(); clrErr == nil {
-				fmt.Printf("Removed Drive metadata cache at %s.\n", config.ShortenPath(c.GetDir()))
+		// Drive metadata cache: an explicit full reset removes BOTH the
+		// current cache dir and the legacy (pre-B2b) one directly — no
+		// cache.New(), so no migrate-then-delete dance and no MkdirAll
+		// side-effect. A removal error is surfaced (not silently swallowed):
+		// the user must not believe a full reset succeeded if it did not.
+		if cacheDir, cerr := config.CacheDirPath(); cerr == nil {
+			if rmErr := os.RemoveAll(cacheDir); rmErr != nil {
+				return fmt.Errorf("removing Drive metadata cache %s: %w", config.ShortenPath(cacheDir), rmErr)
 			}
+			fmt.Printf("Removed Drive metadata cache at %s.\n", config.ShortenPath(cacheDir))
 		}
 		if legacy, lerr := config.LegacyCacheDir(); lerr == nil {
-			_ = os.RemoveAll(legacy)
+			if rmErr := os.RemoveAll(legacy); rmErr != nil {
+				return fmt.Errorf("removing legacy Drive cache %s: %w", config.ShortenPath(legacy), rmErr)
+			}
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -171,6 +171,16 @@ func GetTokenPath() (string, error) { return inDir(TokenFile) }
 // GetConfigPath returns the authoritative config file path (config.yml).
 func GetConfigPath() (string, error) { return inDir(ConfigFileYAML) }
 
+// GetConfigPathNoCreate is GetConfigPath WITHOUT creating the config dir —
+// for side-effect-free paths such as `config clear --dry-run`.
+func GetConfigPathNoCreate() (string, error) {
+	dir, err := configDirPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, ConfigFileYAML), nil
+}
+
 // LegacyConfigJSONPath returns the pre-migration config.json path.
 func LegacyConfigJSONPath() (string, error) { return inDir(ConfigFile) }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,11 +90,17 @@ type KeyringConfig struct {
 	Backend string `yaml:"backend,omitempty" json:"-"`
 }
 
-// GetConfigDir returns the configuration directory, creating it if needed.
+// legacyCacheSubdir is the pre-B2b cache location: a "cache" subdir inside the
+// config dir. Retained only so the one-time relocation can find and remove it.
+// A local literal (not cache.CacheDir) — internal/config must not import
+// internal/cache.
+const legacyCacheSubdir = "cache"
+
+// configDirPath resolves the configuration directory WITHOUT creating it.
 // Uses $XDG_CONFIG_HOME if set, else ~/.config/google-readonly. Identical on
 // Linux, macOS, and Windows — matches the released layout (no %APPDATA%
 // branch), so config.yml sits beside the legacy files it supersedes.
-func GetConfigDir() (string, error) {
+func configDirPath() (string, error) {
 	configHome := os.Getenv("XDG_CONFIG_HOME")
 	if configHome == "" {
 		home, err := os.UserHomeDir()
@@ -103,11 +109,54 @@ func GetConfigDir() (string, error) {
 		}
 		configHome = filepath.Join(home, ".config")
 	}
-	configDir := filepath.Join(configHome, DirName)
+	return filepath.Join(configHome, DirName), nil
+}
+
+// GetConfigDir returns the configuration directory, creating it if needed.
+func GetConfigDir() (string, error) {
+	configDir, err := configDirPath()
+	if err != nil {
+		return "", err
+	}
 	if err := os.MkdirAll(configDir, DirPerm); err != nil { //nolint:gosec // not user-controlled
 		return "", err
 	}
 	return configDir, nil
+}
+
+// CacheDirPath resolves the OS-designated cache directory WITHOUT creating it
+// (used by `config clear --all --dry-run` and tests). os.UserCacheDir gives
+// the canonical per-OS root: Linux $XDG_CACHE_HOME or ~/.cache, macOS
+// ~/Library/Caches, Windows %LocalAppData%. We append only DirName — no
+// platform-specific suffix — to keep all three consistent.
+func CacheDirPath() (string, error) {
+	base, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, DirName), nil
+}
+
+// GetCacheDir returns the cache directory, creating it if needed.
+func GetCacheDir() (string, error) {
+	cacheDir, err := CacheDirPath()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(cacheDir, DirPerm); err != nil { //nolint:gosec // not user-controlled
+		return "", err
+	}
+	return cacheDir, nil
+}
+
+// LegacyCacheDir resolves the pre-B2b cache directory (a "cache" subdir of the
+// config dir) WITHOUT creating anything — for the one-time relocation only.
+func LegacyCacheDir() (string, error) {
+	configDir, err := configDirPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(configDir, legacyCacheSubdir), nil
 }
 
 // GetCredentialsPath returns the path to the LEGACY credentials.json

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -439,6 +439,17 @@ func TestCacheDirResolvers(t *testing.T) {
 		if want := filepath.Join(filepath.Join(d, "xconfig"), DirName, legacyCacheSubdir); lp != want {
 			t.Errorf("LegacyCacheDir = %q, want %q", lp, want)
 		}
+
+		gp, err := GetConfigPathNoCreate()
+		if err != nil {
+			t.Fatalf("GetConfigPathNoCreate: %v", err)
+		}
+		if _, serr := os.Stat(filepath.Dir(gp)); !os.IsNotExist(serr) {
+			t.Errorf("GetConfigPathNoCreate must not create the config dir %q (stat err=%v)", filepath.Dir(gp), serr)
+		}
+		if want := filepath.Join(filepath.Join(d, "xconfig"), DirName, ConfigFileYAML); gp != want {
+			t.Errorf("GetConfigPathNoCreate = %q, want %q", gp, want)
+		}
 	})
 
 	t.Run("GetConfigDir still creates", func(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -378,3 +378,77 @@ func TestGetCacheTTLHours(t *testing.T) {
 		}
 	})
 }
+
+func TestCacheDirResolvers(t *testing.T) {
+	// Each subtest gets its OWN hermetic env + fresh temp dir: GetCacheDir is
+	// creating, so a shared env would let one subtest's mkdir defeat
+	// another's "non-creating" assertion.
+	hermeticCfg := func(t *testing.T) string {
+		t.Helper()
+		d := t.TempDir()
+		t.Setenv("HOME", d)
+		t.Setenv("XDG_CACHE_HOME", filepath.Join(d, "xcache"))
+		t.Setenv("LOCALAPPDATA", filepath.Join(d, "localappdata"))
+		t.Setenv("XDG_CONFIG_HOME", filepath.Join(d, "xconfig"))
+		return d
+	}
+
+	t.Run("GetCacheDir is under os.UserCacheDir()/DirName, not the config tree", func(t *testing.T) {
+		hermeticCfg(t)
+		base, err := os.UserCacheDir() // computed in-test — no hard-coded per-OS strings
+		if err != nil {
+			t.Fatalf("UserCacheDir: %v", err)
+		}
+		want := filepath.Join(base, DirName)
+
+		got, err := GetCacheDir()
+		if err != nil {
+			t.Fatalf("GetCacheDir: %v", err)
+		}
+		if got != want {
+			t.Errorf("GetCacheDir = %q, want %q", got, want)
+		}
+		cfgDir, err := configDirPath()
+		if err != nil {
+			t.Fatalf("configDirPath: %v", err)
+		}
+		if strings.HasPrefix(got, cfgDir) {
+			t.Errorf("cache dir %q must not be under the config dir %q", got, cfgDir)
+		}
+		if info, serr := os.Stat(got); serr != nil || !info.IsDir() {
+			t.Errorf("GetCacheDir must create the dir: stat err=%v", serr)
+		}
+	})
+
+	t.Run("CacheDirPath and LegacyCacheDir are non-creating", func(t *testing.T) {
+		d := hermeticCfg(t)
+		cp, err := CacheDirPath()
+		if err != nil {
+			t.Fatalf("CacheDirPath: %v", err)
+		}
+		if _, serr := os.Stat(cp); !os.IsNotExist(serr) {
+			t.Errorf("CacheDirPath must not create %q (stat err=%v)", cp, serr)
+		}
+		lp, err := LegacyCacheDir()
+		if err != nil {
+			t.Fatalf("LegacyCacheDir: %v", err)
+		}
+		if _, serr := os.Stat(lp); !os.IsNotExist(serr) {
+			t.Errorf("LegacyCacheDir must not create %q (stat err=%v)", lp, serr)
+		}
+		if want := filepath.Join(filepath.Join(d, "xconfig"), DirName, legacyCacheSubdir); lp != want {
+			t.Errorf("LegacyCacheDir = %q, want %q", lp, want)
+		}
+	})
+
+	t.Run("GetConfigDir still creates", func(t *testing.T) {
+		hermeticCfg(t)
+		cd, err := GetConfigDir()
+		if err != nil {
+			t.Fatalf("GetConfigDir: %v", err)
+		}
+		if info, serr := os.Stat(cd); serr != nil || !info.IsDir() {
+			t.Errorf("GetConfigDir must create the dir: stat err=%v", serr)
+		}
+	})
+}

--- a/internal/credtest/credtest.go
+++ b/internal/credtest/credtest.go
@@ -28,6 +28,10 @@ func Setup(t *testing.T) string {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "xdgconfig"))
+	// Isolate the OS cache dir too (B2b): XDG_CACHE_HOME covers Linux/CI,
+	// LOCALAPPDATA covers Windows os.UserCacheDir; HOME already covers macOS.
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmp, "xdgcache"))
+	t.Setenv("LOCALAPPDATA", filepath.Join(tmp, "localappdata"))
 	t.Setenv("GOOGLE_READONLY_KEYRING_BACKEND", "file")
 	t.Setenv("GOOGLE_READONLY_KEYRING_PASSPHRASE", "test-passphrase")
 	t.Setenv("GRO_TEST_DISABLE_LEGACY_KEYCHAIN_SCAN", "1")


### PR DESCRIPTION
Phase B unit **B2b** (orthogonal cache-hygiene slice; security-complete migration was B2a / #128 / `e8699d2`). Closes #129. [INT-439]

## What
Relocate the Drive metadata cache out of the config dir into the OS-designated cache dir, with transparent one-time migration. No secret/auth changes.

- **Location:** `os.UserCacheDir()/google-readonly` — Linux `$XDG_CACHE_HOME` or `~/.cache`, macOS `~/Library/Caches`, Windows `%LocalAppData%`. Stdlib only, zero new deps. (Deliberate: canonical stdlib root, no Windows `\Cache` suffix — architect-reviewed/accepted.)
- **config:** pure `configDirPath()`/`CacheDirPath()` resolvers split from the creating `GetConfigDir()`/`GetCacheDir()` wrappers; `LegacyCacheDir()` + local `legacyCacheSubdir` (no `config`->`cache` import).
- **cache.New():** transparent, silent, best-effort one-time relocation (carry warm `drives.json`, then remove legacy dir). Never fails `New()` (cache is disposable); skips removal if the carry failed; idempotent.
- **config clear --all:** also clears the Drive cache and force-cleans the legacy dir; `--dry-run` uses the non-creating resolver and touches nothing; plain `clear` stays token-only.
- **tests:** hermetic cache/config tests (also fixes a pre-existing real-dir pollution bug — `cache_test.go` had no env isolation); migration/idempotency/clear coverage; de-brittled `TestCache_GetDir`; `credtest.Setup` isolates the cache dir too.
- **docs:** README cache location + auto-migration + `clear --all`.

## Review
Architect review converged 0/0/0/0 over 3 iterations before implementation; all findings folded into the plan (#129).

## Gates
gofmt clean, build, vet, `go test -race ./...` 1387 pass / 32 pkgs, golangci-lint v2.12.2 = 0, CI-pin v2.0.2 = 0.