### PR TITLE
feat(mail): consume quoted reply elision

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,11 +282,13 @@ gro mail search "is:unread"
 gro mail search "from:someone@example.com" --max 20
 gro mail search "is:starred" --ids          # Output IDs only (for piping)
 
-# Read a message
+# Read a message (terminal quoted reply history is elided by default)
 gro mail read <message-id>
+gro mail read <message-id> --include-quoted-reply-bodies
 
-# View conversation thread
+# View conversation thread (terminal quoted reply history is elided by default)
 gro mail thread <thread-id>
+gro mail thread <thread-id> --include-quoted-reply-bodies
 
 # List labels
 gro mail labels

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/noamcohen97/touchid-go v0.3.0 // indirect
-	github.com/open-cli-collective/google-cli-common v0.1.2
+	github.com/open-cli-collective/google-cli-common v0.2.0
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/noamcohen97/touchid-go v0.3.0 h1:fcXxVCizysD7KHRR6hrURt3nyNIs5JBGSbOI
 github.com/noamcohen97/touchid-go v0.3.0/go.mod h1:X9MRNIBGEmPqwpDm1G3fQOAQX7fwBlhzUbnkDTxuta0=
 github.com/open-cli-collective/cli-common v0.4.1 h1:6oNaUVmMtXWi4pJn1X+W6KZVDP/WAJwbyZUyxYpGdbQ=
 github.com/open-cli-collective/cli-common v0.4.1/go.mod h1:3AzjCT0V8xgslHlGi1+rUkcV+Vf5wONGwISQkufLZLQ=
-github.com/open-cli-collective/google-cli-common v0.1.2 h1:VzhtqVxCYX/S5EDhN7X6mAWKzPaaI4FRwn+KOOeExHU=
-github.com/open-cli-collective/google-cli-common v0.1.2/go.mod h1:EgRDUOb7s6cRa8PncoUrablPL3OcEDjTU8TByE7tsqs=
+github.com/open-cli-collective/google-cli-common v0.2.0 h1:yJ9x1gijQ0rgPTvhuCg74a19XhSteiGWkCcqhcVknLc=
+github.com/open-cli-collective/google-cli-common v0.2.0/go.mod h1:EgRDUOb7s6cRa8PncoUrablPL3OcEDjTU8TByE7tsqs=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=


### PR DESCRIPTION
## Summary

- consume `google-cli-common` v0.2.0 so `gro mail read` and `gro mail thread` elide confidently identified terminal quoted reply history by default
- document `--include-quoted-reply-bodies` for restoring complete message bodies
- keep all parsing and output policy in the shared package

## Checks

- `make check`
- `go run ./cmd/gro mail read --help`
- `go run ./cmd/gro mail thread --help`
- root diff review

Parent workstream: #170

Closes #171
