### PR TITLE
fix: init re-auths instead of hard-failing on an expired stored token

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/noamcohen97/touchid-go v0.3.0 // indirect
-	github.com/open-cli-collective/google-cli-common v0.1.1
+	github.com/open-cli-collective/google-cli-common v0.1.2
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/noamcohen97/touchid-go v0.3.0 h1:fcXxVCizysD7KHRR6hrURt3nyNIs5JBGSbOI
 github.com/noamcohen97/touchid-go v0.3.0/go.mod h1:X9MRNIBGEmPqwpDm1G3fQOAQX7fwBlhzUbnkDTxuta0=
 github.com/open-cli-collective/cli-common v0.4.1 h1:6oNaUVmMtXWi4pJn1X+W6KZVDP/WAJwbyZUyxYpGdbQ=
 github.com/open-cli-collective/cli-common v0.4.1/go.mod h1:3AzjCT0V8xgslHlGi1+rUkcV+Vf5wONGwISQkufLZLQ=
-github.com/open-cli-collective/google-cli-common v0.1.1 h1:4+Lp844w6bxpxQ/Qycu6foaT7cbNCd2NXccxJeITgnM=
-github.com/open-cli-collective/google-cli-common v0.1.1/go.mod h1:EgRDUOb7s6cRa8PncoUrablPL3OcEDjTU8TByE7tsqs=
+github.com/open-cli-collective/google-cli-common v0.1.2 h1:VzhtqVxCYX/S5EDhN7X6mAWKzPaaI4FRwn+KOOeExHU=
+github.com/open-cli-collective/google-cli-common v0.1.2/go.mod h1:EgRDUOb7s6cRa8PncoUrablPL3OcEDjTU8TByE7tsqs=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=


### PR DESCRIPTION
Bumps `google-cli-common` v0.1.1 → v0.1.2, picking up open-cli-collective/google-cli-common#1.

`gro init` previously hard-failed when the stored token was expired/revoked (the weekly fate of Testing-mode OAuth apps):

```
Error: getting profile: Get "https://gmail.googleapis.com/...": oauth2: "invalid_grant" "Token has been expired or revoked."
```

requiring a manual keychain delete before re-auth. With v0.1.2 the invalid_grant is recognized as an auth error and routed into the existing re-auth flow (confirm → clear token → fresh consent), and the confirmation prompt is skipped under `--auth-code-stdin` where no TTY exists.

Real-world validation: a locally patched gro built from this exact combination handled a production expired-token re-auth end to end on 2026-08-03.

`go build ./...` and `go test ./...` pass locally with the bump.

https://claude.ai/code/session_018kd6nduhCb2p3RzVvbPnMF