### PR TITLE
ci: restore macOS Keychain via CGO-enabled darwin builds [INT-449]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,10 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    # INT-449: darwin must build with cgo (Keychain backend). cgo+darwin
+    # cannot cross-compile from Linux, so this job runs on macOS. Pinned
+    # image (not the moving macos-latest label) for a reproducible release.
+    runs-on: macos-15
     env:
       TAG: ${{ github.ref_name || inputs.tag }}
     steps:
@@ -29,11 +32,75 @@ jobs:
         with:
           go-version: "1.22"
 
-      - name: Run GoReleaser
+      - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
-          args: release --clean
+          version: "~> v2"
+          install-only: true
+
+      - name: GoReleaser check
+        run: goreleaser check
+
+      - name: Build (snapshot, no publish)
+        run: goreleaser release --snapshot --clean
+
+      # INT-449 pre-publish gate: prove the darwin binaries actually carry
+      # the Keychain backend BEFORE anything is published. A CGO_ENABLED=0
+      # darwin build links no Security.framework and fails closed at
+      # runtime; this gate makes that impossible to ship silently.
+      - name: Pre-publish gate — darwin Keychain backend present
+        run: |
+          set -euo pipefail
+          art=dist/artifacts.json
+          arm_bin=$(jq -r '.[]|select(.type=="Binary" and .goos=="darwin" and .goarch=="arm64")|.path' "$art")
+          amd_bin=$(jq -r '.[]|select(.type=="Binary" and .goos=="darwin" and .goarch=="amd64")|.path' "$art")
+          [ -n "$arm_bin" ] && [ -n "$amd_bin" ] || { echo "missing a darwin binary in artifacts.json"; exit 1; }
+          # darwin archives: exactly one per arch, no duplicate names
+          tot=$(jq '[.[]|select(.type=="Archive" and .goos=="darwin")|.name]|length' "$art")
+          uniq=$(jq '[.[]|select(.type=="Archive" and .goos=="darwin")|.name]|unique|length' "$art")
+          [ "$tot" = "$uniq" ] || { echo "duplicate darwin archive names"; exit 1; }
+          [ "$(jq '[.[]|select(.type=="Archive" and .goos=="darwin" and .goarch=="arm64")]|length' "$art")" = 1 ] || { echo "expected exactly one darwin/arm64 archive"; exit 1; }
+          [ "$(jq '[.[]|select(.type=="Archive" and .goos=="darwin" and .goarch=="amd64")]|length' "$art")" = 1 ] || { echo "expected exactly one darwin/amd64 archive"; exit 1; }
+          # Mach-O arch sanity (both slices)
+          file "$arm_bin" | grep -q 'arm64'  || { echo "arm64 binary is not arm64 Mach-O";  exit 1; }
+          file "$amd_bin" | grep -q 'x86_64' || { echo "amd64 binary is not x86_64 Mach-O"; exit 1; }
+          lipo -archs "$arm_bin" | grep -qw arm64  || { echo "lipo: arm64 slice missing";  exit 1; }
+          lipo -archs "$amd_bin" | grep -qw x86_64 || { echo "lipo: x86_64 slice missing"; exit 1; }
+          # amd64 cannot run on the arm64 runner: assert Security.framework
+          # is linked. CGO_ENABLED=0 omits it entirely, so its presence is a
+          # sound *necessary* cgo signal for the slice we can't execute.
+          otool -L "$amd_bin" | grep -q '/System/Library/Frameworks/Security.framework' \
+            || { echo "amd64 binary not linked against Security.framework (cgo missing)"; exit 1; }
+          # arm64 authoritative functional check: with no backend override
+          # and a seeded config, credstore must auto-select the Keychain.
+          # config.yml lives under $XDG_CONFIG_HOME/google-readonly/config.yml.
+          # -u GOOGLE_READONLY_KEYRING_BACKEND: derived from DirName
+          # "google-readonly" upper-snake-cased.
+          tmp=$(mktemp -d)
+          mkdir -p "$tmp/xdg/google-readonly"
+          printf 'credential_ref: google-readonly/default\n' > "$tmp/xdg/google-readonly/config.yml"
+          out=$(env -u GOOGLE_READONLY_KEYRING_BACKEND HOME="$tmp" XDG_CONFIG_HOME="$tmp/xdg" "$arm_bin" config show -j)
+          echo "$out"
+          b=$(echo "$out" | jq -r '.backend'); s=$(echo "$out" | jq -r '.backend_source'); r=$(echo "$out" | jq -r '.credential_ref')
+          [ "$b" = "keychain" ] && [ "$s" = "auto" ] && [ "$r" = "google-readonly/default" ] \
+            || { echo "GATE FAIL: backend=$b source=$s ref=$r (want keychain/auto/google-readonly/default)"; exit 1; }
+          echo "GATE OK: darwin/arm64 backend=keychain source=auto; darwin/amd64 Security.framework linked"
+
+      - name: Release notes
+        run: |
+          set -euo pipefail
+          cat > "$RUNNER_TEMP/release-notes.md" <<'EOF'
+          ### macOS Keychain storage restored
+
+          Builds since the credential-store migration were compiled without
+          cgo and failed closed on macOS (no Keychain backend). This release
+          builds the darwin binaries with cgo enabled, restoring native
+          macOS Keychain storage. Upgrade and re-run your normal commands;
+          no other action is required.
+          EOF
+
+      - name: Release (publish)
+        run: goreleaser release --clean --release-notes="$RUNNER_TEMP/release-notes.md"
         env:
           # TAP_GITHUB_TOKEN (PAT) is required here instead of the default
           # GITHUB_TOKEN because releases created with GITHUB_TOKEN do not fire
