### PR TITLE
feat(cred): select credential ref per invocation (--ref flag + env)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,30 @@ config > auto). With the default ref, `set-credential`
 runs the one-time legacy migration first so a pre-existing `token.json` cannot
 later collide; an explicit `--ref` never migrates.
 
+### Selecting an account per invocation (concurrent multi-account use)
+
+`set-credential` can store tokens for several accounts under distinct credential
+refs (`<service>/<profile>`), but by default every command reads the single
+active `credential_ref` from `config.yml`. To let concurrent processes each
+target a *different* account without racing on that shared file, **any** command
+accepts a per-invocation credential ref, resolved with the same precedence shape
+as `--backend`:
+
+`--ref <service>/<profile>` flag > `GOOGLE_READONLY_CREDENTIAL_REF` env > `config.yml` `credential_ref`
+
+```bash
+# Two mailboxes in parallel, each fully self-contained — no config.yml rewrite:
+gro mail search "is:unread" --ref google-readonly/work &
+gro mail search "is:unread" --ref google-readonly/personal &
+
+# Or via the environment, to wrap a whole process:
+GOOGLE_READONLY_CREDENTIAL_REF=google-readonly/work gro calendar today
+```
+
+An explicit `--ref`/env override targets an already-provisioned profile, so it
+never runs the one-time legacy `token.json` migration (that only ever applies to
+the configured/default ref).
+
 ## Commands
 
 ### Configuration Commands

