### PR TITLE
gro: remove per-command --json (BREAKING) [#144]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ make install        # Install to /usr/local/bin
 - **Non-destructive by design**: Only allowlisted scopes in `auth.AllScopes`. No destructive API methods (send, delete, trash). Non-destructive modify operations (label, archive, star) are permitted.
 - **Interface-at-consumer**: Each `internal/cmd/{domain}/output.go` defines its client interface.
 - **ClientFactory DI**: Swappable factory for test mock injection.
-- **--json on all leaf commands**: Every leaf subcommand supports `--json/-j`.
+- **Text-only resource leaves (#144)**: Resource-surface leaf commands (under `mail`, `calendar`, `contacts`, `drive`, `me`) emit text only — they must NOT declare `--json/-j`. JSON is reserved for control-plane envelopes outside the domain resource packages: `gro refresh --json` (§4.6) and `gro config show --json` (diagnostic).
 - **Structural enforcement**: `internal/architecture/architecture_test.go` enforces all patterns at CI time.
 
 See `docs/golden-principles.md` for the full set of enforced rules.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A non-destructive command-line interface for Google services. Search, read, and 
 - **Contacts support** - List contacts, search, view details, list groups, star, group management
 - **Drive support** - List files, search, view metadata, download files, folder tree, star/unstar
 - **Bulk operations** - Pipe IDs between commands, use search queries inline, or pass IDs as arguments
-- **JSON output** - Machine-readable output for scripting
+- **Text-first output** - Resource-surface commands emit token-dense text only. JSON is reserved for control-plane envelopes (`gro refresh --json`, `gro config show --json`); see cli-common `docs/output-and-rendering.md` §2. **Breaking change in #144:** per-command `--json` on resource reads/mutations has been removed.
 - **Secure storage** - the OAuth token is stored only in the OS keyring (macOS Keychain, Linux Secret Service, Windows Credential Manager, or an opt-in encrypted file) via the shared `cli-common/credstore`
 - **Single-run guided setup** - `gro init` reads the OAuth client JSON from clipboard / paste / file path (your admin may share one via 1Password) and walks you through OAuth in one shot; `gro me` confirms identity afterwards
 
@@ -230,9 +230,6 @@ gro me --id
 # Adds granted scopes, token expiry, and storage backend
 gro me --extended
 
-# JSON output (combines with --id and --extended; -j is the short form)
-gro me --json
-gro me --extended -j
 
 # Check configuration status
 gro config show
@@ -259,24 +256,19 @@ All Gmail commands are under `gro mail`:
 # Search messages
 gro mail search "is:unread"
 gro mail search "from:someone@example.com" --max 20
-gro mail search "subject:meeting" --json
 gro mail search "is:starred" --ids          # Output IDs only (for piping)
 
 # Read a message
 gro mail read <message-id>
-gro mail read <message-id> --json
 
 # View conversation thread
 gro mail thread <thread-id>
-gro mail thread <message-id> --json
 
 # List labels
 gro mail labels
-gro mail labels --json
 
 # List attachments
 gro mail attachments list <message-id>
-gro mail attachments list <message-id> --json
 
 # Download attachments
 gro mail attachments download <message-id> --all
@@ -340,7 +332,6 @@ All Calendar commands are under `gro calendar` (or `gro cal`):
 ```bash
 # List all calendars
 gro calendar list
-gro cal list --json
 
 # List upcoming events
 gro calendar events
@@ -349,15 +340,12 @@ gro cal events --from 2026-01-01 --to 2026-01-31
 
 # Get event details
 gro calendar get <event-id>
-gro cal get <event-id> --json
 
 # Today's events
 gro calendar today
-gro cal today --json
 
 # This week's events
 gro calendar week
-gro cal week --json
 
 # RSVP to an event
 gro calendar rsvp <event-id> accept
@@ -377,7 +365,6 @@ All Contacts commands are under `gro contacts` (or `gro ppl`):
 # List all contacts
 gro contacts list
 gro ppl list --max 20
-gro contacts list --json
 gro contacts list --ids                     # Output resource names only
 
 # Search contacts
@@ -387,11 +374,9 @@ gro contacts search "John" --ids            # Output resource names only
 
 # Get contact details
 gro contacts get people/c123456789
-gro ppl get people/c123456789 --json
 
 # List contact groups
 gro contacts groups
-gro ppl groups --json
 
 # Star / unstar contacts
 gro contacts star people/c123 people/c456
@@ -423,7 +408,6 @@ gro drive search "budget" --ids             # Output file IDs only
 
 # Get file metadata
 gro drive get <file-id>
-gro files get <file-id> --json
 
 # Download files
 gro drive download <file-id>
@@ -449,7 +433,6 @@ gro supports Google Shared Drives (formerly Team Drives). By default, search inc
 ```bash
 # List available shared drives
 gro drive drives
-gro drive drives --json
 
 # Search all drives (default)
 gro drive search "quarterly report"
@@ -512,10 +495,7 @@ Usage: gro me [flags]
 Flags:
       --id         Print only the primary email (scriptable)
       --extended   Add granted scopes, token expiry, and storage backend
-  -j, --json       Output as JSON
 ```
-
-`--id` and `--extended` can be combined with `--json`.
 
 ### gro config show
 
@@ -553,10 +533,8 @@ Usage: gro mail search <query> [flags]
 Flags:
   -m, --max int    Maximum number of results (default 10)
       --ids        Output only message IDs (one per line, for piping)
-  -j, --json       Output as JSON
 ```
 
-`--ids` and `--json` are mutually exclusive.
 
 ### gro mail read
 
@@ -566,7 +544,6 @@ Read the full content of a Gmail message by its ID.
 Usage: gro mail read <message-id> [flags]
 
 Flags:
-  -j, --json       Output as JSON
 ```
 
 ### gro mail thread
@@ -577,7 +554,6 @@ Read all messages in a Gmail conversation thread.
 Usage: gro mail thread <id> [flags]
 
 Flags:
-  -j, --json       Output as JSON
 ```
 
 ### gro mail labels
@@ -588,7 +564,6 @@ List all Gmail labels including user labels and system categories.
 Usage: gro mail labels [flags]
 
 Flags:
-  -j, --json       Output as JSON
 ```
 
 ### gro mail attachments list
@@ -599,7 +574,6 @@ List all attachments in a Gmail message.
 Usage: gro mail attachments list <message-id> [flags]
 
 Flags:
-  -j, --json       Output as JSON
 ```
 
 ### gro mail attachments download
@@ -627,7 +601,6 @@ Flags:
   -n, --dry-run    Preview without making changes
       --stdin      Read message IDs from stdin
       --query string   Search query to resolve message IDs
-  -j, --json       Output results as JSON
 ```
 
 ### gro mail star
@@ -641,7 +614,6 @@ Flags:
   -n, --dry-run    Preview without making changes
       --stdin      Read message IDs from stdin
       --query string   Search query to resolve message IDs
-  -j, --json       Output results as JSON
 ```
 
 ### gro mail unstar
@@ -655,7 +627,6 @@ Flags:
   -n, --dry-run    Preview without making changes
       --stdin      Read message IDs from stdin
       --query string   Search query to resolve message IDs
-  -j, --json       Output results as JSON
 ```
 
 ### gro mail mark-read
@@ -669,7 +640,6 @@ Flags:
   -n, --dry-run    Preview without making changes
       --stdin      Read message IDs from stdin
       --query string   Search query to resolve message IDs
-  -j, --json       Output results as JSON
 ```
 
 ### gro mail mark-unread
@@ -683,7 +653,6 @@ Flags:
   -n, --dry-run    Preview without making changes
       --stdin      Read message IDs from stdin
       --query string   Search query to resolve message IDs
-  -j, --json       Output results as JSON
 ```
 
 ### gro mail label
@@ -697,7 +666,6 @@ Flags:
   -n, --dry-run    Preview without making changes
       --stdin      Read message IDs from stdin
       --query string   Search query to resolve message IDs
-  -j, --json       Output results as JSON
 ```
 
 ### gro mail unlabel
@@ -711,7 +679,6 @@ Flags:
   -n, --dry-run    Preview without making changes
       --stdin      Read message IDs from stdin
       --query string   Search query to resolve message IDs
-  -j, --json       Output results as JSON
 ```
 
 ### gro mail categorize
@@ -725,7 +692,6 @@ Flags:
   -n, --dry-run    Preview without making changes
       --stdin      Read message IDs from stdin
       --query string   Search query to resolve message IDs
-  -j, --json       Output results as JSON
 ```
 
 ### gro mail draft
@@ -749,7 +715,6 @@ Flags:
       --plain             Send body as plain text (no markdown rendering)
       --html              Send body as raw HTML (no markdown rendering)
   -a, --attach strings    File path to attach (repeat for multiple)
-  -j, --json              Output result as JSON
       --reply-to string   Source Gmail message ID to reply to (derives To/Subject/threading)
       --reply-all         Include the source To/Cc as Cc on the reply (requires --reply-to)
       --no-quote          Reply without quoting the source message (requires --reply-to)
@@ -771,7 +736,6 @@ Usage: gro calendar list [flags]
 Aliases: gro cal list
 
 Flags:
-  -j, --json       Output as JSON
 ```
 
 ### gro calendar events
@@ -788,7 +752,6 @@ Flags:
   -m, --max int           Maximum number of events (default 10)
       --from string       Start date (YYYY-MM-DD)
       --to string         End date (YYYY-MM-DD)
-  -j, --json              Output as JSON
 ```
 
 ### gro calendar get
@@ -802,7 +765,6 @@ Aliases: gro cal get
 
 Flags:
   -c, --calendar string   Calendar ID containing the event (default "primary")
-  -j, --json              Output as JSON
 ```
 
 ### gro calendar today
@@ -816,7 +778,6 @@ Aliases: gro cal today
 
 Flags:
   -c, --calendar string   Calendar ID to query (default "primary")
-  -j, --json              Output as JSON
 ```
 
 ### gro calendar week
@@ -830,7 +791,6 @@ Aliases: gro cal week
 
 Flags:
   -c, --calendar string   Calendar ID to query (default "primary")
-  -j, --json              Output as JSON
 ```
 
 ### gro calendar rsvp
@@ -845,7 +805,6 @@ Aliases: gro cal rsvp
 Flags:
   -c, --calendar string   Calendar ID containing the event (default "primary")
   -n, --dry-run           Preview without making changes
-  -j, --json              Output as JSON
 ```
 
 ### gro calendar color
@@ -860,7 +819,6 @@ Aliases: gro cal color
 Flags:
   -c, --calendar string   Calendar ID containing the event (default "primary")
   -n, --dry-run           Preview without making changes
-  -j, --json              Output as JSON
 ```
 
 ### gro contacts list
@@ -875,10 +833,8 @@ Aliases: gro ppl list
 Flags:
   -m, --max int    Maximum number of contacts (default 10)
       --ids        Output only resource names (one per line, for piping)
-  -j, --json       Output as JSON
 ```
 
-`--ids` and `--json` are mutually exclusive.
 
 ### gro contacts search
 
@@ -892,10 +848,8 @@ Aliases: gro ppl search
 Flags:
   -m, --max int    Maximum number of results (default 10)
       --ids        Output only resource names (one per line, for piping)
-  -j, --json       Output as JSON
 ```
 
-`--ids` and `--json` are mutually exclusive.
 
 ### gro contacts get
 
@@ -907,7 +861,6 @@ Usage: gro contacts get <resource-name> [flags]
 Aliases: gro ppl get
 
 Flags:
-  -j, --json       Output as JSON
 ```
 
 ### gro contacts groups
@@ -921,7 +874,6 @@ Aliases: gro ppl groups
 
 Flags:
   -m, --max int    Maximum number of groups (default 30)
-  -j, --json       Output as JSON
 ```
 
 ### gro contacts star
@@ -937,7 +889,6 @@ Flags:
   -n, --dry-run    Preview without making changes
       --stdin      Read contact IDs from stdin
       --query string   Search query to resolve contact IDs
-  -j, --json       Output results as JSON
 ```
 
 ### gro contacts unstar
@@ -953,7 +904,6 @@ Flags:
   -n, --dry-run    Preview without making changes
       --stdin      Read contact IDs from stdin
       --query string   Search query to resolve contact IDs
-  -j, --json       Output results as JSON
 ```
 
 ### gro contacts add-to-group
@@ -969,7 +919,6 @@ Flags:
   -n, --dry-run    Preview without making changes
       --stdin      Read contact IDs from stdin
       --query string   Search query to resolve contact IDs
-  -j, --json       Output results as JSON
 ```
 
 ### gro contacts remove-from-group
@@ -985,7 +934,6 @@ Flags:
   -n, --dry-run    Preview without making changes
       --stdin      Read contact IDs from stdin
       --query string   Search query to resolve contact IDs
-  -j, --json       Output results as JSON
 ```
 
 ### gro drive list
@@ -1003,10 +951,9 @@ Flags:
       --ids          Output only file IDs (one per line, for piping)
       --my-drive     List from My Drive only
       --drive string List from specific shared drive (name or ID)
-  -j, --json         Output as JSON
 ```
 
-`--ids` and `--json` are mutually exclusive. `--my-drive` and `--drive` are mutually exclusive.
+`--my-drive` and `--drive` are mutually exclusive.
 
 ### gro drive search
 
@@ -1028,10 +975,9 @@ Flags:
       --my-drive               Search only My Drive
       --drive string           Search specific shared drive (name or ID)
   -m, --max int                Maximum results (default 25)
-  -j, --json                   Output as JSON
 ```
 
-`--ids` and `--json` are mutually exclusive. `--my-drive` and `--drive` are mutually exclusive.
+`--my-drive` and `--drive` are mutually exclusive.
 
 ### gro drive get
 
@@ -1043,7 +989,6 @@ Usage: gro drive get <file-id> [flags]
 Aliases: gro files get
 
 Flags:
-  -j, --json       Output as JSON
 ```
 
 ### gro drive download
@@ -1081,7 +1026,6 @@ Flags:
       --files        Include files in addition to folders
       --my-drive     Show My Drive only (default)
       --drive string Show tree from specific shared drive
-  -j, --json         Output as JSON
 ```
 
 ### gro drive drives
@@ -1096,7 +1040,6 @@ Aliases: gro files drives
 
 Flags:
       --refresh    Force refresh from API (deprecated; use 'gro refresh drives')
-  -j, --json       Output as JSON
 ```
 
 ### gro refresh
@@ -1126,7 +1069,6 @@ Flags:
   -n, --dry-run    Preview without making changes
       --stdin      Read file IDs from stdin
       --query string   Search query to resolve file IDs
-  -j, --json       Output results as JSON
 ```
 
 ### gro drive unstar
@@ -1142,7 +1084,6 @@ Flags:
   -n, --dry-run    Preview without making changes
       --stdin      Read file IDs from stdin
       --query string   Search query to resolve file IDs
-  -j, --json       Output results as JSON
 ```
 
 ## Search Query Reference

--- a/docs/adding-a-domain.md
+++ b/docs/adding-a-domain.md
@@ -51,15 +51,17 @@ Create `internal/cmd/{domain}/` with these files:
 - An exported interface ending in `Client` (e.g., `TasksClient`)
 - A `ClientFactory` variable
 - A `newXClient()` wrapper function
-- A `printJSON()` function
+- Domain-specific text-rendering helpers (e.g., `printTask`, `printTaskSummary`)
+
+> Do **not** add a package-local `printJSON()` helper. Per golden principle §4 (#144), resource-surface leaves emit text only. The `internal/output` package is reserved for control-plane envelopes (`refresh --json`, `config show --json`).
 
 **`{domain}.go`** — [enforced] Must contain:
 - An exported `NewCommand()` function returning `*cobra.Command`
 - `AddCommand()` calls for all subcommands
 
-**Each subcommand file** — [enforced] Each leaf command must have `--json/-j` flag:
+**Each subcommand file** — [enforced] Resource-surface leaves emit text only — they must NOT declare `--json/-j`. The structural test `TestResourceLeavesHaveNoJSONFlag` catches accidental re-introduction. Each leaf file contains:
 - Unexported `new{Sub}Command()` factory
-- `--json/-j` flag for JSON output (exempt for binary download commands)
+- Text rendering via the domain's printers from `output.go`
 
 ### 4. Create test infrastructure
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,7 +64,7 @@ Each domain command package (`internal/cmd/{domain}/`) contains:
 | File | Purpose |
 |------|---------|
 | `{domain}.go` | Parent command with `NewCommand()` and `AddCommand()` calls |
-| `output.go` | Client interface, `ClientFactory`, `printJSON()`, text formatters |
+| `output.go` | Client interface, `ClientFactory`, text formatters (no `printJSON()` — see #144) |
 | `{subcommand}.go` | One file per subcommand with `new{Sub}Command()` factory |
 | `mock_test.go` | Mock client with function fields + compile-time interface check |
 | `handlers_test.go` | `withMockClient()`, `withFailingClientFactory()`, integration tests |

--- a/docs/golden-principles.md
+++ b/docs/golden-principles.md
@@ -26,11 +26,11 @@ Parent commands export `NewCommand()` returning `*cobra.Command`. Subcommands us
 
 **Enforced by:** `TestDomainPackagesExportNewCommand`
 
-## 4. --json on every leaf command
+## 4. Text-only resource leaves (no per-command `--json`)
 
-All leaf subcommands (commands with no children) support `--json/-j` for machine-readable output. Download commands that output binary file data are exempt.
+Per cli-common `docs/output-and-rendering.md` §2, resource-surface leaf commands (every leaf under `mail`, `calendar`, `contacts`, `drive`, `me`) emit text output only. JSON is reserved for control-plane envelopes — today that's `gro refresh --json` (§4.6) and `gro config show --json` (diagnostic). Inverted from the pre-#144 "every leaf must have `--json`" rule.
 
-**Enforced by:** `TestAllLeafCommandsHaveJSONFlag`
+**Enforced by:** `TestResourceLeavesHaveNoJSONFlag`
 
 ## 5. Non-destructive only
 

--- a/docs/golden-principles.md
+++ b/docs/golden-principles.md
@@ -30,6 +30,8 @@ Parent commands export `NewCommand()` returning `*cobra.Command`. Subcommands us
 
 Per cli-common `docs/output-and-rendering.md` §2, resource-surface leaf commands (every leaf under `mail`, `calendar`, `contacts`, `drive`, `me`) emit text output only. JSON is reserved for control-plane envelopes — today that's `gro refresh --json` (§4.6) and `gro config show --json` (diagnostic). Inverted from the pre-#144 "every leaf must have `--json`" rule.
 
+**Control-plane carve-out criteria.** A command qualifies as a carve-out only if it (a) lives outside the domain resource packages (`internal/cmd/{mail,calendar,contacts,drive,me}`), AND (b) emits a control-plane envelope (write confirmation, cache freshness) or diagnostic introspection of CLI state — not a Google API resource. New JSON surfaces should be argued against these criteria before being added.
+
 **Enforced by:** `TestResourceLeavesHaveNoJSONFlag`
 
 ## 5. Non-destructive only

--- a/internal/architecture/architecture_test.go
+++ b/internal/architecture/architecture_test.go
@@ -25,14 +25,6 @@ var domainPackages = []string{"mail", "calendar", "contacts", "drive", "me"}
 // apiClientPackages lists the internal API client package directory names.
 var apiClientPackages = []string{"gmail", "calendar", "contacts", "drive", "people"}
 
-// jsonExemptCommands lists leaf commands exempt from the --json flag requirement.
-// Key format: "parent subcommand" (e.g., "mail attachments download").
-// Only add exemptions for commands that output binary file data where JSON is inapplicable.
-var jsonExemptCommands = map[string]bool{
-	"mail attachments download": true, // writes binary attachment files to disk
-	"drive download":            true, // writes binary file data to disk
-}
-
 // domainCommands returns the top-level cobra.Command for each domain package.
 func domainCommands() map[string]*cobra.Command {
 	return map[string]*cobra.Command{
@@ -236,9 +228,14 @@ func TestDomainPackagesExportNewCommand(t *testing.T) {
 	}
 }
 
-// TestAllLeafCommandsHaveJSONFlag verifies that every leaf subcommand
-// (commands with no children) declares a --json/-j flag.
-func TestAllLeafCommandsHaveJSONFlag(t *testing.T) {
+// TestResourceLeavesHaveNoJSONFlag verifies the §2 closed-set policy
+// from cli-common/docs/output-and-rendering.md: resource-surface leaf
+// commands (every leaf under mail/calendar/contacts/drive/me) emit text
+// output only. JSON is reserved for control-plane envelopes — today
+// that's `gro refresh --json` and `gro config show --json`, neither of
+// which is in domainCommands() so neither is touched by this walk.
+// Inverted from the pre-#144 TestAllLeafCommandsHaveJSONFlag invariant.
+func TestResourceLeavesHaveNoJSONFlag(t *testing.T) {
 	t.Parallel()
 
 	for name, cmd := range domainCommands() {
@@ -246,16 +243,8 @@ func TestAllLeafCommandsHaveJSONFlag(t *testing.T) {
 			t.Run(strings.TrimSpace(leaf.path), func(t *testing.T) {
 				t.Parallel()
 				key := strings.TrimSpace(leaf.path)
-				if jsonExemptCommands[key] {
-					t.Skipf("exempt from --json requirement")
-				}
-				flag := leaf.cmd.Flags().Lookup("json")
-				if flag == nil {
-					t.Errorf("leaf command %q must have a --json flag (see docs/golden-principles.md)", key)
-					return
-				}
-				if flag.Shorthand != "j" {
-					t.Errorf("leaf command %q --json flag must have shorthand 'j', got %q", key, flag.Shorthand)
+				if flag := leaf.cmd.Flags().Lookup("json"); flag != nil {
+					t.Errorf("resource-surface leaf %q must NOT declare --json (see docs/golden-principles.md §4 + cli-common output-and-rendering §2)", key)
 				}
 			})
 		}

--- a/internal/architecture/architecture_test.go
+++ b/internal/architecture/architecture_test.go
@@ -252,13 +252,13 @@ func TestResourceLeavesHaveNoJSONFlag(t *testing.T) {
 	}
 }
 
-// TestResourceLeaf_RejectsJSON_EndToEnd is the end-to-end complement to
-// TestResourceLeavesHaveNoJSONFlag — instead of inspecting the flag set
-// statically, it dispatches one representative resource leaf with --json
-// through cobra and asserts the user-visible "unknown flag" error.
-// The static guard catches missing flag declarations; this one catches a
-// hypothetical regression where the flag is declared but the structural
-// test's domain set was bypassed.
+// TestResourceLeaf_RejectsJSON_EndToEnd is a spot-check complement to the
+// structural walk in TestResourceLeavesHaveNoJSONFlag. It dispatches one
+// representative resource leaf with --json through cobra and asserts the
+// user-visible "unknown flag" error so the end-to-end contract is exercised,
+// not just the static flag set. Closing the closed-set bypass (a new domain
+// added outside domainPackages) still requires updating that list — neither
+// test compensates for that.
 func TestResourceLeaf_RejectsJSON_EndToEnd(t *testing.T) {
 	t.Parallel()
 	cmd := drivecmd.NewCommand()

--- a/internal/architecture/architecture_test.go
+++ b/internal/architecture/architecture_test.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -248,6 +249,31 @@ func TestResourceLeavesHaveNoJSONFlag(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+// TestResourceLeaf_RejectsJSON_EndToEnd is the end-to-end complement to
+// TestResourceLeavesHaveNoJSONFlag — instead of inspecting the flag set
+// statically, it dispatches one representative resource leaf with --json
+// through cobra and asserts the user-visible "unknown flag" error.
+// The static guard catches missing flag declarations; this one catches a
+// hypothetical regression where the flag is declared but the structural
+// test's domain set was bypassed.
+func TestResourceLeaf_RejectsJSON_EndToEnd(t *testing.T) {
+	t.Parallel()
+	cmd := drivecmd.NewCommand()
+	cmd.SetArgs([]string{"drives", "--json"})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("gro drive drives --json should error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown flag") {
+		t.Fatalf("expected 'unknown flag' error, got: %v", err)
 	}
 }
 

--- a/internal/bulk/result.go
+++ b/internal/bulk/result.go
@@ -3,25 +3,20 @@ package bulk
 import (
 	"fmt"
 	"strings"
-
-	"github.com/open-cli-collective/google-readonly/internal/output"
 )
 
 // Result represents the outcome of a bulk operation.
 type Result struct {
-	Action   string   `json:"action"`
-	IDs      []string `json:"ids"`
-	Count    int      `json:"count"`
-	DryRun   bool     `json:"dryRun"`
-	Details  any      `json:"details,omitempty"`
-	ItemNoun string   `json:"-"` // e.g. "message", "file", "contact"; defaults to "message"
+	Action   string
+	IDs      []string
+	Count    int
+	DryRun   bool
+	Details  any
+	ItemNoun string // e.g. "message", "file", "contact"; defaults to "message"
 }
 
-// Print outputs the result as text or JSON.
-func (r *Result) Print(jsonOutput bool) error {
-	if jsonOutput {
-		return output.JSONStdout(r)
-	}
+// Print outputs the result as text.
+func (r *Result) Print() error {
 	noun := r.ItemNoun
 	if noun == "" {
 		noun = "message"

--- a/internal/bulk/result_test.go
+++ b/internal/bulk/result_test.go
@@ -1,7 +1,6 @@
 package bulk
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/open-cli-collective/google-readonly/internal/testutil"
@@ -10,7 +9,7 @@ import (
 func TestResult_Print_Text(t *testing.T) {
 	r := &Result{Action: "archived", IDs: []string{"a", "b"}, Count: 2}
 	out := testutil.CaptureStdout(t, func() {
-		err := r.Print(false)
+		err := r.Print()
 		testutil.NoError(t, err)
 	})
 	testutil.Contains(t, out, "Archived 2 message(s).")
@@ -19,23 +18,10 @@ func TestResult_Print_Text(t *testing.T) {
 func TestResult_Print_TextDryRun(t *testing.T) {
 	r := &Result{Action: "archive", IDs: []string{"a", "b"}, Count: 2, DryRun: true}
 	out := testutil.CaptureStdout(t, func() {
-		err := r.Print(false)
+		err := r.Print()
 		testutil.NoError(t, err)
 	})
 	testutil.Contains(t, out, "[dry-run] Would archive 2 message(s).")
-}
-
-func TestResult_Print_JSON(t *testing.T) {
-	r := &Result{Action: "archived", IDs: []string{"a"}, Count: 1}
-	out := testutil.CaptureStdout(t, func() {
-		err := r.Print(true)
-		testutil.NoError(t, err)
-	})
-	var parsed Result
-	err := json.Unmarshal([]byte(out), &parsed)
-	testutil.NoError(t, err)
-	testutil.Equal(t, parsed.Action, "archived")
-	testutil.Equal(t, parsed.Count, 1)
 }
 
 func TestCapitalize(t *testing.T) {

--- a/internal/cmd/calendar/calendar.go
+++ b/internal/cmd/calendar/calendar.go
@@ -25,7 +25,7 @@ This command group provides Calendar functionality:
 Examples:
   gro calendar list
   gro cal events --max 20
-  gro cal today --json
+  gro cal today
   gro calendar get <event-id>
   gro cal rsvp <event-id> accept
   gro cal color <event-id> tomato`,

--- a/internal/cmd/calendar/calendar_test.go
+++ b/internal/cmd/calendar/calendar_test.go
@@ -58,13 +58,6 @@ func TestListCommand(t *testing.T) {
 		testutil.Error(t, err)
 	})
 
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-		testutil.Equal(t, flag.DefValue, "false")
-	})
-
 	t.Run("has short description", func(t *testing.T) {
 		testutil.NotEmpty(t, cmd.Short)
 		testutil.Contains(t, cmd.Short, "calendar")
@@ -87,12 +80,6 @@ func TestEventsCommand(t *testing.T) {
 
 		err = cmd.Args(cmd, []string{"calendar-id", "extra"})
 		testutil.Error(t, err)
-	})
-
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
 	})
 
 	t.Run("has max flag", func(t *testing.T) {
@@ -138,12 +125,6 @@ func TestGetCommand(t *testing.T) {
 		testutil.Error(t, err)
 	})
 
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-	})
-
 	t.Run("has calendar flag", func(t *testing.T) {
 		flag := cmd.Flags().Lookup("calendar")
 		testutil.NotNil(t, flag)
@@ -165,12 +146,6 @@ func TestTodayCommand(t *testing.T) {
 
 		err = cmd.Args(cmd, []string{"extra"})
 		testutil.Error(t, err)
-	})
-
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
 	})
 
 	t.Run("has calendar flag", func(t *testing.T) {
@@ -197,12 +172,6 @@ func TestWeekCommand(t *testing.T) {
 
 		err = cmd.Args(cmd, []string{"extra"})
 		testutil.Error(t, err)
-	})
-
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
 	})
 
 	t.Run("has calendar flag", func(t *testing.T) {

--- a/internal/cmd/calendar/color.go
+++ b/internal/cmd/calendar/color.go
@@ -36,7 +36,6 @@ var colorIDToName = func() map[string]string {
 func newColorCommand() *cobra.Command {
 	var (
 		calendarID string
-		jsonOutput bool
 		dryRun     bool
 	)
 
@@ -58,29 +57,18 @@ Color names: %s
 Examples:
   gro calendar color abc123 tomato
   gro cal color abc123 7
-  gro cal color abc123 sage --dry-run --json`, strings.Join(colorNames, ", ")),
+  gro cal color abc123 sage --dry-run`, strings.Join(colorNames, ", ")),
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			eventID := args[0]
 			colorInput := strings.ToLower(args[1])
 
-			// Resolve color input to ID and name
 			colorID, colorName, err := resolveColor(colorInput)
 			if err != nil {
 				return err
 			}
 
 			if dryRun {
-				result := map[string]any{
-					"action":    fmt.Sprintf("set event color to %s", colorName),
-					"eventId":   eventID,
-					"colorId":   colorID,
-					"colorName": colorName,
-					"dryRun":    true,
-				}
-				if jsonOutput {
-					return printJSON(result)
-				}
 				fmt.Printf("[dry-run] Would set event %s color to %s.\n", eventID, colorName)
 				return nil
 			}
@@ -94,23 +82,12 @@ Examples:
 				return fmt.Errorf("setting event color: %w", err)
 			}
 
-			result := map[string]any{
-				"action":    fmt.Sprintf("set event color to %s", colorName),
-				"eventId":   eventID,
-				"colorId":   colorID,
-				"colorName": colorName,
-				"dryRun":    false,
-			}
-			if jsonOutput {
-				return printJSON(result)
-			}
 			fmt.Printf("Set event %s color to %s.\n", eventID, colorName)
 			return nil
 		},
 	}
 
 	cmd.Flags().StringVarP(&calendarID, "calendar", "c", "primary", "Calendar ID containing the event")
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output as JSON")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
 
 	return cmd

--- a/internal/cmd/calendar/color_test.go
+++ b/internal/cmd/calendar/color_test.go
@@ -2,7 +2,6 @@ package calendar
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"testing"
 
@@ -11,12 +10,6 @@ import (
 
 func TestColorCommand(t *testing.T) {
 	cmd := newColorCommand()
-
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-	})
 
 	t.Run("has dry-run flag", func(t *testing.T) {
 		flag := cmd.Flags().Lookup("dry-run")
@@ -116,50 +109,6 @@ func TestColorCommand_DryRun(t *testing.T) {
 			testutil.NoError(t, err)
 		})
 		testutil.Contains(t, output, "[dry-run] Would set event event123 color to sage.")
-	})
-}
-
-func TestColorCommand_DryRunJSON(t *testing.T) {
-	cmd := newColorCommand()
-	cmd.SetArgs([]string{"event123", "flamingo", "--dry-run", "--json"})
-
-	withMockClient(&MockCalendarClient{}, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var result map[string]any
-		err := json.Unmarshal([]byte(output), &result)
-		testutil.NoError(t, err)
-		testutil.Equal(t, result["colorName"], "flamingo")
-		testutil.Equal(t, result["colorId"], "4")
-		testutil.Equal(t, result["dryRun"], true)
-	})
-}
-
-func TestColorCommand_JSON(t *testing.T) {
-	mock := &MockCalendarClient{
-		SetEventColorFunc: func(_ context.Context, _, _, _ string) error {
-			return nil
-		},
-	}
-
-	cmd := newColorCommand()
-	cmd.SetArgs([]string{"event123", "grape", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var result map[string]any
-		err := json.Unmarshal([]byte(output), &result)
-		testutil.NoError(t, err)
-		testutil.Equal(t, result["colorName"], "grape")
-		testutil.Equal(t, result["colorId"], "3")
-		testutil.Equal(t, result["dryRun"], false)
 	})
 }
 

--- a/internal/cmd/calendar/events.go
+++ b/internal/cmd/calendar/events.go
@@ -13,7 +13,6 @@ func newEventsCommand() *cobra.Command {
 		maxResults int64
 		from       string
 		to         string
-		jsonOutput bool
 	)
 
 	cmd := &cobra.Command{
@@ -30,7 +29,7 @@ Examples:
   gro calendar events
   gro cal events --max 20
   gro cal events --from 2026-01-01 --to 2026-01-31
-  gro calendar events work@group.calendar.google.com --json`,
+  gro calendar events work@group.calendar.google.com`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			calID := calendarID
@@ -71,7 +70,6 @@ Examples:
 				TimeMin:      timeMin,
 				TimeMax:      timeMax,
 				MaxResults:   maxResults,
-				JSONOutput:   jsonOutput,
 				Header:       "", // Will be generated based on count
 				EmptyMessage: "No events found.",
 			})
@@ -82,7 +80,6 @@ Examples:
 	cmd.Flags().Int64VarP(&maxResults, "max", "m", 10, "Maximum number of events to return")
 	cmd.Flags().StringVar(&from, "from", "", "Start date (YYYY-MM-DD)")
 	cmd.Flags().StringVar(&to, "to", "", "End date (YYYY-MM-DD)")
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output as JSON")
 
 	return cmd
 }

--- a/internal/cmd/calendar/events_helper.go
+++ b/internal/cmd/calendar/events_helper.go
@@ -13,7 +13,6 @@ type EventListOptions struct {
 	TimeMin      string // RFC3339 format
 	TimeMax      string // RFC3339 format
 	MaxResults   int64
-	JSONOutput   bool
 	Header       string // Header message to print (empty to show count-based header)
 	EmptyMessage string // Message when no events found
 }
@@ -27,10 +26,6 @@ func listAndPrintEvents(ctx context.Context, client CalendarClient, opts EventLi
 	}
 
 	if len(events) == 0 {
-		if opts.JSONOutput {
-			fmt.Println("[]")
-			return nil
-		}
 		if opts.EmptyMessage != "" {
 			fmt.Println(opts.EmptyMessage)
 		} else {
@@ -39,17 +34,11 @@ func listAndPrintEvents(ctx context.Context, client CalendarClient, opts EventLi
 		return nil
 	}
 
-	// Convert to our format
 	parsedEvents := make([]*calendar.Event, len(events))
 	for i, e := range events {
 		parsedEvents[i] = calendar.ParseEvent(e)
 	}
 
-	if opts.JSONOutput {
-		return printJSON(parsedEvents)
-	}
-
-	// Print header
 	if opts.Header != "" {
 		fmt.Printf("%s\n\n", opts.Header)
 	} else {

--- a/internal/cmd/calendar/get.go
+++ b/internal/cmd/calendar/get.go
@@ -11,7 +11,6 @@ import (
 func newGetCommand() *cobra.Command {
 	var (
 		calendarID string
-		jsonOutput bool
 	)
 
 	cmd := &cobra.Command{
@@ -23,7 +22,6 @@ Shows summary, time, location, description, attendees, and meeting links.
 
 Examples:
   gro calendar get abc123xyz
-  gro cal get abc123xyz --json
   gro cal get abc123xyz --calendar work@group.calendar.google.com`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -40,18 +38,12 @@ Examples:
 			}
 
 			parsedEvent := calendar.ParseEvent(event)
-
-			if jsonOutput {
-				return printJSON(parsedEvent)
-			}
-
 			printEvent(parsedEvent, true)
 			return nil
 		},
 	}
 
 	cmd.Flags().StringVarP(&calendarID, "calendar", "c", "primary", "Calendar ID containing the event")
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output as JSON")
 
 	return cmd
 }

--- a/internal/cmd/calendar/handlers_test.go
+++ b/internal/cmd/calendar/handlers_test.go
@@ -2,13 +2,11 @@ package calendar
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"testing"
 
 	"google.golang.org/api/calendar/v3"
 
-	calendarapi "github.com/open-cli-collective/google-readonly/internal/calendar"
 	"github.com/open-cli-collective/google-readonly/internal/testutil"
 )
 
@@ -47,29 +45,6 @@ func TestListCommand_Success(t *testing.T) {
 	})
 }
 
-func TestListCommand_JSONOutput(t *testing.T) {
-	mock := &MockCalendarClient{
-		ListCalendarsFunc: func(_ context.Context) ([]*calendar.CalendarListEntry, error) {
-			return testutil.SampleCalendars(), nil
-		},
-	}
-
-	cmd := newListCommand()
-	cmd.SetArgs([]string{"--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var calendars []*calendarapi.CalendarInfo
-		err := json.Unmarshal([]byte(output), &calendars)
-		testutil.NoError(t, err)
-		testutil.Len(t, calendars, 2)
-	})
-}
-
 func TestListCommand_Empty(t *testing.T) {
 	mock := &MockCalendarClient{
 		ListCalendarsFunc: func(_ context.Context) ([]*calendar.CalendarListEntry, error) {
@@ -86,29 +61,6 @@ func TestListCommand_Empty(t *testing.T) {
 		})
 
 		testutil.Contains(t, output, "No calendars found")
-	})
-}
-
-func TestListCommand_Empty_JSON(t *testing.T) {
-	mock := &MockCalendarClient{
-		ListCalendarsFunc: func(_ context.Context) ([]*calendar.CalendarListEntry, error) {
-			return []*calendar.CalendarListEntry{}, nil
-		},
-	}
-
-	cmd := newListCommand()
-	cmd.SetArgs([]string{"--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var calendars []any
-		err := json.Unmarshal([]byte(output), &calendars)
-		testutil.NoError(t, err)
-		testutil.Len(t, calendars, 0)
 	})
 }
 
@@ -185,52 +137,6 @@ func TestEventsCommand_WithDateRange(t *testing.T) {
 	})
 }
 
-func TestEventsCommand_JSONOutput(t *testing.T) {
-	mock := &MockCalendarClient{
-		ListEventsFunc: func(_ context.Context, _, _, _ string, _ int64) ([]*calendar.Event, error) {
-			return []*calendar.Event{testutil.SampleEvent("event1")}, nil
-		},
-	}
-
-	cmd := newEventsCommand()
-	cmd.SetArgs([]string{"--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var events []*calendarapi.Event
-		err := json.Unmarshal([]byte(output), &events)
-		testutil.NoError(t, err)
-		testutil.Len(t, events, 1)
-	})
-}
-
-func TestEventsCommand_Empty_JSON(t *testing.T) {
-	mock := &MockCalendarClient{
-		ListEventsFunc: func(_ context.Context, _, _, _ string, _ int64) ([]*calendar.Event, error) {
-			return []*calendar.Event{}, nil
-		},
-	}
-
-	cmd := newEventsCommand()
-	cmd.SetArgs([]string{"--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var events []any
-		err := json.Unmarshal([]byte(output), &events)
-		testutil.NoError(t, err)
-		testutil.Len(t, events, 0)
-	})
-}
-
 func TestEventsCommand_InvalidFromDate(t *testing.T) {
 	cmd := newEventsCommand()
 	cmd.SetArgs([]string{"--from", "invalid-date"})
@@ -277,29 +183,6 @@ func TestGetCommand_Success(t *testing.T) {
 	})
 }
 
-func TestGetCommand_JSONOutput(t *testing.T) {
-	mock := &MockCalendarClient{
-		GetEventFunc: func(_ context.Context, _, _ string) (*calendar.Event, error) {
-			return testutil.SampleEvent("event123"), nil
-		},
-	}
-
-	cmd := newGetCommand()
-	cmd.SetArgs([]string{"event123", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var event calendarapi.Event
-		err := json.Unmarshal([]byte(output), &event)
-		testutil.NoError(t, err)
-		testutil.Equal(t, event.ID, "event123")
-	})
-}
-
 func TestGetCommand_NotFound(t *testing.T) {
 	mock := &MockCalendarClient{
 		GetEventFunc: func(_ context.Context, _, _ string) (*calendar.Event, error) {
@@ -333,29 +216,6 @@ func TestTodayCommand_Success(t *testing.T) {
 		})
 
 		testutil.Contains(t, output, "Test Meeting")
-	})
-}
-
-func TestTodayCommand_Empty_JSON(t *testing.T) {
-	mock := &MockCalendarClient{
-		ListEventsFunc: func(_ context.Context, _, _, _ string, _ int64) ([]*calendar.Event, error) {
-			return []*calendar.Event{}, nil
-		},
-	}
-
-	cmd := newTodayCommand()
-	cmd.SetArgs([]string{"--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var events []any
-		err := json.Unmarshal([]byte(output), &events)
-		testutil.NoError(t, err)
-		testutil.Len(t, events, 0)
 	})
 }
 

--- a/internal/cmd/calendar/list.go
+++ b/internal/cmd/calendar/list.go
@@ -9,8 +9,6 @@ import (
 )
 
 func newListCommand() *cobra.Command {
-	var jsonOutput bool
-
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all calendars",
@@ -19,8 +17,7 @@ func newListCommand() *cobra.Command {
 Shows primary calendar, shared calendars, and subscribed calendars.
 
 Examples:
-  gro calendar list
-  gro cal list --json`,
+  gro calendar list`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := newCalendarClient(cmd.Context())
@@ -34,22 +31,13 @@ Examples:
 			}
 
 			if len(calendars) == 0 {
-				if jsonOutput {
-					fmt.Println("[]")
-					return nil
-				}
 				fmt.Println("No calendars found.")
 				return nil
 			}
 
-			// Convert to our format
 			calInfos := make([]*calendar.CalendarInfo, len(calendars))
 			for i, c := range calendars {
 				calInfos[i] = calendar.ParseCalendar(c)
-			}
-
-			if jsonOutput {
-				return printJSON(calInfos)
 			}
 
 			fmt.Printf("Found %d calendar(s):\n\n", len(calendars))
@@ -60,8 +48,6 @@ Examples:
 			return nil
 		},
 	}
-
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output as JSON")
 
 	return cmd
 }

--- a/internal/cmd/calendar/output.go
+++ b/internal/cmd/calendar/output.go
@@ -7,7 +7,6 @@ import (
 	calendarv3 "google.golang.org/api/calendar/v3"
 
 	"github.com/open-cli-collective/google-readonly/internal/calendar"
-	"github.com/open-cli-collective/google-readonly/internal/output"
 )
 
 // CalendarClient defines the interface for Calendar client operations used by calendar commands.
@@ -28,11 +27,6 @@ var ClientFactory = func(ctx context.Context) (CalendarClient, error) {
 // newCalendarClient creates a new calendar client
 func newCalendarClient(ctx context.Context) (CalendarClient, error) {
 	return ClientFactory(ctx)
-}
-
-// printJSON outputs data as indented JSON
-func printJSON(data any) error {
-	return output.JSONStdout(data)
 }
 
 // printEvent prints a single event in text format

--- a/internal/cmd/calendar/output_test.go
+++ b/internal/cmd/calendar/output_test.go
@@ -2,7 +2,6 @@ package calendar
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
 	"os"
 	"strings"
@@ -11,76 +10,6 @@ import (
 	"github.com/open-cli-collective/google-readonly/internal/calendar"
 	"github.com/open-cli-collective/google-readonly/internal/testutil"
 )
-
-func TestPrintJSON(t *testing.T) {
-	tests := []struct {
-		name     string
-		data     any
-		wantJSON string
-	}{
-		{
-			name: "single event",
-			data: &calendar.Event{
-				ID:      "event123",
-				Summary: "Team Meeting",
-			},
-			wantJSON: `{
-  "id": "event123",
-  "summary": "Team Meeting",
-  "start": null,
-  "end": null,
-  "status": "",
-  "allDay": false
-}
-`,
-		},
-		{
-			name: "event list",
-			data: []*calendar.Event{
-				{ID: "e1", Summary: "Event 1"},
-				{ID: "e2", Summary: "Event 2"},
-			},
-		},
-		{
-			name: "calendar info",
-			data: &calendar.CalendarInfo{
-				ID:      "primary",
-				Summary: "My Calendar",
-				Primary: true,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Capture stdout
-			oldStdout := os.Stdout
-			r, w, _ := os.Pipe()
-			os.Stdout = w
-
-			err := printJSON(tt.data)
-			testutil.NoError(t, err)
-
-			w.Close()
-			os.Stdout = oldStdout
-
-			var buf bytes.Buffer
-			io.Copy(&buf, r)
-
-			output := buf.String()
-			testutil.NotEmpty(t, output)
-
-			// Verify it's valid JSON
-			var parsed any
-			err = json.Unmarshal([]byte(output), &parsed)
-			testutil.NoError(t, err)
-
-			if tt.wantJSON != "" {
-				testutil.Equal(t, output, tt.wantJSON)
-			}
-		})
-	}
-}
 
 func TestPrintEvent(t *testing.T) {
 	tests := []struct {

--- a/internal/cmd/calendar/rsvp.go
+++ b/internal/cmd/calendar/rsvp.go
@@ -17,7 +17,6 @@ var validResponses = map[string]string{
 func newRSVPCommand() *cobra.Command {
 	var (
 		calendarID string
-		jsonOutput bool
 		dryRun     bool
 	)
 
@@ -31,7 +30,7 @@ Valid responses: accept, decline, tentative
 Examples:
   gro calendar rsvp abc123 accept
   gro cal rsvp abc123 decline --dry-run
-  gro cal rsvp abc123 tentative --calendar work@group.calendar.google.com --json`,
+  gro cal rsvp abc123 tentative --calendar work@group.calendar.google.com`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			eventID := args[0]
@@ -43,15 +42,6 @@ Examples:
 			}
 
 			if dryRun {
-				result := map[string]any{
-					"action":   fmt.Sprintf("RSVP '%s' to event", apiResponse),
-					"eventId":  eventID,
-					"response": apiResponse,
-					"dryRun":   true,
-				}
-				if jsonOutput {
-					return printJSON(result)
-				}
 				fmt.Printf("[dry-run] Would RSVP '%s' to event %s.\n", apiResponse, eventID)
 				return nil
 			}
@@ -65,22 +55,12 @@ Examples:
 				return fmt.Errorf("updating RSVP: %w", err)
 			}
 
-			result := map[string]any{
-				"action":   fmt.Sprintf("RSVP'd '%s' to event", apiResponse),
-				"eventId":  eventID,
-				"response": apiResponse,
-				"dryRun":   false,
-			}
-			if jsonOutput {
-				return printJSON(result)
-			}
 			fmt.Printf("RSVP'd '%s' to event %s.\n", apiResponse, eventID)
 			return nil
 		},
 	}
 
 	cmd.Flags().StringVarP(&calendarID, "calendar", "c", "primary", "Calendar ID containing the event")
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output as JSON")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
 
 	return cmd

--- a/internal/cmd/calendar/rsvp_test.go
+++ b/internal/cmd/calendar/rsvp_test.go
@@ -2,7 +2,6 @@ package calendar
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"testing"
 
@@ -11,12 +10,6 @@ import (
 
 func TestRSVPCommand(t *testing.T) {
 	cmd := newRSVPCommand()
-
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-	})
 
 	t.Run("has dry-run flag", func(t *testing.T) {
 		flag := cmd.Flags().Lookup("dry-run")
@@ -126,49 +119,6 @@ func TestRSVPCommand_DryRun(t *testing.T) {
 			testutil.NoError(t, err)
 		})
 		testutil.Contains(t, output, "[dry-run] Would RSVP 'accepted' to event event123.")
-	})
-}
-
-func TestRSVPCommand_DryRunJSON(t *testing.T) {
-	cmd := newRSVPCommand()
-	cmd.SetArgs([]string{"event123", "decline", "--dry-run", "--json"})
-
-	withMockClient(&MockCalendarClient{}, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var result map[string]any
-		err := json.Unmarshal([]byte(output), &result)
-		testutil.NoError(t, err)
-		testutil.Equal(t, result["response"], "declined")
-		testutil.Equal(t, result["dryRun"], true)
-	})
-}
-
-func TestRSVPCommand_JSON(t *testing.T) {
-	mock := &MockCalendarClient{
-		RSVPEventFunc: func(_ context.Context, _, _, _ string) error {
-			return nil
-		},
-	}
-
-	cmd := newRSVPCommand()
-	cmd.SetArgs([]string{"event123", "accept", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var result map[string]any
-		err := json.Unmarshal([]byte(output), &result)
-		testutil.NoError(t, err)
-		testutil.Equal(t, result["response"], "accepted")
-		testutil.Equal(t, result["eventId"], "event123")
-		testutil.Equal(t, result["dryRun"], false)
 	})
 }
 

