### PR TITLE
feat(root): add --no-color persistent flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/huh v0.8.0
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/muesli/termenv v0.16.0
 	github.com/open-cli-collective/cli-common v0.2.1
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/spf13/cobra v1.8.0
@@ -61,7 +62,6 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/noamcohen97/touchid-go v0.3.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
 
 	cccredstore "github.com/open-cli-collective/cli-common/credstore"
@@ -24,7 +26,10 @@ import (
 	"github.com/open-cli-collective/google-readonly/internal/version"
 )
 
-var verbose bool
+var (
+	verbose bool
+	noColor bool
+)
 
 var rootCmd = &cobra.Command{
 	Use:   "gro",
@@ -43,6 +48,9 @@ This will guide you through OAuth setup for Google API access.`,
 	Version: version.Version,
 	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 		log.Verbose = verbose
+		if noColor {
+			lipgloss.DefaultRenderer().SetColorProfile(termenv.Ascii)
+		}
 		return WireBackendSelection(cmd)
 	},
 }
@@ -106,6 +114,7 @@ func init() {
 
 	// Global flags
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output for debugging")
+	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colored output")
 	rootCmd.PersistentFlags().String(cccredstore.BackendFlagName, "", cccredstore.BackendFlagUsage())
 
 	// Register commands

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+
 	"github.com/open-cli-collective/cli-common/credstore"
 
 	"github.com/open-cli-collective/google-readonly/internal/migrationsink"
@@ -93,5 +96,62 @@ func TestRunRootFlushesMigrationNoticeOnError(t *testing.T) {
 	migrationsink.FlushMigrationNotice(&again)
 	if again.Len() != 0 {
 		t.Fatalf("notice must be consume-once, got %q", again.String())
+	}
+}
+
+func TestNoColorFlagRegistered(t *testing.T) {
+	f := rootCmd.PersistentFlags().Lookup("no-color")
+	if f == nil {
+		t.Fatal("--no-color persistent flag not registered on rootCmd")
+	}
+	if f.Value.Type() != "bool" {
+		t.Fatalf("expected --no-color to be a bool flag, got %s", f.Value.Type())
+	}
+}
+
+// withRenderer swaps the lipgloss default renderer for the duration of the
+// test, restoring the saved renderer on cleanup. Tests using this must not
+// call t.Parallel — the default renderer is process-global.
+func withRenderer(t *testing.T, profile termenv.Profile) {
+	t.Helper()
+	saved := lipgloss.DefaultRenderer()
+	t.Cleanup(func() { lipgloss.SetDefaultRenderer(saved) })
+
+	r := lipgloss.NewRenderer(io.Discard)
+	r.SetColorProfile(profile)
+	lipgloss.SetDefaultRenderer(r)
+}
+
+func TestPersistentPreRunE_NoColorTrueFlipsToAscii(t *testing.T) {
+	// Baseline: force ANSI so the flip is detectable.
+	withRenderer(t, termenv.ANSI)
+
+	// Reset the package-level flag binding on cleanup so subsequent tests
+	// or runs don't see a leaked true.
+	t.Cleanup(func() { noColor = false })
+	noColor = true
+
+	if err := rootCmd.PersistentPreRunE(rootCmd, nil); err != nil {
+		t.Fatalf("PersistentPreRunE returned error: %v", err)
+	}
+
+	if got := lipgloss.DefaultRenderer().ColorProfile(); got != termenv.Ascii {
+		t.Fatalf("expected ColorProfile == Ascii after noColor=true, got %v", got)
+	}
+}
+
+func TestPersistentPreRunE_NoColorFalseLeavesRendererUntouched(t *testing.T) {
+	// Baseline: force ANSI.
+	withRenderer(t, termenv.ANSI)
+
+	t.Cleanup(func() { noColor = false })
+	noColor = false
+
+	// WireBackendSelection may succeed or fail in the test env; we don't
+	// care about its return — we care that the renderer wasn't mutated.
+	_ = rootCmd.PersistentPreRunE(rootCmd, nil)
+
+	if got := lipgloss.DefaultRenderer().ColorProfile(); got != termenv.ANSI {
+		t.Fatalf("expected renderer untouched when noColor=false, got %v", got)
 	}
 }

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
+	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/cli-common/credstore"
 
@@ -137,6 +138,38 @@ func TestPersistentPreRunE_NoColorTrueFlipsToAscii(t *testing.T) {
 
 	if got := lipgloss.DefaultRenderer().ColorProfile(); got != termenv.Ascii {
 		t.Fatalf("expected ColorProfile == Ascii after noColor=true, got %v", got)
+	}
+}
+
+// TestNoColorFlagThroughCobra proves the full wiring: cobra parses
+// --no-color, sets the bound `noColor` package variable, the existing
+// PersistentPreRunE picks it up, and the lipgloss renderer is flipped to
+// Ascii. Unlike the direct PreRunE invocation above, this exercises the
+// real argv → flag binding → PreRunE chain.
+func TestNoColorFlagThroughCobra(t *testing.T) {
+	withRenderer(t, termenv.ANSI)
+
+	probe := &cobra.Command{
+		Use:  "probe-no-color-flag-wiring",
+		RunE: func(_ *cobra.Command, _ []string) error { return nil },
+	}
+	rootCmd.AddCommand(probe)
+	t.Cleanup(func() {
+		rootCmd.RemoveCommand(probe)
+		rootCmd.SetArgs(nil)
+		noColor = false
+	})
+
+	rootCmd.SetArgs([]string{"--no-color", "probe-no-color-flag-wiring"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if !noColor {
+		t.Fatal("expected cobra to set noColor=true after parsing --no-color")
+	}
+	if got := lipgloss.DefaultRenderer().ColorProfile(); got != termenv.Ascii {
+		t.Fatalf("expected Ascii via real flag-binding path, got %v", got)
 	}
 }
 

--- a/internal/view/view_test.go
+++ b/internal/view/view_test.go
@@ -118,3 +118,15 @@ func TestErrorUnderAsciiProfileEmitsNoANSI(t *testing.T) {
 		t.Fatalf("expected no ANSI escape under ascii profile, got %q", errw.String())
 	}
 }
+
+func TestInfoUnderAsciiProfileEmitsNoANSI(t *testing.T) {
+	withRenderer(t, termenv.Ascii)
+
+	var out, errw bytes.Buffer
+	v := NewWithWriters(&out, &errw)
+	v.Info("hint")
+
+	if strings.Contains(out.String(), "\x1b[") {
+		t.Fatalf("expected no ANSI escape under ascii profile, got %q", out.String())
+	}
+}

--- a/internal/view/view_test.go
+++ b/internal/view/view_test.go
@@ -2,8 +2,12 @@ package view
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 )
 
 func TestSuccessGoesToStdout(t *testing.T) {
@@ -62,5 +66,55 @@ func TestPrintlnAddsNewline(t *testing.T) {
 	v.Println("hello")
 	if got := out.String(); got != "hello\n" {
 		t.Fatalf("expected 'hello\\n', got %q", got)
+	}
+}
+
+// withRenderer swaps the lipgloss default renderer for the duration of the
+// test, restoring the saved renderer on cleanup. Tests using this must not
+// call t.Parallel — the default renderer is process-global.
+func withRenderer(t *testing.T, profile termenv.Profile) {
+	t.Helper()
+	saved := lipgloss.DefaultRenderer()
+	t.Cleanup(func() { lipgloss.SetDefaultRenderer(saved) })
+
+	r := lipgloss.NewRenderer(io.Discard)
+	r.SetColorProfile(profile)
+	lipgloss.SetDefaultRenderer(r)
+}
+
+func TestSuccessUnderAsciiProfileEmitsNoANSI(t *testing.T) {
+	withRenderer(t, termenv.Ascii)
+
+	var out, errw bytes.Buffer
+	v := NewWithWriters(&out, &errw)
+	v.Success("hello")
+
+	if strings.Contains(out.String(), "\x1b[") {
+		t.Fatalf("expected no ANSI escape under ascii profile, got %q", out.String())
+	}
+}
+
+func TestSuccessUnderANSIProfileEmitsANSI(t *testing.T) {
+	// Regression: proves the no-color test isn't just env-determined.
+	withRenderer(t, termenv.ANSI)
+
+	var out, errw bytes.Buffer
+	v := NewWithWriters(&out, &errw)
+	v.Success("hello")
+
+	if !strings.Contains(out.String(), "\x1b[") {
+		t.Fatalf("expected ANSI escape under ANSI profile, got %q", out.String())
+	}
+}
+
+func TestErrorUnderAsciiProfileEmitsNoANSI(t *testing.T) {
+	withRenderer(t, termenv.Ascii)
+
+	var out, errw bytes.Buffer
+	v := NewWithWriters(&out, &errw)
+	v.Error("bad")
+
+	if strings.Contains(errw.String(), "\x1b[") {
+		t.Fatalf("expected no ANSI escape under ascii profile, got %q", errw.String())
 	}
 }


### PR DESCRIPTION
## Summary
- New `--no-color` persistent flag on the gro root.
- Existing `PersistentPreRunE` at `internal/cmd/root/root.go:44` extended (not replaced) — preserves `log.Verbose` and `WireBackendSelection` wiring.
- When `--no-color` is set, switches `lipgloss.DefaultRenderer()` to `termenv.Ascii` so every `Style.Render` call in this process emits plain text.
- `NO_COLOR` env behavior (handled natively by lipgloss/termenv) is unchanged — the flag is an additive, discoverable opt-out.

## Why
§8 of cli-common `output-and-rendering.md` requires `--no-color` as the documented opt-out alongside `NO_COLOR` env. gro was the only CLI in the family missing the flag (per the divergence catalog).

## Test plan
- [x] `make build` — `bin/gro` clean.
- [x] `make check` (tidy+lint+test) — 24 tests green across view + root packages.
- [x] New view tests:
  - `TestSuccessUnderAsciiProfileEmitsNoANSI` — proves Ascii profile suppresses ANSI.
  - `TestSuccessUnderANSIProfileEmitsANSI` — regression proving the test setup isn't env-determined.
  - `TestErrorUnderAsciiProfileEmitsNoANSI` — same for `Error` (stderr).
- [x] New root tests:
  - `TestNoColorFlagRegistered` — flag exists, type bool, persistent.
  - `TestPersistentPreRunE_NoColorTrueFlipsToAscii` — end-to-end: forces ANSI baseline, sets `noColor = true`, calls `PersistentPreRunE`, asserts `ColorProfile() == Ascii`.
  - `TestPersistentPreRunE_NoColorFalseLeavesRendererUntouched` — regression: `noColor = false` doesn't mutate the renderer.
- [x] All renderer-mutating tests use `t.Cleanup` to restore `lipgloss.SetDefaultRenderer(saved)` and reset the `noColor` package var — no state leak across tests.

## Out of scope (per §8)
- No `isatty` gating. §8 is explicit: "No CLI gates color on `isatty`. This is intentional."

Closes #143