--- a/docs/development.md
+++ b/docs/development.md
@@ -104,6 +104,8 @@ OAuth tokens are per-user access secrets and live only through `cli-common/creds
 
 Non-secret config uses the OS-native config directory via `cli-common/statedir`. Current config fields include `credential_ref`, `oauth_client_path`, `granted_scopes`, and `keyring.backend`.
 
+The active `credential_ref` can be overridden per invocation — precedence `--ref` flag > `GOOGLE_READONLY_CREDENTIAL_REF` env > `config.yml` — so concurrent processes can target different accounts without racing on the shared config file. This mirrors the `--backend` selection machinery: the persistent flag is recorded by `root.WireCredentialRefSelection` and applied at the single `keychain.open` resolution site (which suppresses the one-time legacy migration whenever an override is present, since migration only ever targets the configured ref).
+
 Secret ingress belongs in setup and credential-management commands only. For the shared rules, use `working-with-secrets.md`, `working-with-state.md`, and `scriptability.md` from `cli-common`.
 
 ## Testing Notes

--- a/internal/cmd/root/backend_wire_test.go
+++ b/internal/cmd/root/backend_wire_test.go
@@ -25,11 +25,13 @@ const serviceName = "google-readonly"
 func resetState(t *testing.T) {
 	t.Helper()
 	keychain.SetBackendFlagOverride("", false)
+	keychain.SetCredentialRefOverride("", false)
 	// rootCmd.SetArgs mutates package-level state; if a test panics before
 	// the next test calls SetArgs, a stale slice could bleed in (notably
 	// under `go test -shuffle=on`). Clear it on cleanup.
 	t.Cleanup(func() {
 		keychain.SetBackendFlagOverride("", false)
+		keychain.SetCredentialRefOverride("", false)
 		rootCmd.SetArgs(nil)
 	})
 }

--- a/internal/cmd/root/credref_wire_test.go
+++ b/internal/cmd/root/credref_wire_test.go
@@ -1,0 +1,117 @@
+package root
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/google-readonly/internal/keychain"
+)
+
+// TestWireCredentialRefSelection_FlagSet proves a --ref on a real command
+// path is recorded in the override the keychain.open resolver reads.
+func TestWireCredentialRefSelection_FlagSet(t *testing.T) {
+	resetState(t)
+	t.Setenv(keychain.CredentialRefEnvVar(), "")
+
+	probe := newProbeCmd("probe-ref-flagset")
+	rootCmd.AddCommand(probe)
+	defer removeChild(t, probe)
+	rootCmd.SetArgs([]string{"probe-ref-flagset", "--ref", "google-readonly/acct-a"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	v, set := keychain.GetCredentialRefOverride()
+	if !set {
+		t.Fatalf("override flagSet = false, want true")
+	}
+	if v != "google-readonly/acct-a" {
+		t.Errorf("override value = %q, want %q", v, "google-readonly/acct-a")
+	}
+}
+
+// TestWireCredentialRefSelection_FlagInvalid asserts a malformed --ref fails
+// up front with a clear "--ref" error, before any keyring work.
+func TestWireCredentialRefSelection_FlagInvalid(t *testing.T) {
+	resetState(t)
+
+	probe := newProbeCmd("probe-ref-invalid")
+	rootCmd.AddCommand(probe)
+	defer removeChild(t, probe)
+	rootCmd.SetArgs([]string{"probe-ref-invalid", "--ref", "no-slash"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "--"+credentialRefFlagName) {
+		t.Errorf("error should mention --%s: %v", credentialRefFlagName, err)
+	}
+}
+
+// TestWireCredentialRefSelection_ShadowingSubcommand regresses the
+// cobra-doesn't-chain-PersistentPreRunE bug for --ref, mirroring the
+// --backend guard.
+func TestWireCredentialRefSelection_ShadowingSubcommand(t *testing.T) {
+	resetState(t)
+	t.Setenv(keychain.CredentialRefEnvVar(), "")
+
+	shadow := &cobra.Command{
+		Use: "shadow-ref",
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			return WireCredentialRefSelection(cmd)
+		},
+	}
+	leaf := newProbeCmd("leaf")
+	shadow.AddCommand(leaf)
+	rootCmd.AddCommand(shadow)
+	defer removeChild(t, shadow)
+
+	rootCmd.SetArgs([]string{"shadow-ref", "leaf", "--ref", "google-readonly/acct-b"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute through shadowing PreRunE: %v", err)
+	}
+	v, set := keychain.GetCredentialRefOverride()
+	if !set || v != "google-readonly/acct-b" {
+		t.Errorf("override = (%q, %v); want (\"google-readonly/acct-b\", true) — shadower's PreRunE failed to invoke WireCredentialRefSelection", v, set)
+	}
+}
+
+// TestCredentialRef_SetCredentialShadowsPersistent documents the intentional
+// exception to the inherit-everywhere rule: `set-credential` keeps its own
+// local --ref (the write target), so it must resolve to a DIFFERENT *pflag.Flag
+// than the root's persistent selector — while a read command inherits the
+// canonical persistent one. A regression that dropped set-credential's local
+// flag (or that made a read command shadow --ref) would flip these.
+func TestCredentialRef_SetCredentialShadowsPersistent(t *testing.T) {
+	canonical := rootCmd.PersistentFlags().Lookup(credentialRefFlagName)
+	if canonical == nil {
+		t.Fatalf("root persistent flag --%s not registered", credentialRefFlagName)
+	}
+
+	var sc *cobra.Command
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "set-credential" {
+			sc = c
+			break
+		}
+	}
+	if sc == nil {
+		t.Fatal("set-credential command not registered on rootCmd")
+	}
+	if got := sc.Flag(credentialRefFlagName); got == nil {
+		t.Fatalf("set-credential has no --%s", credentialRefFlagName)
+	} else if got == canonical {
+		t.Errorf("set-credential --%s resolved to the persistent flag; expected its own local shadow", credentialRefFlagName)
+	}
+
+	// A read command (no local --ref) must inherit the canonical persistent flag.
+	me := newProbeCmd("probe-ref-inherit")
+	rootCmd.AddCommand(me)
+	defer removeChild(t, me)
+	if got := me.Flag(credentialRefFlagName); got != canonical {
+		t.Errorf("read command --%s = %p, want canonical %p (unexpected shadow)", credentialRefFlagName, got, canonical)
+	}
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -32,6 +32,11 @@ var (
 	noColor bool
 )
 
+// credentialRefFlagName is the global per-invocation credential-ref selector.
+// It shares its name with `set-credential`'s own write-target --ref (a local
+// flag that shadows this persistent one for that command only).
+const credentialRefFlagName = "ref"
+
 var rootCmd = &cobra.Command{
 	Use:   "gro",
 	Short: "A non-destructive CLI for Google services",
@@ -52,7 +57,10 @@ This will guide you through OAuth setup for Google API access.`,
 		if noColor {
 			lipgloss.DefaultRenderer().SetColorProfile(termenv.Ascii)
 		}