--- a/internal/cmd/calendar/today.go
+++ b/internal/cmd/calendar/today.go
@@ -10,7 +10,6 @@ import (
 func newTodayCommand() *cobra.Command {
 	var (
 		calendarID string
-		jsonOutput bool
 	)
 
 	cmd := &cobra.Command{
@@ -22,7 +21,6 @@ This is a shortcut for: gro calendar events --from <today> --to <today>
 
 Examples:
   gro calendar today
-  gro cal today --json
   gro cal today --calendar work@group.calendar.google.com`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -39,7 +37,6 @@ Examples:
 				TimeMin:      startOfDay.Format(time.RFC3339),
 				TimeMax:      endOfDayTime.Format(time.RFC3339),
 				MaxResults:   50,
-				JSONOutput:   jsonOutput,
 				Header:       fmt.Sprintf("Today's events (%s):", now.Format("Mon, Jan 2, 2006")),
 				EmptyMessage: "No events today.",
 			})
@@ -47,7 +44,6 @@ Examples:
 	}
 
 	cmd.Flags().StringVarP(&calendarID, "calendar", "c", "primary", "Calendar ID to query")
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output as JSON")
 
 	return cmd
 }

--- a/internal/cmd/calendar/week.go
+++ b/internal/cmd/calendar/week.go
@@ -10,7 +10,6 @@ import (
 func newWeekCommand() *cobra.Command {
 	var (
 		calendarID string
-		jsonOutput bool
 	)
 
 	cmd := &cobra.Command{
@@ -22,7 +21,6 @@ This is a shortcut for: gro calendar events --from <monday> --to <sunday>
 
 Examples:
   gro calendar week
-  gro cal week --json
   gro cal week --calendar work@group.calendar.google.com`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -39,7 +37,6 @@ Examples:
 				TimeMin:    startOfWeek.Format(time.RFC3339),
 				TimeMax:    endOfWeek.Format(time.RFC3339),
 				MaxResults: 100,
-				JSONOutput: jsonOutput,
 				Header: fmt.Sprintf("This week's events (%s - %s):",
 					startOfWeek.Format("Mon, Jan 2"),
 					endOfWeek.Format("Mon, Jan 2, 2006")),
@@ -49,7 +46,6 @@ Examples:
 	}
 
 	cmd.Flags().StringVarP(&calendarID, "calendar", "c", "primary", "Calendar ID to query")
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output as JSON")
 
 	return cmd
 }

--- a/internal/cmd/config/config_test.go
+++ b/internal/cmd/config/config_test.go
@@ -53,6 +53,12 @@ func TestConfigShowCommand(t *testing.T) {
 	t.Run("has long description", func(t *testing.T) {
 		testutil.NotEmpty(t, cmd.Long)
 	})
+
+	t.Run("declares --json (control-plane carve-out per #144)", func(t *testing.T) {
+		flag := cmd.Flags().Lookup("json")
+		testutil.NotNil(t, flag)
+		testutil.Equal(t, flag.Shorthand, "j")
+	})
 }
 
 func TestConfigTestCommand(t *testing.T) {

--- a/internal/cmd/contacts/contacts_test.go
+++ b/internal/cmd/contacts/contacts_test.go
@@ -73,13 +73,6 @@ func TestListCommand(t *testing.T) {
 		testutil.Equal(t, flag.DefValue, "10")
 	})
 
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-		testutil.Equal(t, flag.DefValue, "false")
-	})
-
 	t.Run("has ids flag", func(t *testing.T) {
 		flag := cmd.Flags().Lookup("ids")
 		testutil.NotNil(t, flag)
@@ -119,12 +112,6 @@ func TestSearchCommand(t *testing.T) {
 		testutil.Equal(t, flag.Shorthand, "m")
 	})
 
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-	})
-
 	t.Run("has ids flag", func(t *testing.T) {
 		flag := cmd.Flags().Lookup("ids")
 		testutil.NotNil(t, flag)
@@ -153,11 +140,6 @@ func TestGetCommand(t *testing.T) {
 		testutil.NotEmpty(t, cmd.Short)
 	})
 
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-	})
 }
 
 func TestAddToGroupCommand(t *testing.T) {
@@ -178,12 +160,6 @@ func TestAddToGroupCommand(t *testing.T) {
 	t.Run("rejects no arguments", func(t *testing.T) {
 		err := cmd.Args(cmd, []string{})
 		testutil.Error(t, err)
-	})
-
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
 	})
 
 	t.Run("has dry-run flag", func(t *testing.T) {
@@ -215,12 +191,6 @@ func TestRemoveFromGroupCommand(t *testing.T) {
 		testutil.NoError(t, err)
 	})
 
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-	})
-
 	t.Run("has dry-run flag", func(t *testing.T) {
 		flag := cmd.Flags().Lookup("dry-run")
 		testutil.NotNil(t, flag)
@@ -232,12 +202,6 @@ func TestStarCommand(t *testing.T) {
 
 	t.Run("has correct use", func(t *testing.T) {
 		testutil.Contains(t, cmd.Use, "star")
-	})
-
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
 	})
 
 	t.Run("has dry-run flag", func(t *testing.T) {
@@ -261,12 +225,6 @@ func TestUnstarCommand(t *testing.T) {
 
 	t.Run("has correct use", func(t *testing.T) {
 		testutil.Contains(t, cmd.Use, "unstar")
-	})
-
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
 	})
 
 	t.Run("has dry-run flag", func(t *testing.T) {
@@ -303,9 +261,4 @@ func TestGroupsCommand(t *testing.T) {
 		testutil.Equal(t, flag.DefValue, "30")
 	})
 
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-	})
 }