@@ -42,14 +109,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
 
-  # Chocolatey and winget publishing live in chocolatey-publish.yml and
-  # winget-publish.yml respectively. They auto-trigger on `release: published`
-  # (and still expose `workflow_dispatch` as a manual fallback). They are kept
-  # out of this workflow so Microsoft-hosted service flakiness (wingetcreate
-  # fork-sync, choco push) does not gate the binary/Homebrew artifacts.
+      - name: Verify release notes published
+        env:
+          GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          body=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body -q .body)
+          if ! printf '%s' "$body" | grep -q 'macOS Keychain'; then
+            gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --notes-file "$RUNNER_TEMP/release-notes.md"
+          fi
 
+  # Snap is temporarily disabled — waiting for personal-files interface approval.
   snap:
-    if: false  # Temporarily disabled - waiting for personal-files interface approval
+    if: false
     needs: goreleaser
     runs-on: ubuntu-latest
     env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,14 +7,46 @@ before:
     - go mod tidy
     - go test ./...
 
+# INT-449: darwin builds with CGO so 99designs/keyring's Keychain backend
+# (//go:build darwin && cgo) is compiled in; without it credstore fails
+# closed on macOS. linux/windows stay CGO-off static (their keyring
+# backends are pure Go; cgo there would regress glibc portability).
+# Split is by GOOS only — both darwin amd64 and arm64 are still produced.
 builds:
-  - id: gro
+  - id: gro-darwin
+    main: ./cmd/gro
+    binary: gro
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    overrides:
+      - goos: darwin
+        goarch: amd64
+        goamd64: v1
+        env:
+          - CGO_ENABLED=1
+          - "CC=xcrun clang -arch x86_64"
+      - goos: darwin
+        goarch: arm64
+        goarm64: v8.0
+        env:
+          - CGO_ENABLED=1
+          - "CC=xcrun clang -arch arm64"
+    ldflags:
+      - -s -w
+      - -X github.com/open-cli-collective/google-readonly/internal/version.Version={{.Version}}
+      - -X github.com/open-cli-collective/google-readonly/internal/version.Commit={{.Commit}}
+      - -X github.com/open-cli-collective/google-readonly/internal/version.Date={{.Date}}
+  - id: gro-unix-win
     main: ./cmd/gro
     binary: gro
     env:
       - CGO_ENABLED=0
     goos:
-      - darwin
       - linux
       - windows
     goarch:
@@ -42,6 +74,11 @@ archives:
 # Linux packages (.deb and .rpm)
 nfpms:
   - id: google-readonly
+    # deb/rpm are linux-only: pull the static CGO-off build, never darwin.
+    # `ids` (the v2 build-id filter) — `builds` is deprecated and fails
+    # `goreleaser check`.
+    ids:
+      - gro-unix-win
     package_name: google-readonly
     vendor: Open CLI Collective
     homepage: https://github.com/open-cli-collective/google-readonly
@@ -65,7 +102,7 @@ homebrew_casks:
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
     homepage: https://github.com/open-cli-collective/google-readonly
     description: "Read-only command-line interface for Google services"
-    binary: gro
+    binaries: [gro]
     hooks:
       post:
         install: |


### PR DESCRIPTION
## Summary

- Splits the single `CGO_ENABLED=0` goreleaser build into `gro-darwin` (darwin/amd64+arm64, `CGO_ENABLED=1`) and `gro-unix-win` (linux/windows, `CGO_ENABLED=0` static). Without cgo, `99designs/keyring/keychain.go` (`//go:build darwin && cgo`) is not compiled, its `init()` never registers the Keychain backend, and every credential op fails closed on macOS.
- Moves the goreleaser job from `ubuntu-latest` to `macos-15` (cgo+darwin cannot cross-compile from Linux).
- Adds a pre-publish gate (snapshot → assert → publish): `file`/`lipo` both darwin arches; `otool -L` amd64 for Security.framework; functional arm64 test with isolated `HOME`/`XDG_CONFIG_HOME` asserting `backend==keychain`, `backend_source==auto`, `credential_ref==google-readonly/default`.
- Pins `nfpms.ids: [gro-unix-win]` so deb/rpm never pull a darwin binary.
- Fixes pre-existing `homebrew_casks.binary` deprecation → `binaries: [gro]` (`goreleaser check` now exits 0).
- `goreleaser version: latest` → `~> v2` (pinned major for reproducibility).

## Local validation

- `goreleaser check` → exit 0
- `CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 CC="xcrun clang -arch arm64" go build` → `Mach-O 64-bit executable arm64`
- `CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 CC="xcrun clang -arch x86_64" go build` → `Mach-O 64-bit executable x86_64`; `otool -L` confirms `Security.framework` linked
- Functional gate: `env -u GOOGLE_READONLY_KEYRING_BACKEND HOME=$tmp XDG_CONFIG_HOME=$tmp/xdg /tmp/gro-arm64 config show -j` → `backend=keychain source=auto ref=google-readonly/default` ✓

## Test plan

- [ ] CI passes on the PR (no Go changes, gate runs in CI only on tag push)
- [ ] After merge, tag a patch release; confirm the goreleaser macos-15 job passes the pre-publish gate and publishes darwin archives
- [ ] On a non-dev Mac: `brew upgrade gro` or reinstall; confirm a real credential op stores to Keychain without fail-closed error

Closes #132