-		return WireBackendSelection(cmd)
+		if err := WireBackendSelection(cmd); err != nil {
+			return err
+		}
+		return WireCredentialRefSelection(cmd)
 	},
 }
 
@@ -79,6 +87,32 @@ func WireBackendSelection(cmd *cobra.Command) error {
 		return fmt.Errorf("--%s: %w", cccredstore.BackendFlagName, err)
 	}
 	keychain.SetBackendFlagOverride(value, changed)
+	return nil
+}
+
+// WireCredentialRefSelection records the user-supplied --ref flag for the next
+// keychain.Open* call and validates its <service>/<profile> shape up front so a
+// bad value fails with a clear "--ref" error before any keyring work. The
+// resolved precedence (--ref flag > <SERVICE>_CREDENTIAL_REF env > config
+// credential_ref) is applied at keychain.open; this hook only records the flag.
+//
+// Like WireBackendSelection, it is exported because cobra does NOT chain
+// PersistentPreRunE — a subcommand that defines its own must call this
+// explicitly. Reads via cmd.Flag() so persistent-flag inheritance works from
+// any subcommand path.
+func WireCredentialRefSelection(cmd *cobra.Command) error {
+	f := cmd.Flag(credentialRefFlagName)
+	if f == nil {
+		return nil
+	}
+	value := f.Value.String()
+	changed := f.Changed
+	if changed && value != "" {
+		if _, _, err := cccredstore.ParseRef(value); err != nil {
+			return fmt.Errorf("--%s: %w", credentialRefFlagName, err)
+		}
+	}
+	keychain.SetCredentialRefOverride(value, changed)
 	return nil
 }
 
@@ -117,6 +151,11 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output for debugging")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colored output")
 	rootCmd.PersistentFlags().String(cccredstore.BackendFlagName, "", cccredstore.BackendFlagUsage())
+	rootCmd.PersistentFlags().String(credentialRefFlagName, "", fmt.Sprintf(
+		"Credential ref <service>/<profile> for this invocation, so concurrent commands "+
+			"can target different accounts without racing on config.yml "+
+			"(precedence: --%s flag > %s env > config credential_ref)",
+		credentialRefFlagName, keychain.CredentialRefEnvVar()))
 
 	// Register commands
 	rootCmd.AddCommand(initcmd.NewCommand())

--- a/internal/keychain/credref_test.go
+++ b/internal/keychain/credref_test.go
@@ -1,6 +1,10 @@
 package keychain
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/open-cli-collective/google-readonly/internal/config"
+)
 
 // resetCredRefOverride keeps the package-level --ref override clean across
 // tests so a leaked value can't tilt the next.