--- a/internal/cmd/contacts/get.go
+++ b/internal/cmd/contacts/get.go
@@ -9,7 +9,6 @@ import (
 )
 
 func newGetCommand() *cobra.Command {
-	var jsonOutput bool
 
 	cmd := &cobra.Command{
 		Use:   "get <resource-name>",
@@ -20,8 +19,7 @@ The resource name is in the format "people/c123456789" and can be
 obtained from the list or search commands.
 
 Examples:
-  gro contacts get people/c123456789
-  gro ppl get people/c123456789 --json`,
+  gro contacts get people/c123456789`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resourceName := args[0]
@@ -37,18 +35,11 @@ Examples:
 			}
 
 			contact := contacts.ParseContact(person)
-
-			if jsonOutput {
-				return printJSON(contact)
-			}
-
 			printContact(contact, true)
 
 			return nil
 		},
 	}
-
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output as JSON")
 
 	return cmd
 }

--- a/internal/cmd/contacts/group_manage.go
+++ b/internal/cmd/contacts/group_manage.go
@@ -10,10 +10,9 @@ import (
 
 func newAddToGroupCommand() *cobra.Command {
 	var (
-		jsonOutput bool
-		dryRun     bool
-		stdin      bool
-		query      string
+		dryRun bool
+		stdin  bool
+		query  string
 	)
 
 	cmd := &cobra.Command{
@@ -71,18 +70,17 @@ Examples:
 
 			if dryRun {
 				result.Action = fmt.Sprintf("add to group '%s'", groupName)
-				return result.Print(jsonOutput)
+				return result.Print()
 			}
 
 			if err := client.AddToGroup(ctx, groupResourceName, ids); err != nil {
 				return fmt.Errorf("adding contacts to group: %w", err)
 			}
 
-			return result.Print(jsonOutput)
+			return result.Print()
 		},
 	}
 
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
 	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read contact IDs from stdin")
 	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve contact IDs")
@@ -92,10 +90,9 @@ Examples:
 
 func newRemoveFromGroupCommand() *cobra.Command {
 	var (
-		jsonOutput bool
-		dryRun     bool
-		stdin      bool
-		query      string
+		dryRun bool
+		stdin  bool
+		query  string
 	)
 
 	cmd := &cobra.Command{
@@ -152,18 +149,17 @@ Examples:
 
 			if dryRun {
 				result.Action = fmt.Sprintf("remove from group '%s'", groupName)
-				return result.Print(jsonOutput)
+				return result.Print()
 			}
 
 			if err := client.RemoveFromGroup(ctx, groupResourceName, ids); err != nil {
 				return fmt.Errorf("removing contacts from group: %w", err)
 			}
 
-			return result.Print(jsonOutput)
+			return result.Print()
 		},
 	}
 
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
 	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read contact IDs from stdin")
 	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve contact IDs")

--- a/internal/cmd/contacts/group_manage_test.go
+++ b/internal/cmd/contacts/group_manage_test.go
@@ -2,7 +2,6 @@ package contacts
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"testing"
 
@@ -59,55 +58,6 @@ func TestAddToGroupCommand_DryRun(t *testing.T) {
 		testutil.Contains(t, output, "[dry-run]")
 		testutil.Contains(t, output, "add to group 'Friends'")
 		testutil.Contains(t, output, "1 contact(s)")
-	})
-}
-
-func TestAddToGroupCommand_DryRunJSON(t *testing.T) {
-	mock := &MockContactsClient{
-		ResolveGroupNameFunc: func(_ context.Context, _ string) (string, error) {
-			return "contactGroups/abc123", nil
-		},
-	}
-
-	cmd := newAddToGroupCommand()
-	cmd.SetArgs([]string{"Friends", "people/c111", "--dry-run", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var result map[string]any
-		err := json.Unmarshal([]byte(output), &result)
-		testutil.NoError(t, err)
-		testutil.Equal(t, result["dryRun"].(bool), true)
-	})
-}
-
-func TestAddToGroupCommand_JSON(t *testing.T) {
-	mock := &MockContactsClient{
-		ResolveGroupNameFunc: func(_ context.Context, _ string) (string, error) {
-			return "contactGroups/abc123", nil
-		},
-		AddToGroupFunc: func(_ context.Context, _ string, _ []string) error {
-			return nil
-		},
-	}
-
-	cmd := newAddToGroupCommand()
-	cmd.SetArgs([]string{"Friends", "people/c111", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var result map[string]any
-		err := json.Unmarshal([]byte(output), &result)
-		testutil.NoError(t, err)
-		testutil.Equal(t, result["count"].(float64), float64(1))
 	})
 }
 