@@ -58,6 +62,56 @@ func TestEffectiveRef_Precedence(t *testing.T) {
 		ref, ov := effectiveRef(cfgRef)
 		if ref != cfgRef || ov {
 			t.Errorf("got (%q,%v), want (%q,false) — empty --ref must fall through", ref, ov, cfgRef)
+		}
+	})
+}
+
+// TestApplyCredentialRefOverride proves the safety-critical part open() relies
+// on: a present override swaps cfg.CredentialRef AND forces runMigration=false
+// (so the one-time legacy migration never runs against an arbitrary
+// --ref/env-selected profile), while no override leaves both untouched. This is
+// the open()-side coverage the pure effectiveRef/wiring tests don't provide.
+func TestApplyCredentialRefOverride(t *testing.T) {
+	const cfgRef = "google-readonly/cfg"
+
+	t.Run("no override: cfg untouched, runMigration passthrough", func(t *testing.T) {
+		resetCredRefOverride(t)
+		t.Setenv(CredentialRefEnvVar(), "")
+		cfg := &config.Config{CredentialRef: cfgRef}
+		if rm := applyCredentialRefOverride(cfg, true); !rm {
+			t.Errorf("runMigration = %v, want true (passthrough)", rm)
+		}
+		if cfg.CredentialRef != cfgRef {
+			t.Errorf("cfg.CredentialRef = %q, want unchanged %q", cfg.CredentialRef, cfgRef)
+		}
+		// passthrough must preserve a false caller value too (OpenNoMigrate path)
+		if rm := applyCredentialRefOverride(cfg, false); rm {
+			t.Errorf("runMigration = %v, want false (passthrough of caller's false)", rm)
+		}
+	})
+
+	t.Run("flag override: cfg swapped, migration suppressed", func(t *testing.T) {
+		resetCredRefOverride(t)
+		t.Setenv(CredentialRefEnvVar(), "")
+		SetCredentialRefOverride("google-readonly/flag", true)
+		cfg := &config.Config{CredentialRef: cfgRef}
+		if rm := applyCredentialRefOverride(cfg, true); rm {
+			t.Errorf("runMigration = %v, want false (override must suppress migration)", rm)
+		}
+		if cfg.CredentialRef != "google-readonly/flag" {
+			t.Errorf("cfg.CredentialRef = %q, want google-readonly/flag", cfg.CredentialRef)
+		}
+	})
+
+	t.Run("env override: cfg swapped, migration suppressed", func(t *testing.T) {
+		resetCredRefOverride(t)
+		t.Setenv(CredentialRefEnvVar(), "google-readonly/env")
+		cfg := &config.Config{CredentialRef: cfgRef}
+		if rm := applyCredentialRefOverride(cfg, true); rm {
+			t.Errorf("runMigration = %v, want false (env override must suppress migration)", rm)
+		}
+		if cfg.CredentialRef != "google-readonly/env" {
+			t.Errorf("cfg.CredentialRef = %q, want google-readonly/env", cfg.CredentialRef)
 		}
 	})
 }

--- a/internal/keychain/credref_test.go
+++ b/internal/keychain/credref_test.go
@@ -1,0 +1,63 @@
+package keychain
+
+import "testing"
+
+// resetCredRefOverride keeps the package-level --ref override clean across
+// tests so a leaked value can't tilt the next.
+func resetCredRefOverride(t *testing.T) {
+	t.Helper()
+	SetCredentialRefOverride("", false)
+	t.Cleanup(func() { SetCredentialRefOverride("", false) })
+}
+
+// TestCredentialRefEnvVar pins the derived env-var name to the documented
+// <SERVICE>_CREDENTIAL_REF, tracking the same prefix as the backend env var.
+func TestCredentialRefEnvVar(t *testing.T) {
+	if got := CredentialRefEnvVar(); got != "GOOGLE_READONLY_CREDENTIAL_REF" {
+		t.Errorf("CredentialRefEnvVar() = %q, want %q", got, "GOOGLE_READONLY_CREDENTIAL_REF")
+	}
+}
+
+// TestEffectiveRef_Precedence proves --ref flag > env > config, and that an
+// override is reported (so the caller suppresses the one-time migration).
+func TestEffectiveRef_Precedence(t *testing.T) {
+	const cfgRef = "google-readonly/cfg"
+
+	t.Run("config only", func(t *testing.T) {
+		resetCredRefOverride(t)
+		t.Setenv(CredentialRefEnvVar(), "")
+		ref, ov := effectiveRef(cfgRef)
+		if ref != cfgRef || ov {
+			t.Errorf("got (%q,%v), want (%q,false)", ref, ov, cfgRef)
+		}
+	})
+
+	t.Run("env overrides config", func(t *testing.T) {
+		resetCredRefOverride(t)
+		t.Setenv(CredentialRefEnvVar(), "google-readonly/env")
+		ref, ov := effectiveRef(cfgRef)
+		if ref != "google-readonly/env" || !ov {
+			t.Errorf("got (%q,%v), want (google-readonly/env,true)", ref, ov)
+		}
+	})
+
+	t.Run("flag overrides env and config", func(t *testing.T) {
+		resetCredRefOverride(t)
+		t.Setenv(CredentialRefEnvVar(), "google-readonly/env")
+		SetCredentialRefOverride("google-readonly/flag", true)
+		ref, ov := effectiveRef(cfgRef)
+		if ref != "google-readonly/flag" || !ov {
+			t.Errorf("got (%q,%v), want (google-readonly/flag,true)", ref, ov)
+		}
+	})
+
+	t.Run("flag set but empty does not override", func(t *testing.T) {
+		resetCredRefOverride(t)
+		t.Setenv(CredentialRefEnvVar(), "")
+		SetCredentialRefOverride("", true) // Changed=true but no value
+		ref, ov := effectiveRef(cfgRef)
+		if ref != cfgRef || ov {
+			t.Errorf("got (%q,%v), want (%q,false) — empty --ref must fall through", ref, ov, cfgRef)
+		}
+	})
+}

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -17,6 +17,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/open-cli-collective/cli-common/credstore"
 	"golang.org/x/oauth2"