--- a/internal/cmd/contacts/groups.go
+++ b/internal/cmd/contacts/groups.go
@@ -11,7 +11,6 @@ import (
 func newGroupsCommand() *cobra.Command {
 	var (
 		maxResults int64
-		jsonOutput bool
 	)
 
 	cmd := &cobra.Command{
@@ -23,8 +22,7 @@ Contact groups include both user-created labels and system groups.
 
 Examples:
   gro contacts groups
-  gro contacts groups --max 50
-  gro ppl groups --json`,
+  gro contacts groups --max 50`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := newContactsClient(cmd.Context())
@@ -38,22 +36,13 @@ Examples:
 			}
 
 			if len(resp.ContactGroups) == 0 {
-				if jsonOutput {
-					fmt.Println("[]")
-					return nil
-				}
 				fmt.Println("No contact groups found.")
 				return nil
 			}
 
-			// Convert to our format
 			parsedGroups := make([]*contacts.ContactGroup, len(resp.ContactGroups))
 			for i, g := range resp.ContactGroups {
 				parsedGroups[i] = contacts.ParseContactGroup(g)
-			}
-
-			if jsonOutput {
-				return printJSON(parsedGroups)
 			}
 
 			fmt.Printf("Found %d contact group(s):\n\n", len(resp.ContactGroups))
@@ -66,7 +55,6 @@ Examples:
 	}
 
 	cmd.Flags().Int64VarP(&maxResults, "max", "m", 30, "Maximum number of groups to return")
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output as JSON")
 
 	return cmd
 }

--- a/internal/cmd/contacts/handlers_test.go
+++ b/internal/cmd/contacts/handlers_test.go
@@ -2,13 +2,11 @@ package contacts
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"testing"
 
 	"google.golang.org/api/people/v1"
 
-	contactsapi "github.com/open-cli-collective/google-readonly/internal/contacts"
 	"github.com/open-cli-collective/google-readonly/internal/testutil"
 )
 
@@ -52,33 +50,6 @@ func TestListCommand_Success(t *testing.T) {
 	})
 }
 
-func TestListCommand_JSONOutput(t *testing.T) {
-	mock := &MockContactsClient{
-		ListContactsFunc: func(_ context.Context, _ string, _ int64) (*people.ListConnectionsResponse, error) {
-			return &people.ListConnectionsResponse{
-				Connections: []*people.Person{
-					testutil.SamplePerson("people/c123"),
-				},
-			}, nil
-		},
-	}
-
-	cmd := newListCommand()
-	cmd.SetArgs([]string{"--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var contacts []*contactsapi.Contact
-		err := json.Unmarshal([]byte(output), &contacts)
-		testutil.NoError(t, err)
-		testutil.Len(t, contacts, 1)
-	})
-}
-
 func TestListCommand_Empty(t *testing.T) {
 	mock := &MockContactsClient{
 		ListContactsFunc: func(_ context.Context, _ string, _ int64) (*people.ListConnectionsResponse, error) {
@@ -97,31 +68,6 @@ func TestListCommand_Empty(t *testing.T) {
 		})
 
 		testutil.Contains(t, output, "No contacts found")
-	})
-}
-
-func TestListCommand_Empty_JSON(t *testing.T) {
-	mock := &MockContactsClient{
-		ListContactsFunc: func(_ context.Context, _ string, _ int64) (*people.ListConnectionsResponse, error) {
-			return &people.ListConnectionsResponse{
-				Connections: []*people.Person{},
-			}, nil
-		},
-	}
-
-	cmd := newListCommand()
-	cmd.SetArgs([]string{"--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var contacts []any
-		err := json.Unmarshal([]byte(output), &contacts)
-		testutil.NoError(t, err)
-		testutil.Len(t, contacts, 0)
 	})
 }
 
@@ -177,33 +123,6 @@ func TestSearchCommand_Success(t *testing.T) {
 	})
 }
 
-func TestSearchCommand_JSONOutput(t *testing.T) {
-	mock := &MockContactsClient{
-		SearchContactsFunc: func(_ context.Context, _ string, _ int64) (*people.SearchResponse, error) {
-			return &people.SearchResponse{
-				Results: []*people.SearchResult{
-					{Person: testutil.SamplePerson("people/c123")},
-				},
-			}, nil
-		},
-	}
-
-	cmd := newSearchCommand()
-	cmd.SetArgs([]string{"John", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var contacts []*contactsapi.Contact
-		err := json.Unmarshal([]byte(output), &contacts)
-		testutil.NoError(t, err)
-		testutil.Len(t, contacts, 1)
-	})
-}
-
 func TestSearchCommand_NoResults(t *testing.T) {
 	mock := &MockContactsClient{
 		SearchContactsFunc: func(_ context.Context, _ string, _ int64) (*people.SearchResponse, error) {
@@ -223,31 +142,6 @@ func TestSearchCommand_NoResults(t *testing.T) {
 		})
 
 		testutil.Contains(t, output, "No contacts found")
-	})
-}
-
-func TestSearchCommand_NoResults_JSON(t *testing.T) {
-	mock := &MockContactsClient{
-		SearchContactsFunc: func(_ context.Context, _ string, _ int64) (*people.SearchResponse, error) {
-			return &people.SearchResponse{
-				Results: []*people.SearchResult{},
-			}, nil
-		},
-	}
-
-	cmd := newSearchCommand()
-	cmd.SetArgs([]string{"nonexistent", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var contacts []any
-		err := json.Unmarshal([]byte(output), &contacts)
-		testutil.NoError(t, err)
-		testutil.Len(t, contacts, 0)
 	})
 }
 
@@ -288,29 +182,6 @@ func TestGetCommand_Success(t *testing.T) {
 		testutil.Contains(t, output, "people/c123")
 		testutil.Contains(t, output, "John Doe")
 		testutil.Contains(t, output, "john@example.com")
-	})
-}
-
-func TestGetCommand_JSONOutput(t *testing.T) {
-	mock := &MockContactsClient{
-		GetContactFunc: func(_ context.Context, _ string) (*people.Person, error) {
-			return testutil.SamplePerson("people/c123"), nil
-		},
-	}
-
-	cmd := newGetCommand()
-	cmd.SetArgs([]string{"people/c123", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var contact contactsapi.Contact
-		err := json.Unmarshal([]byte(output), &contact)
-		testutil.NoError(t, err)
-		testutil.Equal(t, contact.ResourceName, "people/c123")
 	})
 }
 
@@ -367,39 +238,6 @@ func TestGroupsCommand_Success(t *testing.T) {
 	})
 }
 
-func TestGroupsCommand_JSONOutput(t *testing.T) {
-	mock := &MockContactsClient{
-		ListContactGroupsFunc: func(_ context.Context, _ string, _ int64) (*people.ListContactGroupsResponse, error) {
-			return &people.ListContactGroupsResponse{
-				ContactGroups: []*people.ContactGroup{
-					{
-						ResourceName: "contactGroups/123",
-						Name:         "Friends",
-						GroupType:    "USER_CONTACT_GROUP",
-						MemberCount:  5,
-					},
-				},
-			}, nil
-		},
-	}
-
-	cmd := newGroupsCommand()
-	cmd.SetArgs([]string{"--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var groups []*contactsapi.ContactGroup
-		err := json.Unmarshal([]byte(output), &groups)
-		testutil.NoError(t, err)
-		testutil.Len(t, groups, 1)
-		testutil.Equal(t, groups[0].Name, "Friends")
-	})
-}
-
 func TestGroupsCommand_Empty(t *testing.T) {
 	mock := &MockContactsClient{
 		ListContactGroupsFunc: func(_ context.Context, _ string, _ int64) (*people.ListContactGroupsResponse, error) {
@@ -418,31 +256,6 @@ func TestGroupsCommand_Empty(t *testing.T) {
 		})
 
 		testutil.Contains(t, output, "No contact groups found")
-	})
-}
-
-func TestGroupsCommand_Empty_JSON(t *testing.T) {
-	mock := &MockContactsClient{
-		ListContactGroupsFunc: func(_ context.Context, _ string, _ int64) (*people.ListContactGroupsResponse, error) {
-			return &people.ListContactGroupsResponse{
-				ContactGroups: []*people.ContactGroup{},
-			}, nil
-		},
-	}
-
-	cmd := newGroupsCommand()
-	cmd.SetArgs([]string{"--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var groups []any
-		err := json.Unmarshal([]byte(output), &groups)
-		testutil.NoError(t, err)
-		testutil.Len(t, groups, 0)
 	})
 }
 
@@ -489,17 +302,6 @@ func TestListCommand_IDsOutput(t *testing.T) {
 	})
 }
 
-func TestListCommand_IDsAndJSONMutuallyExclusive(t *testing.T) {
-	cmd := newListCommand()
-	cmd.SetArgs([]string{"--ids", "--json"})
-
-	withMockClient(&MockContactsClient{}, func() {
-		err := cmd.Execute()
-		testutil.Error(t, err)
-		testutil.Contains(t, err.Error(), "mutually exclusive")
-	})
-}
-
 func TestSearchCommand_IDsOutput(t *testing.T) {
 	mock := &MockContactsClient{
 		SearchContactsFunc: func(_ context.Context, _ string, _ int64) (*people.SearchResponse, error) {
@@ -524,16 +326,5 @@ func TestSearchCommand_IDsOutput(t *testing.T) {
 		testutil.Contains(t, output, "people/c123")
 		testutil.Contains(t, output, "people/c456")
 		testutil.NotContains(t, output, "John Doe")
-	})
-}
-
-func TestSearchCommand_IDsAndJSONMutuallyExclusive(t *testing.T) {
-	cmd := newSearchCommand()
-	cmd.SetArgs([]string{"John", "--ids", "--json"})
-
-	withMockClient(&MockContactsClient{}, func() {
-		err := cmd.Execute()
-		testutil.Error(t, err)
-		testutil.Contains(t, err.Error(), "mutually exclusive")
 	})
 }

--- a/internal/cmd/contacts/list.go
+++ b/internal/cmd/contacts/list.go
@@ -11,7 +11,6 @@ import (
 func newListCommand() *cobra.Command {
 	var (
 		maxResults int64
-		jsonOutput bool
 		idsOutput  bool
 	)
 
@@ -25,14 +24,9 @@ Contacts are sorted by last name.
 Examples:
   gro contacts list
   gro contacts list --max 50
-  gro ppl list --json
   gro ppl list --ids | gro contacts star --stdin`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if idsOutput && jsonOutput {
-				return fmt.Errorf("--ids and --json are mutually exclusive")
-			}
-
 			client, err := newContactsClient(cmd.Context())
 			if err != nil {
 				return fmt.Errorf("creating Contacts client: %w", err)
@@ -44,10 +38,6 @@ Examples:
 			}
 
 			if len(resp.Connections) == 0 {
-				if jsonOutput {
-					fmt.Println("[]")
-					return nil
-				}
 				if !idsOutput {
 					fmt.Println("No contacts found.")
 				}
@@ -61,14 +51,9 @@ Examples:
 				return nil
 			}
 
-			// Convert to our format
 			parsedContacts := make([]*contacts.Contact, len(resp.Connections))
 			for i, p := range resp.Connections {
 				parsedContacts[i] = contacts.ParseContact(p)
-			}
-
-			if jsonOutput {
-				return printJSON(parsedContacts)
 			}
 
 			fmt.Printf("Found %d contact(s):\n\n", len(resp.Connections))
@@ -81,7 +66,6 @@ Examples:
 	}
 
 	cmd.Flags().Int64VarP(&maxResults, "max", "m", 10, "Maximum number of contacts to return")
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output as JSON")
 	cmd.Flags().BoolVar(&idsOutput, "ids", false, "Output only resource names, one per line")
 
 	return cmd

--- a/internal/cmd/contacts/output.go
+++ b/internal/cmd/contacts/output.go
@@ -7,7 +7,6 @@ import (
 	"google.golang.org/api/people/v1"
 
 	"github.com/open-cli-collective/google-readonly/internal/contacts"
-	"github.com/open-cli-collective/google-readonly/internal/output"
 )
 
 // ContactsClient defines the interface for Contacts client operations used by contacts commands.
@@ -31,11 +30,6 @@ var ClientFactory = func(ctx context.Context) (ContactsClient, error) {
 // newContactsClient creates a new contacts client
 func newContactsClient(ctx context.Context) (ContactsClient, error) {
 	return ClientFactory(ctx)
-}
-
-// printJSON outputs data as indented JSON
-func printJSON(data any) error {
-	return output.JSONStdout(data)
 }
 
 // printContact prints a single contact in text format

--- a/internal/cmd/contacts/output_test.go
+++ b/internal/cmd/contacts/output_test.go
@@ -2,7 +2,6 @@ package contacts
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
 	"os"
 	"testing"
@@ -10,62 +9,6 @@ import (
 	"github.com/open-cli-collective/google-readonly/internal/contacts"
 	"github.com/open-cli-collective/google-readonly/internal/testutil"
 )
-
-func TestPrintJSON(t *testing.T) {
-	tests := []struct {
-		name string
-		data any
-	}{
-		{
-			name: "single contact",
-			data: &contacts.Contact{
-				ResourceName: "people/c123",
-				DisplayName:  "John Doe",
-			},
-		},
-		{
-			name: "contact list",
-			data: []*contacts.Contact{
-				{ResourceName: "people/c1", DisplayName: "Alice"},
-				{ResourceName: "people/c2", DisplayName: "Bob"},
-			},
-		},
-		{
-			name: "contact group",
-			data: &contacts.ContactGroup{
-				ResourceName: "contactGroups/abc",
-				Name:         "Work",
-				MemberCount:  5,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Capture stdout
-			oldStdout := os.Stdout
-			r, w, _ := os.Pipe()
-			os.Stdout = w
-
-			err := printJSON(tt.data)
-			testutil.NoError(t, err)
-
-			w.Close()
-			os.Stdout = oldStdout
-
-			var buf bytes.Buffer
-			io.Copy(&buf, r)
-
-			output := buf.String()
-			testutil.NotEmpty(t, output)
-
-			// Verify it's valid JSON
-			var parsed any
-			err = json.Unmarshal([]byte(output), &parsed)
-			testutil.NoError(t, err)
-		})
-	}
-}
 
 func TestPrintContact(t *testing.T) {
 	tests := []struct {

--- a/internal/cmd/contacts/search.go
+++ b/internal/cmd/contacts/search.go
@@ -11,7 +11,6 @@ import (
 func newSearchCommand() *cobra.Command {
 	var (
 		maxResults int64
-		jsonOutput bool
 		idsOutput  bool
 	)
 
@@ -31,14 +30,9 @@ Examples:
   gro contacts search "John"
   gro contacts search "example.com"
   gro contacts search "+1-555" --max 20
-  gro ppl search "Acme" --json
   gro ppl search "John" --ids | gro contacts add-to-group "Friends" --stdin`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if idsOutput && jsonOutput {
-				return fmt.Errorf("--ids and --json are mutually exclusive")
-			}
-
 			query := args[0]
 
 			client, err := newContactsClient(cmd.Context())
@@ -52,10 +46,6 @@ Examples:
 			}
 
 			if len(resp.Results) == 0 {
-				if jsonOutput {
-					fmt.Println("[]")
-					return nil
-				}
 				if !idsOutput {
 					fmt.Printf("No contacts found matching \"%s\".\n", query)
 				}
@@ -71,14 +61,9 @@ Examples:
 				return nil
 			}
 
-			// Convert to our format
 			parsedContacts := make([]*contacts.Contact, len(resp.Results))
 			for i, r := range resp.Results {
 				parsedContacts[i] = contacts.ParseContact(r.Person)
-			}
-
-			if jsonOutput {
-				return printJSON(parsedContacts)
 			}
 
 			fmt.Printf("Found %d contact(s) matching \"%s\":\n\n", len(resp.Results), query)
@@ -91,7 +76,6 @@ Examples:
 	}
 
 	cmd.Flags().Int64VarP(&maxResults, "max", "m", 10, "Maximum number of results")
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output as JSON")
 	cmd.Flags().BoolVar(&idsOutput, "ids", false, "Output only resource names, one per line")
 
 	return cmd

--- a/internal/cmd/contacts/star.go
+++ b/internal/cmd/contacts/star.go
@@ -13,10 +13,9 @@ const starredGroupResourceName = "contactGroups/starred"
 
 func newStarCommand() *cobra.Command {
 	var (
-		jsonOutput bool
-		dryRun     bool
-		stdin      bool
-		query      string
+		dryRun bool
+		stdin  bool
+		query  string
 	)
 
 	cmd := &cobra.Command{
@@ -63,18 +62,17 @@ Examples:
 
 			if dryRun {
 				result.Action = "star"
-				return result.Print(jsonOutput)
+				return result.Print()
 			}
 
 			if err := client.AddToGroup(ctx, starredGroupResourceName, ids); err != nil {
 				return fmt.Errorf("starring contacts: %w", err)
 			}
 
-			return result.Print(jsonOutput)
+			return result.Print()
 		},
 	}
 
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
 	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read contact IDs from stdin")
 	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve contact IDs")
@@ -84,10 +82,9 @@ Examples:
 
 func newUnstarCommand() *cobra.Command {
 	var (
-		jsonOutput bool
-		dryRun     bool
-		stdin      bool
-		query      string
+		dryRun bool
+		stdin  bool
+		query  string
 	)
 
 	cmd := &cobra.Command{
@@ -133,18 +130,17 @@ Examples:
 
 			if dryRun {
 				result.Action = "unstar"
-				return result.Print(jsonOutput)
+				return result.Print()
 			}
 
 			if err := client.RemoveFromGroup(ctx, starredGroupResourceName, ids); err != nil {
 				return fmt.Errorf("unstarring contacts: %w", err)
 			}
 
-			return result.Print(jsonOutput)
+			return result.Print()
 		},
 	}
 
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
 	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read contact IDs from stdin")
 	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve contact IDs")

--- a/internal/cmd/contacts/star_test.go
+++ b/internal/cmd/contacts/star_test.go
@@ -2,7 +2,6 @@ package contacts
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"testing"
 
@@ -51,50 +50,6 @@ func TestStarCommand_DryRun(t *testing.T) {
 		testutil.Contains(t, output, "[dry-run]")
 		testutil.Contains(t, output, "star")
 		testutil.Contains(t, output, "1 contact(s)")
-	})
-}
-
-func TestStarCommand_DryRunJSON(t *testing.T) {
-	mock := &MockContactsClient{}
-
-	cmd := newStarCommand()
-	cmd.SetArgs([]string{"people/c111", "--dry-run", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var result map[string]any
-		err := json.Unmarshal([]byte(output), &result)
-		testutil.NoError(t, err)
-		testutil.Equal(t, result["dryRun"].(bool), true)
-		testutil.Equal(t, result["action"].(string), "star")
-	})
-}
-
-func TestStarCommand_JSON(t *testing.T) {
-	mock := &MockContactsClient{
-		AddToGroupFunc: func(_ context.Context, _ string, _ []string) error {
-			return nil
-		},
-	}
-
-	cmd := newStarCommand()
-	cmd.SetArgs([]string{"people/c111", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var result map[string]any
-		err := json.Unmarshal([]byte(output), &result)
-		testutil.NoError(t, err)
-		testutil.Equal(t, result["action"].(string), "starred")
-		testutil.Equal(t, result["count"].(float64), float64(1))
 	})
 }
 

--- a/internal/cmd/drive/drives.go
+++ b/internal/cmd/drive/drives.go
@@ -14,10 +14,7 @@ import (
 )
 
 func newDrivesCommand() *cobra.Command {
-	var (
-		jsonOutput bool
-		refresh    bool
-	)
+	var refresh bool
 
 	cmd := &cobra.Command{
 		Use:   "drives",
@@ -28,8 +25,7 @@ Results are cached locally for fast lookups. Use 'gro refresh drives' to
 force a refresh.
 
 Examples:
-  gro drive drives              # List shared drives (uses cache)
-  gro drive drives --json       # Output as JSON`,
+  gro drive drives              # List shared drives (uses cache)`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := newDriveClient(cmd.Context())
@@ -85,16 +81,8 @@ Examples:
 			}
 
 			if len(drives) == 0 {
-				if jsonOutput {
-					fmt.Println("[]")
-					return nil
-				}
 				fmt.Println("No shared drives found.")
 				return nil
-			}
-
-			if jsonOutput {
-				return printJSON(drives)
 			}
 
 			printSharedDrives(drives)
@@ -102,7 +90,6 @@ Examples:
 		},
 	}
 
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force refresh from API (ignore cache)")
 	_ = cmd.Flags().MarkDeprecated("refresh", "use 'gro refresh drives' instead")
 

--- a/internal/cmd/drive/drives_test.go
+++ b/internal/cmd/drive/drives_test.go
@@ -27,11 +27,6 @@ func TestDrivesCommand(t *testing.T) {
 		testutil.Error(t, err)
 	})
 
-	t.Run("no json flag (#144 — resource leaves emit text only)", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.Nil(t, flag)
-	})
-
 	t.Run("has refresh flag", func(t *testing.T) {
 		flag := cmd.Flags().Lookup("refresh")
 		testutil.NotNil(t, flag)

--- a/internal/cmd/drive/drives_test.go
+++ b/internal/cmd/drive/drives_test.go
@@ -27,11 +27,9 @@ func TestDrivesCommand(t *testing.T) {
 		testutil.Error(t, err)
 	})
 
-	t.Run("has json flag", func(t *testing.T) {
+	t.Run("no json flag (#144 — resource leaves emit text only)", func(t *testing.T) {
 		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-		testutil.Equal(t, flag.DefValue, "false")
+		testutil.Nil(t, flag)
 	})
 
 	t.Run("has refresh flag", func(t *testing.T) {

--- a/internal/cmd/drive/get.go
+++ b/internal/cmd/drive/get.go
@@ -11,16 +11,13 @@ import (
 )
 
 func newGetCommand() *cobra.Command {
-	var jsonOutput bool
-
 	cmd := &cobra.Command{
 		Use:   "get <file-id>",
 		Short: "Get file details",
 		Long: `Get detailed metadata for a specific file in Google Drive.
 
 Examples:
-  gro drive get <file-id>        # Show file details
-  gro drive get <file-id> --json # Output as JSON`,
+  gro drive get <file-id>        # Show file details`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := newDriveClient(cmd.Context())
@@ -34,16 +31,10 @@ Examples:
 				return fmt.Errorf("getting file %s: %w", fileID, err)
 			}
 
-			if jsonOutput {
-				return printJSON(file)
-			}
-
 			printFileDetails(file)
 			return nil
 		},
 	}
-
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 
 	return cmd
 }

--- a/internal/cmd/drive/get_test.go
+++ b/internal/cmd/drive/get_test.go
@@ -26,13 +26,6 @@ func TestGetCommand(t *testing.T) {
 		testutil.Error(t, err)
 	})
 
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-		testutil.Equal(t, flag.DefValue, "false")
-	})
-
 	t.Run("has short description", func(t *testing.T) {
 		testutil.Contains(t, cmd.Short, "Get")
 	})

--- a/internal/cmd/drive/handlers_test.go
+++ b/internal/cmd/drive/handlers_test.go
@@ -2,7 +2,6 @@ package drive
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"os"
 	"testing"
@@ -46,29 +45,6 @@ func TestListCommand_Success(t *testing.T) {
 	})
 }
 
-func TestListCommand_JSONOutput(t *testing.T) {
-	mock := &MockDriveClient{
-		ListFilesFunc: func(_ context.Context, _ string, _ int64) ([]*driveapi.File, error) {
-			return testutil.SampleDriveFiles(1), nil
-		},
-	}
-
-	cmd := newListCommand()
-	cmd.SetArgs([]string{"--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var files []*driveapi.File
-		err := json.Unmarshal([]byte(output), &files)
-		testutil.NoError(t, err)
-		testutil.Len(t, files, 1)
-	})
-}
-
 func TestListCommand_Empty(t *testing.T) {
 	mock := &MockDriveClient{
 		ListFilesFunc: func(_ context.Context, _ string, _ int64) ([]*driveapi.File, error) {
@@ -85,29 +61,6 @@ func TestListCommand_Empty(t *testing.T) {
 		})
 
 		testutil.Contains(t, output, "No files found")
-	})
-}
-
-func TestListCommand_Empty_JSON(t *testing.T) {
-	mock := &MockDriveClient{
-		ListFilesFunc: func(_ context.Context, _ string, _ int64) ([]*driveapi.File, error) {
-			return []*driveapi.File{}, nil
-		},
-	}
-
-	cmd := newListCommand()
-	cmd.SetArgs([]string{"--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var files []any
-		err := json.Unmarshal([]byte(output), &files)
-		testutil.NoError(t, err)
-		testutil.Len(t, files, 0)
 	})
 }
 
@@ -233,29 +186,6 @@ func TestSearchCommand_NameOnly(t *testing.T) {
 	})
 }
 
-func TestSearchCommand_JSONOutput(t *testing.T) {
-	mock := &MockDriveClient{
-		ListFilesFunc: func(_ context.Context, _ string, _ int64) ([]*driveapi.File, error) {
-			return testutil.SampleDriveFiles(1), nil
-		},
-	}
-
-	cmd := newSearchCommand()
-	cmd.SetArgs([]string{"test", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var files []*driveapi.File
-		err := json.Unmarshal([]byte(output), &files)
-		testutil.NoError(t, err)
-		testutil.Len(t, files, 1)
-	})
-}
-
 func TestSearchCommand_NoResults(t *testing.T) {
 	mock := &MockDriveClient{
 		ListFilesFunc: func(_ context.Context, _ string, _ int64) ([]*driveapi.File, error) {
@@ -273,29 +203,6 @@ func TestSearchCommand_NoResults(t *testing.T) {
 		})
 
 		testutil.Contains(t, output, "No files found")
-	})
-}
-
-func TestSearchCommand_NoResults_JSON(t *testing.T) {
-	mock := &MockDriveClient{
-		ListFilesFunc: func(_ context.Context, _ string, _ int64) ([]*driveapi.File, error) {
-			return []*driveapi.File{}, nil
-		},
-	}
-
-	cmd := newSearchCommand()
-	cmd.SetArgs([]string{"nonexistent", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var files []any
-		err := json.Unmarshal([]byte(output), &files)
-		testutil.NoError(t, err)
-		testutil.Len(t, files, 0)
 	})
 }
 
@@ -336,29 +243,6 @@ func TestGetCommand_Success(t *testing.T) {
 		testutil.Contains(t, output, "file123")
 		testutil.Contains(t, output, "test-document.pdf")
 		testutil.Contains(t, output, "owner@example.com")
-	})
-}
-
-func TestGetCommand_JSONOutput(t *testing.T) {
-	mock := &MockDriveClient{
-		GetFileFunc: func(_ context.Context, _ string) (*driveapi.File, error) {
-			return testutil.SampleDriveFile("file123"), nil
-		},
-	}
-
-	cmd := newGetCommand()
-	cmd.SetArgs([]string{"file123", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var file driveapi.File
-		err := json.Unmarshal([]byte(output), &file)
-		testutil.NoError(t, err)
-		testutil.Equal(t, file.ID, "file123")
 	})
 }
 

--- a/internal/cmd/drive/list.go
+++ b/internal/cmd/drive/list.go
@@ -17,7 +17,6 @@ func newListCommand() *cobra.Command {
 	var (
 		maxResults int64
 		fileType   string
-		jsonOutput bool
 		idsOutput  bool
 		myDrive    bool
 		driveFlag  string
@@ -37,17 +36,12 @@ Examples:
   gro drive list --drive "Engineering"  # List files in shared drive root
   gro drive list --type document        # Filter by file type
   gro drive list --max 50               # Limit results
-  gro drive list --json                 # Output as JSON
 
 File types: document, spreadsheet, presentation, folder, pdf, image, video, audio`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Validate mutually exclusive flags
 			if myDrive && driveFlag != "" {
 				return fmt.Errorf("--my-drive and --drive are mutually exclusive")
-			}
-			if idsOutput && jsonOutput {
-				return fmt.Errorf("--ids and --json are mutually exclusive")
 			}
 
 			client, err := newDriveClient(cmd.Context())
@@ -85,16 +79,8 @@ File types: document, spreadsheet, presentation, folder, pdf, image, video, audi
 			}
 
 			if len(files) == 0 {
-				if jsonOutput {
-					fmt.Println("[]")
-					return nil
-				}
 				fmt.Println("No files found.")
 				return nil
-			}
-
-			if jsonOutput {
-				return printJSON(files)
 			}
 
 			printFileTable(files)
@@ -104,7 +90,6 @@ File types: document, spreadsheet, presentation, folder, pdf, image, video, audi
 
 	cmd.Flags().Int64VarP(&maxResults, "max", "m", 25, "Maximum number of results to return")
 	cmd.Flags().StringVarP(&fileType, "type", "t", "", "Filter by file type")
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 	cmd.Flags().BoolVar(&idsOutput, "ids", false, "Output only file IDs (one per line, for piping)")
 	cmd.Flags().BoolVar(&myDrive, "my-drive", false, "Limit to My Drive only")
 	cmd.Flags().StringVar(&driveFlag, "drive", "", "List files in specific shared drive (name or ID)")

--- a/internal/cmd/drive/list_test.go
+++ b/internal/cmd/drive/list_test.go
@@ -37,13 +37,6 @@ func TestListCommand(t *testing.T) {
 		testutil.Equal(t, flag.Shorthand, "t")
 	})
 
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-		testutil.Equal(t, flag.DefValue, "false")
-	})
-
 	t.Run("has short description", func(t *testing.T) {
 		testutil.Contains(t, cmd.Short, "List")
 	})

--- a/internal/cmd/drive/output.go
+++ b/internal/cmd/drive/output.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/open-cli-collective/google-readonly/internal/drive"
-	"github.com/open-cli-collective/google-readonly/internal/output"
 )
 
 // DriveClient defines the interface for Drive client operations used by drive commands.
@@ -29,9 +28,4 @@ var ClientFactory = func(ctx context.Context) (DriveClient, error) {
 // newDriveClient creates and returns a new Drive client
 func newDriveClient(ctx context.Context) (DriveClient, error) {
 	return ClientFactory(ctx)
-}
-
-// printJSON encodes data as indented JSON to stdout
-func printJSON(data any) error {
-	return output.JSONStdout(data)
 }

--- a/internal/cmd/drive/search.go
+++ b/internal/cmd/drive/search.go
@@ -16,7 +16,6 @@ func newSearchCommand() *cobra.Command {
 		modAfter   string
 		modBefore  string
 		inFolder   string
-		jsonOutput bool
 		idsOutput  bool
 		myDrive    bool
 		driveFlag  string
@@ -41,17 +40,12 @@ Examples:
   gro drive search --owner john@example.com     # Files owned by someone
   gro drive search --modified-after 2024-01-01  # Modified after date
   gro drive search --in-folder <folder-id>      # Search within folder
-  gro drive search "report" --type document --max 20 --json
 
 File types: document, spreadsheet, presentation, folder, pdf, image, video, audio`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Validate mutually exclusive flags
 			if myDrive && driveFlag != "" {
 				return fmt.Errorf("--my-drive and --drive are mutually exclusive")
-			}
-			if idsOutput && jsonOutput {
-				return fmt.Errorf("--ids and --json are mutually exclusive")
 			}
 
 			client, err := newDriveClient(cmd.Context())
@@ -89,20 +83,12 @@ File types: document, spreadsheet, presentation, folder, pdf, image, video, audi
 			}
 
 			if len(files) == 0 {
-				if jsonOutput {
-					fmt.Println("[]")
-					return nil
-				}
 				if query != "" {
 					fmt.Printf("No files found matching \"%s\".\n", query)
 				} else {
 					fmt.Println("No files found.")
 				}
 				return nil
-			}
-
-			if jsonOutput {
-				return printJSON(files)
 			}
 
 			if query != "" {
@@ -122,7 +108,6 @@ File types: document, spreadsheet, presentation, folder, pdf, image, video, audi
 	cmd.Flags().StringVar(&modAfter, "modified-after", "", "Modified after date (YYYY-MM-DD)")
 	cmd.Flags().StringVar(&modBefore, "modified-before", "", "Modified before date (YYYY-MM-DD)")
 	cmd.Flags().StringVar(&inFolder, "in-folder", "", "Search within specific folder")
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 	cmd.Flags().BoolVar(&idsOutput, "ids", false, "Output only file IDs (one per line, for piping)")
 	cmd.Flags().BoolVar(&myDrive, "my-drive", false, "Limit search to My Drive only")
 	cmd.Flags().StringVar(&driveFlag, "drive", "", "Search in specific shared drive (name or ID)")

--- a/internal/cmd/drive/search_test.go
+++ b/internal/cmd/drive/search_test.go
@@ -63,12 +63,6 @@ func TestSearchCommand(t *testing.T) {
 		testutil.NotNil(t, flag)
 	})
 
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-	})
-
 	t.Run("has short description", func(t *testing.T) {
 		testutil.Contains(t, cmd.Short, "Search")
 	})

--- a/internal/cmd/drive/star.go
+++ b/internal/cmd/drive/star.go
@@ -10,10 +10,9 @@ import (
 
 func newStarCommand() *cobra.Command {
 	var (
-		jsonOutput bool
-		dryRun     bool
-		stdin      bool
-		query      string
+		dryRun bool
+		stdin  bool
+		query  string
 	)
 
 	cmd := &cobra.Command{
@@ -58,7 +57,7 @@ Examples:
 
 			if dryRun {
 				result.Action = "star"
-				return result.Print(jsonOutput)
+				return result.Print()
 			}
 
 			for _, id := range ids {
@@ -67,11 +66,10 @@ Examples:
 				}
 			}
 
-			return result.Print(jsonOutput)
+			return result.Print()
 		},
 	}
 
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
 	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read file IDs from stdin")
 	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve file IDs")