@@ -71,7 +73,47 @@ func open(overwrite, runMigration bool) (*Store, error) {
 	if err != nil {
 		return nil, err
 	}
+	// A per-invocation --ref flag or <SERVICE>_CREDENTIAL_REF env selects the
+	// credential ref for this process (precedence: flag > env > config), so
+	// concurrent processes can each target a different account without racing
+	// on the shared config.yml. An explicit override also suppresses the
+	// one-time §1.8 migration: it only ever targets the configured/default ref
+	// (running it against an arbitrary ref could write the default's legacy
+	// data under the wrong service/profile — the same reason OpenRef skips it).
+	if ref, overridden := effectiveRef(cfg.CredentialRef); overridden {
+		cfg.CredentialRef = ref
+		runMigration = false
+	}
 	return openWith(cfg, overwrite, runMigration)
+}
+
+// CredentialRefEnvVar is the per-invocation credential-ref override env var
+// (e.g. "GOOGLE_READONLY_CREDENTIAL_REF"). It is derived from gro's service so
+// it always tracks the same <SERVICE>_ prefix credstore uses for the backend
+// env var, and is never hard-coded (§1.3). Exported so the cobra layer can name
+// it in the --ref flag's help text.
+func CredentialRefEnvVar() string {
+	service, _, err := credstore.ParseRef(config.DefaultCredentialRef)
+	if err != nil {
+		// DefaultCredentialRef is a compile-time-valid ref; unreachable.
+		return ""
+	}
+	return strings.TrimSuffix(credstore.BackendEnvVar(service), "_KEYRING_BACKEND") + "_CREDENTIAL_REF"
+}
+
+// effectiveRef applies the per-invocation credential-ref precedence
+// (--ref flag > <SERVICE>_CREDENTIAL_REF env > config credential_ref) and
+// reports whether an explicit override was supplied. Mirrors the --backend
+// precedence chain. When overridden is true, the caller must skip the one-time
+// §1.8 migration (see open / OpenRef).
+func effectiveRef(configRef string) (ref string, overridden bool) {
+	if v, set := GetCredentialRefOverride(); set && v != "" {
+		return v, true
+	}
+	if v := os.Getenv(CredentialRefEnvVar()); v != "" {
+		return v, true
+	}
+	return configRef, false
 }
 
 // OpenRef opens a store against an explicit ref instead of config.yml's

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -73,18 +73,28 @@ func open(overwrite, runMigration bool) (*Store, error) {
 	if err != nil {
 		return nil, err
 	}
-	// A per-invocation --ref flag or <SERVICE>_CREDENTIAL_REF env selects the
-	// credential ref for this process (precedence: flag > env > config), so
-	// concurrent processes can each target a different account without racing
-	// on the shared config.yml. An explicit override also suppresses the
-	// one-time §1.8 migration: it only ever targets the configured/default ref
-	// (running it against an arbitrary ref could write the default's legacy
-	// data under the wrong service/profile — the same reason OpenRef skips it).
+	runMigration = applyCredentialRefOverride(cfg, runMigration)
+	return openWith(cfg, overwrite, runMigration)
+}
+
+// applyCredentialRefOverride applies the per-invocation credential-ref override
+// to cfg in place and returns the effective runMigration decision. A
+// --ref flag or <SERVICE>_CREDENTIAL_REF env (precedence: flag > env > config)
+// selects the ref for this process, so concurrent processes can each target a
+// different account without racing on the shared config.yml. A present override
+// also FORCES runMigration=false: the one-time §1.8 migration only ever targets
+// the configured/default ref (running it against an arbitrary ref could write
+// the default's legacy data under the wrong service/profile — the same reason
+// OpenRef skips it). With no override, cfg is untouched and the caller's
+// runMigration is returned unchanged. Split out of open() so this
+// safety-critical swap+suppression is directly testable without
+// config.LoadConfigForRuntime or a real keyring.
+func applyCredentialRefOverride(cfg *config.Config, runMigration bool) bool {
 	if ref, overridden := effectiveRef(cfg.CredentialRef); overridden {
 		cfg.CredentialRef = ref
-		runMigration = false
+		return false
 	}
-	return openWith(cfg, overwrite, runMigration)
+	return runMigration
 }
 
 // CredentialRefEnvVar is the per-invocation credential-ref override env var