@@ -81,10 +79,9 @@ Examples:
 
 func newUnstarCommand() *cobra.Command {
 	var (
-		jsonOutput bool
-		dryRun     bool
-		stdin      bool
-		query      string
+		dryRun bool
+		stdin  bool
+		query  string
 	)
 
 	cmd := &cobra.Command{
@@ -128,7 +125,7 @@ Examples:
 
 			if dryRun {
 				result.Action = "unstar"
-				return result.Print(jsonOutput)
+				return result.Print()
 			}
 
 			for _, id := range ids {
@@ -137,11 +134,10 @@ Examples:
 				}
 			}
 
-			return result.Print(jsonOutput)
+			return result.Print()
 		},
 	}
 
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
 	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read file IDs from stdin")
 	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve file IDs")

--- a/internal/cmd/drive/star_test.go
+++ b/internal/cmd/drive/star_test.go
@@ -2,22 +2,14 @@ package drive
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"testing"
 
-	"github.com/open-cli-collective/google-readonly/internal/bulk"
 	"github.com/open-cli-collective/google-readonly/internal/testutil"
 )
 
 func TestStarCommand(t *testing.T) {
 	cmd := newStarCommand()
-
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-	})
 
 	t.Run("has dry-run flag", func(t *testing.T) {
 		flag := cmd.Flags().Lookup("dry-run")
@@ -75,30 +67,6 @@ func TestStarCommand_DryRun(t *testing.T) {
 		})
 
 		testutil.Contains(t, output, "[dry-run] Would star 1 file(s).")
-	})
-}
-
-func TestStarCommand_JSON(t *testing.T) {
-	mock := &MockDriveClient{
-		StarFileFunc: func(_ context.Context, _ string) error {
-			return nil
-		},
-	}
-
-	cmd := newStarCommand()
-	cmd.SetArgs([]string{"file1", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var result bulk.Result
-		err := json.Unmarshal([]byte(output), &result)
-		testutil.NoError(t, err)
-		testutil.Equal(t, result.Action, "starred")
-		testutil.Equal(t, result.Count, 1)
 	})
 }
 

--- a/internal/cmd/drive/tree.go
+++ b/internal/cmd/drive/tree.go
@@ -20,11 +20,10 @@ type TreeNode struct {
 
 func newTreeCommand() *cobra.Command {
 	var (
-		depth      int
-		files      bool
-		jsonOutput bool
-		myDrive    bool
-		driveFlag  string
+		depth     int
+		files     bool
+		myDrive   bool
+		driveFlag string
 	)
 
 	cmd := &cobra.Command{
@@ -40,8 +39,7 @@ Examples:
   gro drive tree <folder-id>            # Show tree from specific folder
   gro drive tree --drive "Engineering"  # Show tree from shared drive root
   gro drive tree --depth 3              # Limit depth
-  gro drive tree --files                # Include files, not just folders
-  gro drive tree --json                 # Output as JSON`,
+  gro drive tree --files                # Include files, not just folders`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Validate mutually exclusive flags
@@ -76,10 +74,6 @@ Examples:
 				return fmt.Errorf("building folder tree: %w", err)
 			}
 
-			if jsonOutput {
-				return printJSON(tree)
-			}
-
 			printTree(tree, "", true)
 			return nil
 		},
@@ -87,7 +81,6 @@ Examples:
 
 	cmd.Flags().IntVarP(&depth, "depth", "d", 2, "Maximum depth to traverse")
 	cmd.Flags().BoolVar(&files, "files", false, "Include files in addition to folders")
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 	cmd.Flags().BoolVar(&myDrive, "my-drive", false, "Show My Drive only (default)")
 	cmd.Flags().StringVar(&driveFlag, "drive", "", "Show tree from specific shared drive (name or ID)")
 

--- a/internal/cmd/drive/tree_test.go
+++ b/internal/cmd/drive/tree_test.go
@@ -41,13 +41,6 @@ func TestTreeCommand(t *testing.T) {
 		testutil.Equal(t, flag.DefValue, "false")
 	})
 
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-		testutil.Equal(t, flag.DefValue, "false")
-	})
-
 	t.Run("has short description", func(t *testing.T) {
 		testutil.Contains(t, cmd.Short, "folder structure")
 	})

--- a/internal/cmd/mail/archive.go
+++ b/internal/cmd/mail/archive.go
@@ -10,10 +10,9 @@ import (
 
 func newArchiveCommand() *cobra.Command {
 	var (
-		jsonOutput bool
-		dryRun     bool
-		stdin      bool
-		query      string
+		dryRun bool
+		stdin  bool
+		query  string
 	)
 
 	cmd := &cobra.Command{
@@ -56,18 +55,17 @@ Examples:
 
 			if dryRun {
 				result.Action = "archive"
-				return result.Print(jsonOutput)
+				return result.Print()
 			}
 
 			if err := client.ModifyMessages(ctx, ids, nil, []string{"INBOX"}); err != nil {
 				return fmt.Errorf("archiving messages: %w", err)
 			}
 
-			return result.Print(jsonOutput)
+			return result.Print()
 		},
 	}
 
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
 	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read message IDs from stdin")
 	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve message IDs")

--- a/internal/cmd/mail/archive_test.go
+++ b/internal/cmd/mail/archive_test.go
@@ -2,21 +2,18 @@ package mail
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"testing"
 
-	"github.com/open-cli-collective/google-readonly/internal/bulk"
 	"github.com/open-cli-collective/google-readonly/internal/testutil"
 )
 
 func TestArchiveCommand(t *testing.T) {
 	cmd := newArchiveCommand()
 
-	t.Run("has json flag", func(t *testing.T) {
+	t.Run("no json flag (#144 — resource leaves emit text only)", func(t *testing.T) {
 		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
+		testutil.Nil(t, flag)
 	})
 
 	t.Run("has dry-run flag", func(t *testing.T) {
@@ -79,30 +76,6 @@ func TestArchiveCommand_DryRun(t *testing.T) {
 		})
 
 		testutil.Contains(t, output, "[dry-run] Would archive 1 message(s).")
-	})
-}
-
-func TestArchiveCommand_JSON(t *testing.T) {
-	mock := &MockGmailClient{
-		ModifyMessagesFunc: func(_ context.Context, _ []string, _, _ []string) error {
-			return nil
-		},
-	}
-
-	cmd := newArchiveCommand()
-	cmd.SetArgs([]string{"msg1", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var result bulk.Result
-		err := json.Unmarshal([]byte(output), &result)
-		testutil.NoError(t, err)
-		testutil.Equal(t, result.Action, "archived")
-		testutil.Equal(t, result.Count, 1)
 	})
 }
 

--- a/internal/cmd/mail/archive_test.go
+++ b/internal/cmd/mail/archive_test.go
@@ -11,11 +11,6 @@ import (
 func TestArchiveCommand(t *testing.T) {
 	cmd := newArchiveCommand()
 
-	t.Run("no json flag (#144 — resource leaves emit text only)", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.Nil(t, flag)
-	})
-
 	t.Run("has dry-run flag", func(t *testing.T) {
 		flag := cmd.Flags().Lookup("dry-run")
 		testutil.NotNil(t, flag)

--- a/internal/cmd/mail/attachments_list.go
+++ b/internal/cmd/mail/attachments_list.go
@@ -9,8 +9,6 @@ import (
 )
 
 func newListAttachmentsCommand() *cobra.Command {
-	var jsonOutput bool
-
 	cmd := &cobra.Command{
 		Use:   "list <message-id>",
 		Short: "List attachments in a message",
@@ -19,8 +17,7 @@ func newListAttachmentsCommand() *cobra.Command {
 Shows filename, MIME type, size, and whether the attachment is inline.
 
 Examples:
-  gro mail attachments list 18abc123def456
-  gro mail attachments list 18abc123def456 --json`,
+  gro mail attachments list 18abc123def456`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := newGmailClient(cmd.Context())
@@ -34,16 +31,8 @@ Examples:
 			}
 
 			if len(attachments) == 0 {
-				if jsonOutput {
-					fmt.Println("[]")
-					return nil
-				}
 				fmt.Println("No attachments found for message.")
 				return nil
-			}
-
-			if jsonOutput {
-				return printJSON(attachments)
 			}
 
 			fmt.Printf("Found %d attachment(s):\n\n", len(attachments))
@@ -61,8 +50,6 @@ Examples:
 			return nil
 		},
 	}
-
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output as JSON")
 
 	return cmd
 }

--- a/internal/cmd/mail/attachments_test.go
+++ b/internal/cmd/mail/attachments_test.go
@@ -70,11 +70,6 @@ func TestListAttachmentsCommand(t *testing.T) {
 		testutil.NoError(t, err)
 	})
 
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-	})
 }
 
 func TestDownloadAttachmentsCommand(t *testing.T) {

--- a/internal/cmd/mail/categorize.go
+++ b/internal/cmd/mail/categorize.go
@@ -31,10 +31,9 @@ func allCategoryLabelIDs() []string {
 
 func newCategorizeCommand() *cobra.Command {
 	var (
-		jsonOutput bool
-		dryRun     bool
-		stdin      bool
-		query      string
+		dryRun bool
+		stdin  bool
+		query  string
 	)
 
 	validCategories := make([]string, 0, len(categoryLabels))
@@ -93,7 +92,7 @@ Examples:
 
 			if dryRun {
 				result.Action = fmt.Sprintf("recategorize to %s", category)
-				return result.Print(jsonOutput)
+				return result.Print()
 			}
 
 			// Remove all category labels and add the target one
@@ -102,11 +101,10 @@ Examples:
 				return fmt.Errorf("recategorizing messages: %w", err)
 			}
 
-			return result.Print(jsonOutput)
+			return result.Print()
 		},
 	}
 
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
 	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read message IDs from stdin")
 	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve message IDs")

--- a/internal/cmd/mail/categorize_test.go
+++ b/internal/cmd/mail/categorize_test.go
@@ -15,9 +15,6 @@ func TestCategorizeCommand(t *testing.T) {
 		testutil.Error(t, err)
 	})
 
-	t.Run("has json flag", func(t *testing.T) {
-		testutil.NotNil(t, cmd.Flags().Lookup("json"))
-	})
 }
 
 func TestCategorizeCommand_Success(t *testing.T) {

--- a/internal/cmd/mail/draft.go
+++ b/internal/cmd/mail/draft.go
@@ -32,7 +32,6 @@ func newDraftCommand() *cobra.Command {
 		plain    bool
 		htmlMode bool
 		attach   []string
-		jsonOut  bool
 		replyTo  string
 		replyAll bool
 		noQuote  bool
@@ -311,10 +310,6 @@ Examples:
 				return fmt.Errorf("creating draft: empty response")
 			}
 
-			// 10. Print result.
-			if jsonOut {
-				return printJSON(result)
-			}
 			fmt.Printf("Draft created: %s\n", result.ID)
 			fmt.Printf("To: %s\n", SanitizeOutput(strings.Join(toAddrs, ", ")))
 			if len(ccAddrs) > 0 {
@@ -345,7 +340,6 @@ Examples:
 	cmd.Flags().BoolVar(&plain, "plain", false, "Treat body as plain text (no markdown rendering)")
 	cmd.Flags().BoolVar(&htmlMode, "html", false, "Treat body as raw HTML (no markdown rendering)")
 	cmd.Flags().StringArrayVarP(&attach, "attach", "a", nil, "File path to attach (repeat for multiple)")
-	cmd.Flags().BoolVarP(&jsonOut, "json", "j", false, "Output result as JSON")
 	cmd.Flags().StringVar(&replyTo, "reply-to", "", "Source Gmail message ID to reply to (derives To/Subject/threading)")
 	cmd.Flags().BoolVar(&replyAll, "reply-all", false, "Include the source To/Cc as Cc on the reply (requires --reply-to)")
 	cmd.Flags().BoolVar(&noQuote, "no-quote", false, "Reply without quoting the source message (requires --reply-to)")

--- a/internal/cmd/mail/draft_test.go
+++ b/internal/cmd/mail/draft_test.go
@@ -2,7 +2,6 @@ package mail
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -20,11 +19,15 @@ func TestDraftCommand_FlagsPresent(t *testing.T) {
 	for _, name := range []string{
 		"to", "cc", "bcc", "from", "subject",
 		"body", "stdin", "file", "plain", "html",
-		"attach", "json", "no-quote",
+		"attach", "no-quote",
 	} {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("flag %q missing", name)
 		}
+	}
+	// #144: --json removed from resource-surface leaves.
+	if cmd.Flags().Lookup("json") != nil {
+		t.Errorf("draft must NOT declare --json after #144")
 	}
 }
 
@@ -345,29 +348,6 @@ func TestDraftCommand_AttachmentMissingFile(t *testing.T) {
 		// attachment loading is the actual failure point.
 		testutil.Contains(t, err.Error(), "reading attachment")
 		testutil.Contains(t, err.Error(), "/nope/does/not/exist.pdf")
-	})
-}
-
-func TestDraftCommand_JSONOutput(t *testing.T) {
-	mock := &MockGmailClient{
-		CreateDraftFunc: func(_ context.Context, _ gmailapi.DraftMessage) (*gmailapi.DraftResult, error) {
-			return &gmailapi.DraftResult{ID: "d1", MessageID: "m1", ThreadID: "t1"}, nil
-		},
-	}
-	cmd := newDraftCommand()
-	cmd.SetArgs([]string{"--to", "a@x.com", "--subject", "Hi", "--body", "x", "--json"})
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-		var result gmailapi.DraftResult
-		if err := json.Unmarshal([]byte(output), &result); err != nil {
-			t.Fatalf("unmarshal: %v\noutput=%q", err, output)
-		}
-		testutil.Equal(t, result.ID, "d1")
-		testutil.Equal(t, result.MessageID, "m1")
-		testutil.Equal(t, result.ThreadID, "t1")
 	})
 }
 

--- a/internal/cmd/mail/handlers_test.go
+++ b/internal/cmd/mail/handlers_test.go
@@ -2,7 +2,6 @@ package mail
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"testing"
 
@@ -51,31 +50,6 @@ func TestSearchCommand_Success(t *testing.T) {
 	})
 }
 
-func TestSearchCommand_JSONOutput(t *testing.T) {
-	mock := &MockGmailClient{
-		SearchMessagesFunc: func(_ context.Context, _ string, _ int64) ([]*gmailapi.Message, int, error) {
-			return testutil.SampleMessages(1), 0, nil
-		},
-	}
-
-	cmd := newSearchCommand()
-	cmd.SetArgs([]string{"is:unread", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		// Verify JSON output is valid
-		var messages []*gmailapi.Message
-		err := json.Unmarshal([]byte(output), &messages)
-		testutil.NoError(t, err)
-		testutil.Len(t, messages, 1)
-		testutil.Equal(t, messages[0].ID, "msg_a")
-	})
-}
-
 func TestSearchCommand_NoResults(t *testing.T) {
 	mock := &MockGmailClient{
 		SearchMessagesFunc: func(_ context.Context, _ string, _ int64) ([]*gmailapi.Message, int, error) {
@@ -93,29 +67,6 @@ func TestSearchCommand_NoResults(t *testing.T) {
 		})
 
 		testutil.Contains(t, output, "No messages found")
-	})
-}
-
-func TestSearchCommand_NoResults_JSON(t *testing.T) {
-	mock := &MockGmailClient{
-		SearchMessagesFunc: func(_ context.Context, _ string, _ int64) ([]*gmailapi.Message, int, error) {
-			return []*gmailapi.Message{}, 0, nil
-		},
-	}
-
-	cmd := newSearchCommand()
-	cmd.SetArgs([]string{"nonexistent", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var messages []any
-		err := json.Unmarshal([]byte(output), &messages)
-		testutil.NoError(t, err)
-		testutil.Len(t, messages, 0)
 	})
 }
 
@@ -170,17 +121,6 @@ func TestSearchCommand_IDsOutput(t *testing.T) {
 	})
 }
 
-func TestSearchCommand_IDsAndJSONMutuallyExclusive(t *testing.T) {
-	cmd := newSearchCommand()
-	cmd.SetArgs([]string{"is:inbox", "--ids", "--json"})
-
-	withMockClient(&MockGmailClient{}, func() {
-		err := cmd.Execute()
-		testutil.Error(t, err)
-		testutil.Contains(t, err.Error(), "mutually exclusive")
-	})
-}
-
 func TestSearchCommand_SkippedMessages(t *testing.T) {
 	mock := &MockGmailClient{
 		SearchMessagesFunc: func(_ context.Context, _ string, _ int64) ([]*gmailapi.Message, int, error) {
@@ -225,29 +165,6 @@ func TestReadCommand_Success(t *testing.T) {
 	})
 }
 
-func TestReadCommand_JSONOutput(t *testing.T) {
-	mock := &MockGmailClient{
-		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) {
-			return testutil.SampleMessage("msg123"), nil
-		},
-	}
-
-	cmd := newReadCommand()
-	cmd.SetArgs([]string{"msg123", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var msg gmailapi.Message
-		err := json.Unmarshal([]byte(output), &msg)
-		testutil.NoError(t, err)
-		testutil.Equal(t, msg.ID, "msg123")
-	})
-}
-
 func TestReadCommand_NotFound(t *testing.T) {
 	mock := &MockGmailClient{
 		GetMessageFunc: func(_ context.Context, _ string, _ bool) (*gmailapi.Message, error) {
@@ -289,29 +206,6 @@ func TestThreadCommand_Success(t *testing.T) {
 	})
 }
 
-func TestThreadCommand_JSONOutput(t *testing.T) {
-	mock := &MockGmailClient{
-		GetThreadFunc: func(_ context.Context, _ string) ([]*gmailapi.Message, error) {
-			return testutil.SampleMessages(2), nil
-		},
-	}
-
-	cmd := newThreadCommand()
-	cmd.SetArgs([]string{"thread123", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var messages []*gmailapi.Message
-		err := json.Unmarshal([]byte(output), &messages)
-		testutil.NoError(t, err)
-		testutil.Len(t, messages, 2)
-	})
-}
-
 func TestLabelsCommand_Success(t *testing.T) {
 	mock := &MockGmailClient{
 		FetchLabelsFunc: func(_ context.Context) error {
@@ -337,55 +231,6 @@ func TestLabelsCommand_Success(t *testing.T) {
 	})
 }
 
-func TestLabelsCommand_JSONOutput(t *testing.T) {
-	mock := &MockGmailClient{
-		FetchLabelsFunc: func(_ context.Context) error {
-			return nil
-		},
-		GetLabelsFunc: func() []*gmail.Label {
-			return testutil.SampleLabels()
-		},
-	}
-
-	cmd := newLabelsCommand()
-	cmd.SetArgs([]string{"--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var labels []Label
-		err := json.Unmarshal([]byte(output), &labels)
-		testutil.NoError(t, err)
-		testutil.Greater(t, len(labels), 0)
-	})
-}
-
-func TestThreadCommand_NoResults_JSON(t *testing.T) {
-	mock := &MockGmailClient{
-		GetThreadFunc: func(_ context.Context, _ string) ([]*gmailapi.Message, error) {
-			return []*gmailapi.Message{}, nil
-		},
-	}
-
-	cmd := newThreadCommand()
-	cmd.SetArgs([]string{"thread123", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var messages []any
-		err := json.Unmarshal([]byte(output), &messages)
-		testutil.NoError(t, err)
-		testutil.Len(t, messages, 0)
-	})
-}
-
 func TestLabelsCommand_Empty(t *testing.T) {
 	mock := &MockGmailClient{
 		FetchLabelsFunc: func(_ context.Context) error {
@@ -405,32 +250,6 @@ func TestLabelsCommand_Empty(t *testing.T) {
 		})
 
 		testutil.Contains(t, output, "No labels found")
-	})
-}
-
-func TestLabelsCommand_Empty_JSON(t *testing.T) {
-	mock := &MockGmailClient{
-		FetchLabelsFunc: func(_ context.Context) error {
-			return nil
-		},
-		GetLabelsFunc: func() []*gmail.Label {
-			return []*gmail.Label{}
-		},
-	}
-
-	cmd := newLabelsCommand()
-	cmd.SetArgs([]string{"--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var labels []any
-		err := json.Unmarshal([]byte(output), &labels)
-		testutil.NoError(t, err)
-		testutil.Len(t, labels, 0)
 	})
 }
 
@@ -476,28 +295,5 @@ func TestListAttachmentsCommand_NoAttachments(t *testing.T) {
 		})
 
 		testutil.Contains(t, output, "No attachments found")
-	})
-}
-
-func TestListAttachmentsCommand_NoAttachments_JSON(t *testing.T) {
-	mock := &MockGmailClient{
-		GetAttachmentsFunc: func(_ context.Context, _ string) ([]*gmailapi.Attachment, error) {
-			return []*gmailapi.Attachment{}, nil
-		},
-	}
-
-	cmd := newListAttachmentsCommand()
-	cmd.SetArgs([]string{"msg123", "--json"})
-
-	withMockClient(mock, func() {
-		output := testutil.CaptureStdout(t, func() {
-			err := cmd.Execute()
-			testutil.NoError(t, err)
-		})
-
-		var attachments []any
-		err := json.Unmarshal([]byte(output), &attachments)
-		testutil.NoError(t, err)
-		testutil.Len(t, attachments, 0)
 	})
 }

--- a/internal/cmd/mail/label.go
+++ b/internal/cmd/mail/label.go
@@ -10,10 +10,9 @@ import (
 
 func newLabelCommand() *cobra.Command {
 	var (
-		jsonOutput bool
-		dryRun     bool
-		stdin      bool
-		query      string
+		dryRun bool
+		stdin  bool
+		query  string
 	)
 
 	cmd := &cobra.Command{
@@ -62,18 +61,17 @@ Examples:
 
 			if dryRun {
 				result.Action = fmt.Sprintf("add label '%s' to", labelName)
-				return result.Print(jsonOutput)
+				return result.Print()
 			}
 
 			if err := client.ModifyMessages(ctx, ids, []string{labelID}, nil); err != nil {
 				return fmt.Errorf("adding label: %w", err)
 			}
 
-			return result.Print(jsonOutput)
+			return result.Print()
 		},
 	}
 
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
 	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read message IDs from stdin")
 	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve message IDs")
@@ -83,10 +81,9 @@ Examples:
 
 func newUnlabelCommand() *cobra.Command {
 	var (
-		jsonOutput bool
-		dryRun     bool
-		stdin      bool
-		query      string
+		dryRun bool
+		stdin  bool
+		query  string
 	)
 
 	cmd := &cobra.Command{
@@ -134,18 +131,17 @@ Examples:
 
 			if dryRun {
 				result.Action = fmt.Sprintf("remove label '%s' from", labelName)
-				return result.Print(jsonOutput)
+				return result.Print()
 			}
 
 			if err := client.ModifyMessages(ctx, ids, nil, []string{labelID}); err != nil {
 				return fmt.Errorf("removing label: %w", err)
 			}
 
-			return result.Print(jsonOutput)
+			return result.Print()
 		},
 	}
 
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
 	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read message IDs from stdin")
 	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve message IDs")

--- a/internal/cmd/mail/label_test.go
+++ b/internal/cmd/mail/label_test.go
@@ -21,9 +21,6 @@ func TestLabelCommand(t *testing.T) {
 		testutil.NoError(t, err)
 	})
 