--- a/internal/keychain/wire.go
+++ b/internal/keychain/wire.go
@@ -28,3 +28,32 @@ func GetBackendFlagOverride() (value string, flagSet bool) {
 	defer backendMu.RUnlock()
 	return backendFlagValue, backendFlagWasSet
 }
+
+var (
+	credRefMu         sync.RWMutex
+	credRefFlagValue  string
+	credRefFlagWasSet bool
+)
+
+// SetCredentialRefOverride records the user-supplied --ref flag for the next
+// keychain.Open* call. Called by root.WireCredentialRefSelection at
+// PersistentPreRunE time. Mirrors SetBackendFlagOverride: a persistent flag
+// can't be threaded through the parameterless keychain.Open() the read
+// commands call, so it is recorded here and read back at the single
+// resolution site (open). flagSet matches cobra's pflag.Flag.Changed — true
+// when the user passed --ref on the command line, regardless of value.
+func SetCredentialRefOverride(value string, flagSet bool) {
+	credRefMu.Lock()
+	defer credRefMu.Unlock()
+	credRefFlagValue = value
+	credRefFlagWasSet = flagSet
+}
+
+// GetCredentialRefOverride returns the current --ref override and whether it
+// was set. The flag-set vs unset distinction lets an explicit empty value be
+// told apart from "no flag".
+func GetCredentialRefOverride() (value string, flagSet bool) {
+	credRefMu.RLock()
+	defer credRefMu.RUnlock()
+	return credRefFlagValue, credRefFlagWasSet
+}


### PR DESCRIPTION
## Summary

Closes #166. Read/query commands could only use the single active `credential_ref` from `config.yml`, so concurrent processes targeting different accounts raced on that shared file (a clobbered ref left `gro` reading the wrong account or a tokenless profile → `no OAuth token found`).

This adds a **per-invocation credential-ref selector** honored by all commands, resolved with the same precedence shape as `--backend`:

```
--ref <service>/<profile>  >  GOOGLE_READONLY_CREDENTIAL_REF env  >  config.yml credential_ref
```

```bash
gro mail search "is:unread" --ref google-readonly/work &
gro mail search "is:unread" --ref google-readonly/personal &   # independent, no config race
```

## Design (mirrors the existing `--backend` machinery)

- **root**: persistent `--ref` flag, recorded via `keychain.SetCredentialRefOverride` in a new `WireCredentialRefSelection` hook that validates `<service>/<profile>` up front (clean `--ref` error before any keyring work). `set-credential` keeps its own **local** `--ref` write-target, which intentionally shadows the persistent one for that command only.
- **keychain**: `effectiveRef()` applies `flag > env > config` at the single `open()` resolution site — so every read/API command picks it up with no per-command wiring. An explicit override **suppresses the one-time legacy `token.json` migration** (it only ever targets the configured/default ref — same rationale as `OpenRef`).
- env-var name is **derived from the service** (tracks the `<SERVICE>_` prefix credstore uses for the backend env var), never hard-coded.

## Tests
- Precedence (flag > env > config) + empty-`--ref` fall-through
- Flag validation (malformed ref → `--ref` error)
- `PersistentPreRunE` shadowing guard (mirrors the `--backend` regression test)
- `set-credential` local-shadow vs a read command inheriting the persistent flag

## Docs
- README: new "Selecting an account per invocation (concurrent multi-account use)" section
- `docs/development.md`: precedence + resolution-site note

Build, full `go test ./...`, and `golangci-lint run` are green locally.