-	t.Run("has json flag", func(t *testing.T) {
-		testutil.NotNil(t, cmd.Flags().Lookup("json"))
-	})
 }
 
 func TestLabelCommand_Success(t *testing.T) {

--- a/internal/cmd/mail/labels.go
+++ b/internal/cmd/mail/labels.go
@@ -21,8 +21,6 @@ type Label struct {
 }
 
 func newLabelsCommand() *cobra.Command {
-	var jsonOutput bool
-
 	cmd := &cobra.Command{
 		Use:   "labels",
 		Short: "List all labels",
@@ -31,8 +29,7 @@ func newLabelsCommand() *cobra.Command {
 Shows label name, type (system/user/category), and message counts.
 
 Examples:
-  gro mail labels
-  gro mail labels --json`,
+  gro mail labels`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := newGmailClient(cmd.Context())
@@ -46,15 +43,10 @@ Examples:
 
 			gmailLabels := client.GetLabels()
 			if len(gmailLabels) == 0 {
-				if jsonOutput {
-					fmt.Println("[]")
-					return nil
-				}
 				fmt.Println("No labels found.")
 				return nil
 			}
 
-			// Convert to our Label type and categorize
 			labels := make([]Label, 0, len(gmailLabels))
 			for _, gl := range gmailLabels {
 				label := Label{
@@ -67,7 +59,6 @@ Examples:
 				labels = append(labels, label)
 			}
 
-			// Sort by type then name
 			sort.Slice(labels, func(i, j int) bool {
 				if labels[i].Type != labels[j].Type {
 					return labelTypePriority(labels[i].Type) < labelTypePriority(labels[j].Type)
@@ -75,11 +66,6 @@ Examples:
 				return strings.ToLower(labels[i].Name) < strings.ToLower(labels[j].Name)
 			})
 
-			if jsonOutput {
-				return printJSON(labels)
-			}
-
-			// Text output
 			fmt.Printf("%-30s %-10s %8s %8s\n", "NAME", "TYPE", "TOTAL", "UNREAD")
 			fmt.Println(strings.Repeat("-", 60))
 			for _, label := range labels {
@@ -93,8 +79,6 @@ Examples:
 			return nil
 		},
 	}
-
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 
 	return cmd
 }

--- a/internal/cmd/mail/labels_test.go
+++ b/internal/cmd/mail/labels_test.go
@@ -23,13 +23,6 @@ func TestLabelsCommand(t *testing.T) {
 		testutil.Error(t, err)
 	})
 
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-		testutil.Equal(t, flag.DefValue, "false")
-	})
-
 	t.Run("has short description", func(t *testing.T) {
 		testutil.NotEmpty(t, cmd.Short)
 		testutil.Contains(t, cmd.Short, "label")

--- a/internal/cmd/mail/markread.go
+++ b/internal/cmd/mail/markread.go
@@ -10,10 +10,9 @@ import (
 
 func newMarkReadCommand() *cobra.Command {
 	var (
-		jsonOutput bool
-		dryRun     bool
-		stdin      bool
-		query      string
+		dryRun bool
+		stdin  bool
+		query  string
 	)
 
 	cmd := &cobra.Command{
@@ -52,18 +51,17 @@ Examples:
 
 			if dryRun {
 				result.Action = "mark as read"
-				return result.Print(jsonOutput)
+				return result.Print()
 			}
 
 			if err := client.ModifyMessages(ctx, ids, nil, []string{"UNREAD"}); err != nil {
 				return fmt.Errorf("marking messages as read: %w", err)
 			}
 
-			return result.Print(jsonOutput)
+			return result.Print()
 		},
 	}
 
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
 	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read message IDs from stdin")
 	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve message IDs")
@@ -73,10 +71,9 @@ Examples:
 
 func newMarkUnreadCommand() *cobra.Command {
 	var (
-		jsonOutput bool
-		dryRun     bool
-		stdin      bool
-		query      string
+		dryRun bool
+		stdin  bool
+		query  string
 	)
 
 	cmd := &cobra.Command{
@@ -114,18 +111,17 @@ Examples:
 
 			if dryRun {
 				result.Action = "mark as unread"
-				return result.Print(jsonOutput)
+				return result.Print()
 			}
 
 			if err := client.ModifyMessages(ctx, ids, []string{"UNREAD"}, nil); err != nil {
 				return fmt.Errorf("marking messages as unread: %w", err)
 			}
 
-			return result.Print(jsonOutput)
+			return result.Print()
 		},
 	}
 
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
 	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read message IDs from stdin")
 	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve message IDs")

--- a/internal/cmd/mail/markread_test.go
+++ b/internal/cmd/mail/markread_test.go
@@ -10,10 +10,6 @@ import (
 func TestMarkReadCommand(t *testing.T) {
 	cmd := newMarkReadCommand()
 
-	t.Run("has json flag", func(t *testing.T) {
-		testutil.NotNil(t, cmd.Flags().Lookup("json"))
-	})
-
 	t.Run("has dry-run flag", func(t *testing.T) {
 		testutil.NotNil(t, cmd.Flags().Lookup("dry-run"))
 	})

--- a/internal/cmd/mail/output.go
+++ b/internal/cmd/mail/output.go
@@ -8,7 +8,6 @@ import (
 	gmailv1 "google.golang.org/api/gmail/v1"
 
 	"github.com/open-cli-collective/google-readonly/internal/gmail"
-	"github.com/open-cli-collective/google-readonly/internal/output"
 )
 
 // MailClient defines the interface for Gmail client operations used by mail commands.
@@ -38,11 +37,6 @@ var ClientFactory = func(ctx context.Context) (MailClient, error) {
 // newGmailClient creates and returns a new Gmail client
 func newGmailClient(ctx context.Context) (MailClient, error) {
 	return ClientFactory(ctx)
-}
-
-// printJSON encodes data as indented JSON to stdout
-func printJSON(data any) error {
-	return output.JSONStdout(data)
 }
 
 // MessagePrintOptions controls which fields to include in message output

--- a/internal/cmd/mail/read.go
+++ b/internal/cmd/mail/read.go
@@ -7,8 +7,6 @@ import (
 )
 
 func newReadCommand() *cobra.Command {
-	var jsonOutput bool
-
 	cmd := &cobra.Command{
 		Use:   "read <message-id>",
 		Short: "Read a single message",
@@ -17,8 +15,7 @@ func newReadCommand() *cobra.Command {
 The message ID can be obtained from the search command output.
 
 Examples:
-  gro mail read 18abc123def456
-  gro mail read 18abc123def456 --json`,
+  gro mail read 18abc123def456`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := newGmailClient(cmd.Context())
@@ -31,10 +28,6 @@ Examples:
 				return fmt.Errorf("reading message: %w", err)
 			}
 
-			if jsonOutput {
-				return printJSON(msg)
-			}
-
 			printMessageHeader(msg, MessagePrintOptions{
 				IncludeTo:   true,
 				IncludeBody: true,
@@ -43,8 +36,6 @@ Examples:
 			return nil
 		},
 	}
-
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output result as JSON")
 
 	return cmd
 }

--- a/internal/cmd/mail/read_test.go
+++ b/internal/cmd/mail/read_test.go
@@ -24,13 +24,6 @@ func TestReadCommand(t *testing.T) {
 		testutil.Error(t, err)
 	})
 
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-		testutil.Equal(t, flag.DefValue, "false")
-	})
-
 	t.Run("has short description", func(t *testing.T) {
 		testutil.NotEmpty(t, cmd.Short)
 		testutil.Contains(t, cmd.Short, "message")

--- a/internal/cmd/mail/search.go
+++ b/internal/cmd/mail/search.go
@@ -9,7 +9,6 @@ import (
 func newSearchCommand() *cobra.Command {
 	var (
 		maxResults int64
-		jsonOutput bool
 		idsOnly    bool
 	)
 
@@ -21,17 +20,13 @@ func newSearchCommand() *cobra.Command {
 Examples:
   gro mail search "from:alice@example.com"
   gro mail search "subject:meeting" --max 20
-  gro mail search "is:unread" --json
+  gro mail search "is:unread"
   gro mail search "after:2024/01/01 before:2024/02/01"
   gro mail search "is:inbox" --ids | gro mail archive --stdin
 
 For more query operators, see: https://support.google.com/mail/answer/7190`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if idsOnly && jsonOutput {
-				return fmt.Errorf("--ids and --json are mutually exclusive")
-			}
-
 			client, err := newGmailClient(cmd.Context())
 			if err != nil {
 				return fmt.Errorf("creating Gmail client: %w", err)
@@ -54,16 +49,8 @@ For more query operators, see: https://support.google.com/mail/answer/7190`,
 			}
 
 			if len(messages) == 0 {
-				if jsonOutput {
-					fmt.Println("[]")
-					return nil
-				}
 				fmt.Println("No messages found.")
 				return nil
-			}
-
-			if jsonOutput {
-				return printJSON(messages)
 			}
 
 			for _, msg := range messages {
@@ -83,7 +70,6 @@ For more query operators, see: https://support.google.com/mail/answer/7190`,
 	}
 
 	cmd.Flags().Int64VarP(&maxResults, "max", "m", 10, "Maximum number of results to return")
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 	cmd.Flags().BoolVar(&idsOnly, "ids", false, "Output only message IDs (one per line, for piping)")
 
 	return cmd

--- a/internal/cmd/mail/search_test.go
+++ b/internal/cmd/mail/search_test.go
@@ -31,13 +31,6 @@ func TestSearchCommand(t *testing.T) {
 		testutil.Equal(t, flag.DefValue, "10")
 	})
 
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-		testutil.Equal(t, flag.DefValue, "false")
-	})
-
 	t.Run("has ids flag", func(t *testing.T) {
 		flag := cmd.Flags().Lookup("ids")
 		testutil.NotNil(t, flag)

--- a/internal/cmd/mail/star.go
+++ b/internal/cmd/mail/star.go
@@ -10,10 +10,9 @@ import (
 
 func newStarCommand() *cobra.Command {
 	var (
-		jsonOutput bool
-		dryRun     bool
-		stdin      bool
-		query      string
+		dryRun bool
+		stdin  bool
+		query  string
 	)
 
 	cmd := &cobra.Command{
@@ -52,18 +51,17 @@ Examples:
 
 			if dryRun {
 				result.Action = "star"
-				return result.Print(jsonOutput)
+				return result.Print()
 			}
 
 			if err := client.ModifyMessages(ctx, ids, []string{"STARRED"}, nil); err != nil {
 				return fmt.Errorf("starring messages: %w", err)
 			}
 
-			return result.Print(jsonOutput)
+			return result.Print()
 		},
 	}
 
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
 	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read message IDs from stdin")
 	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve message IDs")
@@ -73,10 +71,9 @@ Examples:
 
 func newUnstarCommand() *cobra.Command {
 	var (
-		jsonOutput bool
-		dryRun     bool
-		stdin      bool
-		query      string
+		dryRun bool
+		stdin  bool
+		query  string
 	)
 
 	cmd := &cobra.Command{
@@ -114,18 +111,17 @@ Examples:
 
 			if dryRun {
 				result.Action = "unstar"
-				return result.Print(jsonOutput)
+				return result.Print()
 			}
 
 			if err := client.ModifyMessages(ctx, ids, nil, []string{"STARRED"}); err != nil {
 				return fmt.Errorf("unstarring messages: %w", err)
 			}
 
-			return result.Print(jsonOutput)
+			return result.Print()
 		},
 	}
 
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Preview without making changes")
 	cmd.Flags().BoolVar(&stdin, "stdin", false, "Read message IDs from stdin")
 	cmd.Flags().StringVar(&query, "query", "", "Search query to resolve message IDs")

--- a/internal/cmd/mail/star_test.go
+++ b/internal/cmd/mail/star_test.go
@@ -10,10 +10,6 @@ import (
 func TestStarCommand(t *testing.T) {
 	cmd := newStarCommand()
 
-	t.Run("has json flag", func(t *testing.T) {
-		testutil.NotNil(t, cmd.Flags().Lookup("json"))
-	})
-
 	t.Run("has dry-run flag", func(t *testing.T) {
 		testutil.NotNil(t, cmd.Flags().Lookup("dry-run"))
 	})

--- a/internal/cmd/mail/thread.go
+++ b/internal/cmd/mail/thread.go
@@ -7,8 +7,6 @@ import (
 )
 
 func newThreadCommand() *cobra.Command {
-	var jsonOutput bool
-
 	cmd := &cobra.Command{
 		Use:   "thread <id>",
 		Short: "Read a full conversation thread",
@@ -20,8 +18,7 @@ Use the search command to find message IDs (the ThreadID field can also
 be used directly).
 
 Examples:
-  gro mail thread 18abc123def456
-  gro mail thread 18abc123def456 --json`,
+  gro mail thread 18abc123def456`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := newGmailClient(cmd.Context())
@@ -35,16 +32,8 @@ Examples:
 			}
 
 			if len(messages) == 0 {
-				if jsonOutput {
-					fmt.Println("[]")
-					return nil
-				}
 				fmt.Println("No messages found in thread.")
 				return nil
-			}
-
-			if jsonOutput {
-				return printJSON(messages)
 			}
 
 			fmt.Printf("Thread contains %d message(s)\n\n", len(messages))
@@ -60,8 +49,6 @@ Examples:
 			return nil
 		},
 	}
-
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Output result as JSON")
 
 	return cmd
 }

--- a/internal/cmd/mail/thread_test.go
+++ b/internal/cmd/mail/thread_test.go
@@ -24,13 +24,6 @@ func TestThreadCommand(t *testing.T) {
 		testutil.Error(t, err)
 	})
 
-	t.Run("has json flag", func(t *testing.T) {
-		flag := cmd.Flags().Lookup("json")
-		testutil.NotNil(t, flag)
-		testutil.Equal(t, flag.Shorthand, "j")
-		testutil.Equal(t, flag.DefValue, "false")
-	})
-
 	t.Run("has short description", func(t *testing.T) {
 		testutil.NotEmpty(t, cmd.Short)
 		testutil.Contains(t, cmd.Short, "thread")

--- a/internal/cmd/me/me.go
+++ b/internal/cmd/me/me.go
@@ -22,9 +22,8 @@ var errReauth = errors.New("re-authentication required")
 // NewCommand returns the `me` cobra command.
 func NewCommand() *cobra.Command {
 	var (
-		idOnly     bool
-		extended   bool
-		jsonOutput bool
+		idOnly   bool
+		extended bool
 	)
 
 	cmd := &cobra.Command{
@@ -43,10 +42,7 @@ Data comes from the People API people/me endpoint.`,
   gro me --id
 
   # Add granted scopes, token expiry, and storage backend
-  gro me --extended
-
-  # JSON output
-  gro me --json`,
+  gro me --extended`,
 		Args: cobra.NoArgs,
 		// SilenceErrors so errReauth's actionable message (already written to
 		// stderr by run()) isn't shadowed by cobra's "Error: re-authentication
@@ -54,19 +50,18 @@ Data comes from the People API people/me endpoint.`,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return run(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), idOnly, extended, jsonOutput)
+			return run(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), idOnly, extended)
 		},
 	}
 
 	cmd.Flags().BoolVar(&idOnly, "id", false, "Print only the primary email")
 	cmd.Flags().BoolVar(&extended, "extended", false, "Add granted scopes, token expiry, and storage backend")
-	cmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "Emit JSON")
 	cmd.MarkFlagsMutuallyExclusive("id", "extended")
 
 	return cmd
 }
 
-func run(ctx context.Context, out, errOut io.Writer, idOnly, extended, jsonOutput bool) error {
+func run(ctx context.Context, out, errOut io.Writer, idOnly, extended bool) error {
 	// Loud-and-early stale-scope check (only fires when scopes were recorded).
 	if cfg, err := config.LoadConfigForRuntime(); err == nil {
 		if msg := auth.CheckScopesMigration(cfg.GrantedScopes); msg != "" {
@@ -102,10 +97,6 @@ func run(ctx context.Context, out, errOut io.Writer, idOnly, extended, jsonOutpu
 	if extended {
 		extras = gatherExtras()
 		extras.GrantedScopes = grantedScopes()
-	}
-
-	if jsonOutput {
-		return RenderJSON(out, profile, extras, idOnly, extended)
 	}
 
 	switch {

--- a/internal/cmd/me/me_test.go
+++ b/internal/cmd/me/me_test.go
@@ -3,7 +3,6 @@ package me
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -12,7 +11,6 @@ import (
 
 	"github.com/open-cli-collective/cli-common/statedirtest"
 
-	"github.com/open-cli-collective/google-readonly/internal/auth"
 	"github.com/open-cli-collective/google-readonly/internal/config"
 	"github.com/open-cli-collective/google-readonly/internal/people"
 )
@@ -117,68 +115,6 @@ func TestRenderExtendedIncludesScopesAndExpiry(t *testing.T) {
 	}
 }
 
-func TestRenderJSONShapes(t *testing.T) {
-	t.Parallel()
-	p := &people.Profile{
-		ResourceName: "people/c1",
-		DisplayName:  "Ada",
-		PrimaryEmail: "ada@example.com",
-	}
-	extras := Extras{GrantedScopes: []string{"scope-a"}, TokenExpiry: "expiry-x", StorageBackend: "keychain"}
-
-	t.Run("default", func(t *testing.T) {
-		var buf bytes.Buffer
-		if err := RenderJSON(&buf, p, Extras{}, false, false); err != nil {
-			t.Fatal(err)
-		}
-		var got jsonOneLiner
-		if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
-			t.Fatal(err)
-		}
-		if got.ResourceName != "people/c1" || got.DisplayName != "Ada" || got.PrimaryEmail != "ada@example.com" {
-			t.Errorf("unexpected: %+v", got)
-		}
-	})
-
-	t.Run("--id", func(t *testing.T) {
-		var buf bytes.Buffer
-		if err := RenderJSON(&buf, p, Extras{}, true, false); err != nil {
-			t.Fatal(err)
-		}
-		var got jsonIDOnly
-		if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
-			t.Fatal(err)
-		}
-		if got.PrimaryEmail != "ada@example.com" {
-			t.Errorf("unexpected: %+v", got)
-		}
-		// Make sure the other fields are absent.
-		if strings.Contains(buf.String(), "resourceName") {
-			t.Errorf("--id JSON should not include resourceName, got %s", buf.String())
-		}
-	})
-
-	t.Run("--extended", func(t *testing.T) {
-		var buf bytes.Buffer
-		if err := RenderJSON(&buf, p, extras, false, true); err != nil {
-			t.Fatal(err)
-		}
-		var got jsonExtended
-		if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
-			t.Fatal(err)
-		}
-		if got.ResourceName != "people/c1" || got.PrimaryEmail != "ada@example.com" {
-			t.Errorf("unexpected: %+v", got)
-		}
-		if len(got.GrantedScopes) != 1 || got.GrantedScopes[0] != "scope-a" {
-			t.Errorf("expected scope-a, got %+v", got.GrantedScopes)
-		}
-		if got.TokenExpiry != "expiry-x" || got.StorageBackend != "keychain" {
-			t.Errorf("unexpected: %+v", got)
-		}
-	})
-}
-
 func TestRunInsufficientScopeRemap(t *testing.T) {
 	// Not Parallel: mutates package-global ClientFactory.
 	withMockClient(t, &mockPeopleClient{
@@ -190,7 +126,7 @@ func TestRunInsufficientScopeRemap(t *testing.T) {
 		},
 	})
 	var out bytes.Buffer
-	err := run(context.Background(), &out, &bytes.Buffer{}, false, false, false)
+	err := run(context.Background(), &out, &bytes.Buffer{}, false, false)
 	if !errors.Is(err, errReauth) {
 		t.Fatalf("expected errReauth, got %v", err)
 	}
@@ -208,7 +144,7 @@ func TestRunServiceDisabledNotRemapped(t *testing.T) {
 		},
 	})
 	var out bytes.Buffer
-	err := run(context.Background(), &out, &bytes.Buffer{}, false, false, false)
+	err := run(context.Background(), &out, &bytes.Buffer{}, false, false)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -232,56 +168,12 @@ func TestRunDefaultPipeOneLiner(t *testing.T) {
 		},
 	})
 	var out bytes.Buffer
-	if err := run(context.Background(), &out, &bytes.Buffer{}, false, false, false); err != nil {
+	if err := run(context.Background(), &out, &bytes.Buffer{}, false, false); err != nil {
 		t.Fatal(err)
 	}
 	want := "people/c1 | Ada | ada@example.com\n"
 	if got := out.String(); got != want {
 		t.Fatalf("got %q, want %q", got, want)
-	}
-}
-
-// TestRunExtendedJSONEndToEnd ensures that --extended + --json flow through
-// run() correctly: the renderer is tested in isolation by TestRenderJSONShapes,
-// but only this test catches a regression where gatherExtras is skipped when
-// jsonOutput is true.
-func TestRunExtendedJSONEndToEnd(t *testing.T) {
-	// Not Parallel: mutates package-global ClientFactory + env.
-	withConfigDir(t)
-	// Seed config with a known scope record so we can assert the JSON
-	// surface reflects the recorded scopes, not auth.AllScopes (which
-	// would overstate consent).
-	if err := config.SaveConfig(&config.Config{
-		GrantedScopes: auth.AllScopes,
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	withMockClient(t, &mockPeopleClient{
-		GetMeFunc: func(_ context.Context) (*people.Profile, error) {
-			return &people.Profile{
-				ResourceName: "people/c1",
-				DisplayName:  "Ada",
-				PrimaryEmail: "ada@example.com",
-			}, nil
-		},
-	})
-	var out, errOut bytes.Buffer
-	if err := run(context.Background(), &out, &errOut, false /*idOnly*/, true /*extended*/, true /*json*/); err != nil {
-		t.Fatalf("run: %v", err)
-	}
-	var got jsonExtended
-	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
-		t.Fatalf("unmarshal: %v\noutput: %s", err, out.String())
-	}
-	if got.PrimaryEmail != "ada@example.com" {
-		t.Errorf("expected ada@example.com, got %+v", got)
-	}
-	// Recorded scopes should propagate through to extended output. This
-	// guards against a regression where gatherExtras is skipped under
-	// jsonOutput.
-	if len(got.GrantedScopes) != len(auth.AllScopes) {
-		t.Errorf("expected %d scopes, got %d: %+v", len(auth.AllScopes), len(got.GrantedScopes), got.GrantedScopes)
 	}
 }
 
@@ -297,7 +189,7 @@ func TestRunIDOnlyEmitsEmail(t *testing.T) {
 		},
 	})
 	var out bytes.Buffer
-	if err := run(context.Background(), &out, &bytes.Buffer{}, true, false, false); err != nil {
+	if err := run(context.Background(), &out, &bytes.Buffer{}, true, false); err != nil {
 		t.Fatal(err)
 	}
 	if got := out.String(); got != "ada@example.com\n" {
@@ -339,15 +231,12 @@ func TestNewCommandSilencesCobraErrorOnReauth(t *testing.T) {
 	}
 }
 
-func TestNewCommandHasJSONFlagWithShorthand(t *testing.T) {
+func TestNewCommandNoJSONFlag(t *testing.T) {
+	// #144: resource leaves emit text only; --json was removed from gro me.
 	t.Parallel()
 	cmd := NewCommand()
-	flag := cmd.Flags().Lookup("json")
-	if flag == nil {
-		t.Fatal("expected --json flag")
-	}
-	if flag.Shorthand != "j" {
-		t.Fatalf("expected -j shorthand, got %q", flag.Shorthand)
+	if cmd.Flags().Lookup("json") != nil {
+		t.Fatal("expected no --json flag on gro me (see #144)")
 	}
 }
 
@@ -399,7 +288,7 @@ func TestRunStaleRecordedScopesTriggersReauthMessage(t *testing.T) {
 		},
 	})
 	var out, errOut bytes.Buffer
-	err := run(context.Background(), &out, &errOut, false, false, false)
+	err := run(context.Background(), &out, &errOut, false, false)
 	if !errors.Is(err, errReauth) {
 		t.Fatalf("expected errReauth, got %v", err)
 	}
@@ -421,7 +310,7 @@ func TestRunMissingConfigDoesNotShortCircuit(t *testing.T) {
 		},
 	})
 	var out, errOut bytes.Buffer
-	if err := run(context.Background(), &out, &errOut, false, false, false); err != nil {
+	if err := run(context.Background(), &out, &errOut, false, false); err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
 	if !strings.Contains(out.String(), "ada@example.com") {
@@ -444,7 +333,7 @@ func TestRunEmptyGrantedScopesDoesNotShortCircuit(t *testing.T) {
 		},
 	})
 	var out, errOut bytes.Buffer
-	if err := run(context.Background(), &out, &errOut, false, false, false); err != nil {
+	if err := run(context.Background(), &out, &errOut, false, false); err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
 }

--- a/internal/cmd/me/output.go
+++ b/internal/cmd/me/output.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/open-cli-collective/google-readonly/internal/keychain"
-	"github.com/open-cli-collective/google-readonly/internal/output"
 	"github.com/open-cli-collective/google-readonly/internal/people"
 )
 
@@ -26,26 +25,6 @@ type Extras struct {
 	GrantedScopes  []string
 	TokenExpiry    string
 	StorageBackend string
-}
-
-// jsonOneLiner is the shape emitted for `gro me --json`.
-type jsonOneLiner struct {
-	ResourceName string `json:"resourceName"`
-	DisplayName  string `json:"displayName"`
-	PrimaryEmail string `json:"primaryEmail"`
-}
-
-// jsonExtended is the shape emitted for `gro me --extended --json`.
-type jsonExtended struct {
-	jsonOneLiner
-	GrantedScopes  []string `json:"grantedScopes,omitempty"`
-	TokenExpiry    string   `json:"tokenExpiry,omitempty"`
-	StorageBackend string   `json:"storageBackend,omitempty"`
-}
-
-// jsonIDOnly is the shape emitted for `gro me --id --json`.
-type jsonIDOnly struct {
-	PrimaryEmail string `json:"primaryEmail"`
 }
 
 // RenderOneLiner writes the canonical `resourceName | displayName | primaryEmail`
@@ -80,37 +59,6 @@ func RenderExtended(w io.Writer, p *people.Profile, e Extras) {
 func RenderID(w io.Writer, p *people.Profile) {
 	em := normalizeField(p.PrimaryEmail)
 	_, _ = fmt.Fprintln(w, em)
-}
-
-// RenderJSON emits one of three JSON shapes depending on (idOnly, extended).
-// It routes through output.JSON so the §1.8 one-time-migration block is
-// spliced in on the first post-migration `gro me --json` (`gro me` is the
-// §445 installer smoke command, so its JSON must carry _migration).
-func RenderJSON(w io.Writer, p *people.Profile, e Extras, idOnly, extended bool) error {
-	switch {
-	case idOnly:
-		// JSON paths consistently emit raw values (empty strings remain
-		// empty), unlike text rendering which uses "-". This keeps
-		// `gro me --json` shapes machine-friendly across all flag combos.
-		return output.JSON(w, jsonIDOnly{PrimaryEmail: p.PrimaryEmail})
-	case extended:
-		return output.JSON(w, jsonExtended{
-			jsonOneLiner: jsonOneLiner{
-				ResourceName: p.ResourceName,
-				DisplayName:  p.DisplayName,
-				PrimaryEmail: p.PrimaryEmail,
-			},
-			GrantedScopes:  e.GrantedScopes,
-			TokenExpiry:    e.TokenExpiry,
-			StorageBackend: e.StorageBackend,
-		})
-	default:
-		return output.JSON(w, jsonOneLiner{
-			ResourceName: p.ResourceName,
-			DisplayName:  p.DisplayName,
-			PrimaryEmail: p.PrimaryEmail,
-		})
-	}
 }
 
 func normalizeField(s string) string {

--- a/internal/noleak/noleak_test.go
+++ b/internal/noleak/noleak_test.go
@@ -116,9 +116,11 @@ func TestSetCredentialNeverLeaks(t *testing.T) {
 	assertNoLeak(t, "set-credential --stdin [stderr]", []byte(se))
 }
 
-// TestMeNeverLeaks covers the §445 smoke command across text + --json +
-// --extended (which reads token expiry from the keyring via gatherExtras),
-// on both output channels. me's People client is mocked (no network).
+// TestMeNeverLeaks covers the §445 smoke command across text + --extended
+// (which reads token expiry from the keyring via gatherExtras), on both
+// output channels. me's People client is mocked (no network). #144 removed
+// the --json variants from gro me — the surviving JSON surface is
+// `config show --json`, covered above.
 func TestMeNeverLeaks(t *testing.T) {
 	seed(t)
 	orig := mecmd.ClientFactory
@@ -127,7 +129,7 @@ func TestMeNeverLeaks(t *testing.T) {
 	}
 	t.Cleanup(func() { mecmd.ClientFactory = orig })
 
-	for _, args := range [][]string{{}, {"--json"}, {"--extended"}, {"--extended", "--json"}} {
+	for _, args := range [][]string{{}, {"--extended"}} {
 		cmd := mecmd.NewCommand()
 		cmd.SetArgs(args)
 		so, se := captureBoth(t, func() { _ = cmd.Execute() })

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -16,8 +16,8 @@ import (
 // "_migration" field and consumed (so it appears exactly once, on the first
 // JSON command after the migration). With no pending block the output is
 // byte-identical to a plain indented Encoder (2-space indent, trailing
-// newline) — existing per-domain printJSON() callers inherit the splice for
-// free via JSONStdout.
+// newline) — the surviving control-plane JSONStdout callers (refresh,
+// config show) inherit the splice for free.
 func JSON(w io.Writer, data any) error {
 	mig, _ := migrationsink.Take()
 	if mig == nil {


### PR DESCRIPTION
## Summary

Remove per-command \`--json/-j\` from every resource-surface leaf in gro (mail, calendar, contacts, drive, me) per cli-common \`docs/output-and-rendering.md\` §2 (JSON reserved for round-trip payloads + control-plane envelopes only). After this PR, attempting any \`gro <resource> --json\` returns cobra's \`unknown flag: --json\`.

**Carve-outs (preserved unchanged):**
- \`gro refresh --json\` / \`gro refresh --status --json\` (control-plane envelope; cli-common §4.6, added in #146)
- \`gro config show --json\` (diagnostic / config introspection; installer-script precondition surface)

\`gro set-credential --json\` does not exist today; if added later it would qualify as a §1.5.2 carve-out, but this PR neither adds nor presupposes that surface.

## Boundary

"No per-command \`--json\` anywhere on resource surfaces, including mutation-success renderers." mail \`archive/label/markread/star/categorize/draft\`, calendar \`color/rsvp\`, contacts \`group_manage/star\`, drive \`star\` are swept up by the same policy as the resource reads — mirrors the cfl#392 boundary.

## Architectural shift

Golden principle #4 is **inverted**:
- **Pre-#144:** every leaf declared \`--json/-j\` (enforced by \`TestAllLeafCommandsHaveJSONFlag\`, with two binary-write exemptions).
- **Post-#144:** every resource leaf must NOT declare \`--json\` (enforced by \`TestResourceLeavesHaveNoJSONFlag\`). The \`jsonExemptCommands\` allowlist is gone.

\`docs/golden-principles.md\` §4 rewritten to match.

## Shared helper cleanup

- \`internal/bulk/result.go\`: \`Result.Print(jsonOutput bool)\` → \`Print()\` (text-only); callers in mail/drive batch commands updated.
- \`internal/cmd/{mail,calendar,contacts,drive}/output.go\`: deleted the four package-local \`printJSON\` helpers (orphaned after branch removal).
- \`internal/cmd/me/output.go\`: deleted \`RenderJSON\` plus the three JSON-shape structs (\`jsonOneLiner\`, \`jsonIDOnly\`, \`jsonExtended\`).
- \`internal/output/\` package unchanged — still consumed by \`refresh\` and \`config show\`.

## Test invariants

- \`gro mail search "test" --json\` → \`unknown flag: --json\` (cobra)
- \`gro refresh --json\` → still emits the §4.6 envelope
- \`gro config show --json\` → still emits the diagnostic record
- \`make build && make test && make lint\` clean
- \`TestResourceLeavesHaveNoJSONFlag\` passes
- \`internal/noleak\` me variants dropped; \`config show --json\` no-leak coverage retained

\`TestResolveDriveScope\` continues to fail on 2 subtests in some local environments — confirmed pre-existing on \`main\` via \`git stash + test\`, environment-dependent, unrelated to this PR.

## Stats

74 files changed, 147 insertions(+), 1954 deletions(-). Net deletion: the removal absorbs more code than it adds.

Closes #144